### PR TITLE
Session persistence, display_inline fixes, HITL interrupt dialog

### DIFF
--- a/cowork_dash/default_agent.py
+++ b/cowork_dash/default_agent.py
@@ -72,8 +72,9 @@ You have tools to write and execute Python code interactively, similar to a Jupy
 - Shows detailed error tracebacks when code fails
 
 ### Displaying Results Inline
-- `display_inline(content, title=None, display_type=None)` - Tool to display content inline in the chat
-  - Use for: **file paths** to images, CSV files, HTML, JSON, PDF
+- `display_inline(file_path, title=None, display_type=None)` - Tool to display a file inline in the chat
+  - ALWAYS pass a file path, never raw content. Save data to a file first, then pass the path.
+  - Supported: images (.png, .jpg, .gif), documents (.html, .pdf), data (.csv, .json)
   - Example: `display_inline("results.csv", title="Sales Data")` as a tool call
 
 ### Canvas Visualization

--- a/cowork_dash/server/main.py
+++ b/cowork_dash/server/main.py
@@ -11,6 +11,7 @@ from cowork_dash.server.middleware import add_middleware
 from cowork_dash.server.routes_config import create_config_router
 from cowork_dash.server.routes_files import create_files_router
 from cowork_dash.server.routes_canvas import create_canvas_router
+from cowork_dash.server.routes_session import create_session_router
 from cowork_dash.server.websocket import chat_websocket
 from cowork_dash.stream.session_manager import SessionManager
 from cowork_dash.workspace.file_manager import FileManager
@@ -39,6 +40,7 @@ def create_fastapi_app(
     app.include_router(create_config_router(config))
     app.include_router(create_files_router(file_manager))
     app.include_router(create_canvas_router(canvas_manager))
+    app.include_router(create_session_router(session_manager))
 
     # Serve local icon file if configured
     if icon_local_path:

--- a/cowork_dash/server/routes_session.py
+++ b/cowork_dash/server/routes_session.py
@@ -1,0 +1,16 @@
+"""REST endpoints for session management."""
+
+from fastapi import APIRouter
+
+from cowork_dash.stream.session_manager import SessionManager
+
+
+def create_session_router(session_manager: SessionManager) -> APIRouter:
+    router = APIRouter(prefix="/api", tags=["session"])
+
+    @router.delete("/session/{session_id}")
+    async def delete_session(session_id: str):
+        session_manager.delete_session(session_id)
+        return {"ok": True}
+
+    return router

--- a/cowork_dash/server/websocket.py
+++ b/cowork_dash/server/websocket.py
@@ -26,7 +26,15 @@ async def chat_websocket(
     """Handle a single WebSocket connection for chat streaming."""
     await websocket.accept()
 
-    session = session_manager.create_session(websocket)
+    # Resume existing session or create new one
+    session_id = websocket.query_params.get("session_id")
+    session = session_manager.get_or_create(websocket, session_id)
+
+    # Tell the client which session it's connected to
+    await websocket.send_json({
+        "type": "session_init",
+        "session_id": session.thread_id,
+    })
     serializer = EventSerializer()
     parser = StreamParser(
         stream_mode=DUAL_STREAM_MODE,

--- a/cowork_dash/server/websocket.py
+++ b/cowork_dash/server/websocket.py
@@ -119,6 +119,11 @@ async def _handle_message(
 
     async for event in parser.aparse(stream):
         msg = serializer.serialize(event)
+        if msg.get("type") == "interrupt":
+            logger.debug(
+                "Sending interrupt event: action_requests=%s",
+                msg.get("action_requests"),
+            )
         await websocket.send_json(msg)
 
 

--- a/cowork_dash/stream/session_manager.py
+++ b/cowork_dash/stream/session_manager.py
@@ -1,4 +1,4 @@
-"""Per-WebSocket-connection session state management."""
+"""Per-connection session state management with persistence across reconnects."""
 
 import asyncio
 import uuid
@@ -8,7 +8,7 @@ from fastapi import WebSocket
 
 
 class AgentSession:
-    """Per-WebSocket-connection state. One per browser tab."""
+    """Session state. Survives WebSocket disconnects so page refresh can resume."""
 
     def __init__(self):
         self.thread_id: str = str(uuid.uuid4())
@@ -22,25 +22,54 @@ class AgentSession:
 
 
 class SessionManager:
-    """Manages active chat sessions. Thread-safe for concurrent connections."""
+    """Manages chat sessions. Sessions persist across WebSocket reconnects."""
 
     def __init__(self):
-        self._sessions: dict[int, AgentSession] = {}
+        # session_id (== thread_id) → AgentSession
+        self._sessions: dict[str, AgentSession] = {}
+        # id(websocket) → session_id
+        self._ws_to_session: dict[int, str] = {}
 
-    def create_session(self, websocket: WebSocket) -> AgentSession:
-        """Always creates a new session. Each tab = new thread."""
-        session = AgentSession()
-        self._sessions[id(websocket)] = session
+    def get_or_create(
+        self, websocket: WebSocket, session_id: str | None = None
+    ) -> AgentSession:
+        """Resume an existing session or create a new one.
+
+        If session_id is provided and exists, reuse it. Otherwise create fresh.
+        Links the websocket to the session for later lookup.
+        """
+        if session_id and session_id in self._sessions:
+            session = self._sessions[session_id]
+        else:
+            session = AgentSession()
+            self._sessions[session.thread_id] = session
+
+        self._ws_to_session[id(websocket)] = session.thread_id
         return session
 
     def get_session(self, websocket: WebSocket) -> AgentSession | None:
-        return self._sessions.get(id(websocket))
+        session_id = self._ws_to_session.get(id(websocket))
+        if session_id:
+            return self._sessions.get(session_id)
+        return None
 
     def remove(self, websocket: WebSocket) -> None:
-        session = self._sessions.pop(id(websocket), None)
+        """Unlink websocket but keep session alive for reconnection."""
+        session_id = self._ws_to_session.pop(id(websocket), None)
+        if session_id:
+            session = self._sessions.get(session_id)
+            if session:
+                session.cancel_current_stream()
+
+    def delete_session(self, session_id: str) -> bool:
+        """Permanently delete a session. Returns True if found."""
+        session = self._sessions.pop(session_id, None)
         if session:
             session.cancel_current_stream()
+            return True
+        return False
 
     @property
     def active_count(self) -> int:
-        return len(self._sessions)
+        """Number of sessions with active websocket connections."""
+        return len(self._ws_to_session)

--- a/cowork_dash/tools.py
+++ b/cowork_dash/tools.py
@@ -915,22 +915,32 @@ def remove_canvas_item(item_id: str) -> str:
 
 @langchain_tool(response_format="content_and_artifact")
 def display_inline(
-    content: Any,
+    file_path: Any,
     title: Optional[str] = None,
     display_type: Optional[str] = None
 ) -> tuple[str, dict]:
-    """Display content to the user in a rich, interactive format inline in the chat.
+    """Display a file to the user in a rich, interactive format inline in the chat.
 
-    This tool renders content directly in the conversation for immediate visibility.
-    Use this when you want the user to see results right away without navigating to
-    the canvas. Supports images, HTML, Plotly charts, CSV/DataFrames, and more.
+    IMPORTANT: Always pass a file path, not raw content. Save your data to a file
+    first (e.g. write a CSV, save a plot as PNG, export HTML to a file), then pass
+    the file path to this tool. Passing raw strings, base64 data, or in-memory
+    objects directly will produce rendering errors in the UI.
+
+    This tool renders file content directly in the conversation for immediate
+    visibility. Use this when you want the user to see results right away without
+    navigating to the canvas. Supports images, HTML, Plotly charts, CSV/DataFrames,
+    PDFs, JSON, and more.
 
     The full display data is sent as an artifact (not visible to the model) to avoid
     consuming context tokens. The model only sees a short confirmation message.
 
     Args:
-        content: The content to display. Can be:
-            - str: File path (image, HTML, CSV, JSON) or raw content
+        file_path: Path to the file to display. Must be a file path (absolute or
+            relative to the workspace). Supported file types:
+            - Images: .png, .jpg, .jpeg, .gif, .webp, .svg, .bmp, .ico
+            - Documents: .html, .htm, .pdf
+            - Data: .csv, .tsv, .json
+            Do NOT pass raw content strings — save to a file first.
         title: Optional title displayed above the content
         display_type: Optional hint for how to render the content. One of:
             - "image": Force image rendering (PNG, JPEG, GIF, etc.)
@@ -939,7 +949,7 @@ def display_inline(
             - "csv" or "dataframe": Force table rendering
             - "json": Force JSON rendering
             - "text": Force plain text rendering
-            Auto-detected if not provided.
+            Auto-detected from file extension if not provided.
 
     Returns:
         Tuple of (content_for_model, artifact_for_ui):
@@ -950,13 +960,16 @@ def display_inline(
         # Show an image file
         display_inline("analysis_results.png", title="Results Chart")
 
-        # Show HTML content
-        display_inline("<h1>Hello</h1><p>World</p>", display_type="html")
-
-        # Show CSV file
+        # Show a CSV file as a table
         display_inline("report.csv", title="Monthly Report")
+
+        # Show an HTML file
+        display_inline("output/dashboard.html", title="Dashboard")
+
+        # Show a PDF
+        display_inline("report.pdf", title="Final Report")
     """
-    result_dict = _display_inline_impl(content, title, display_type)
+    result_dict = _display_inline_impl(file_path, title, display_type)
 
     # Build a short stub for the model's context
     dt = result_dict.get("display_type", "content")
@@ -971,7 +984,7 @@ def display_inline(
 
 
 def _display_inline_impl(
-    content: Any,
+    file_path: Any,
     title: Optional[str] = None,
     display_type: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -997,112 +1010,112 @@ def _display_inline_impl(
         workspace_root = _get_workspace_root_for_context()
 
         # Detect content type and process accordingly
-        obj_type = type(content).__name__
-        obj_module = type(content).__module__
+        obj_type = type(file_path).__name__
+        obj_module = type(file_path).__module__
 
         # Handle file paths (strings that look like file paths)
-        if isinstance(content, str) and not display_type:
+        if isinstance(file_path, str) and not display_type:
             # Check if it's a file path
-            if _is_file_path(content, workspace_root):
-                return _process_file_for_display(content, workspace_root, title, display_type)
+            if _is_file_path(file_path, workspace_root):
+                return _process_file_for_display(file_path, workspace_root, title, display_type)
 
             # If it looks like a file path but doesn't exist, try to find it
             from pathlib import PurePath
-            ext = PurePath(content).suffix.lower()
+            ext = PurePath(file_path).suffix.lower()
             known_file_extensions = {
                 '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.bmp', '.ico',
                 '.html', '.htm', '.csv', '.tsv', '.json', '.pdf'
             }
-            if ext in known_file_extensions and "\n" not in content and len(content) < 500:
+            if ext in known_file_extensions and "\n" not in file_path and len(file_path) < 500:
                 # Try to find the file - check if just filename was passed
-                found_path = _find_file_in_workspace(content, workspace_root)
+                found_path = _find_file_in_workspace(file_path, workspace_root)
                 if found_path:
                     return _process_file_for_display(found_path, workspace_root, title, display_type)
                 else:
                     # Return error - file not found
                     result["status"] = "error"
                     result["display_type"] = "error"
-                    result["error"] = f"File not found: {content}"
-                    result["data"] = f"Could not find file '{content}' in workspace. Make sure the file exists and the path is correct."
+                    result["error"] = f"File not found: {file_path}"
+                    result["data"] = f"Could not find file '{file_path}' in workspace. Make sure the file exists and the path is correct."
                     return result
 
             # Otherwise, check for explicit display types or treat as text/HTML
-            if content.strip().startswith("<") and ">" in content:
+            if file_path.strip().startswith("<") and ">" in file_path:
                 result["display_type"] = "html"
-                result["data"] = content
-                result["preview"] = content[:500] + "..." if len(content) > 500 else content
+                result["data"] = file_path
+                result["preview"] = file_path[:500] + "..." if len(file_path) > 500 else file_path
                 return result
 
         # Handle explicit display_type for strings
-        if isinstance(content, str) and display_type:
+        if isinstance(file_path, str) and display_type:
             if display_type == "html":
                 # Check if it's a file path first
-                if _is_file_path(content, workspace_root):
-                    return _process_file_for_display(content, workspace_root, title, "html")
+                if _is_file_path(file_path, workspace_root):
+                    return _process_file_for_display(file_path, workspace_root, title, "html")
                 result["display_type"] = "html"
-                result["data"] = content
-                result["preview"] = content[:500] + "..." if len(content) > 500 else content
+                result["data"] = file_path
+                result["preview"] = file_path[:500] + "..." if len(file_path) > 500 else file_path
                 return result
             elif display_type == "text":
                 result["display_type"] = "text"
-                result["data"] = content
+                result["data"] = file_path
                 return result
             elif display_type in ("csv", "dataframe"):
                 # Check if it's a file path first
-                if _is_file_path(content, workspace_root):
-                    return _process_file_for_display(content, workspace_root, title, "csv")
+                if _is_file_path(file_path, workspace_root):
+                    return _process_file_for_display(file_path, workspace_root, title, "csv")
                 # Parse CSV string
                 try:
                     import pandas as pd
-                    df = pd.read_csv(io.StringIO(content))
+                    df = pd.read_csv(io.StringIO(file_path))
                     return _process_dataframe_for_display(df, title)
                 except Exception as e:
                     result["display_type"] = "text"
-                    result["data"] = content
+                    result["data"] = file_path
                     result["error"] = f"Could not parse as CSV: {e}"
                     return result
             elif display_type == "json":
                 # Check if it's a file path first
-                if _is_file_path(content, workspace_root):
-                    return _process_file_for_display(content, workspace_root, title, "json")
+                if _is_file_path(file_path, workspace_root):
+                    return _process_file_for_display(file_path, workspace_root, title, "json")
                 result["display_type"] = "json"
                 try:
-                    result["data"] = json.loads(content) if isinstance(content, str) else content
+                    result["data"] = json.loads(file_path) if isinstance(file_path, str) else file_path
                 except json.JSONDecodeError:
-                    result["data"] = content
+                    result["data"] = file_path
                 return result
             elif display_type == "image":
                 # Assume it's base64 or file path
-                if _is_file_path(content, workspace_root):
-                    return _process_file_for_display(content, workspace_root, title, "image")
+                if _is_file_path(file_path, workspace_root):
+                    return _process_file_for_display(file_path, workspace_root, title, "image")
                 result["display_type"] = "image"
-                result["data"] = content  # Assume base64
+                result["data"] = file_path  # Assume base64
                 return result
             elif display_type == "plotly":
                 # Check if it's a file path first
-                if _is_file_path(content, workspace_root):
-                    return _process_file_for_display(content, workspace_root, title, "plotly")
+                if _is_file_path(file_path, workspace_root):
+                    return _process_file_for_display(file_path, workspace_root, title, "plotly")
                 result["display_type"] = "plotly"
-                if isinstance(content, str):
-                    result["data"] = json.loads(content)
+                if isinstance(file_path, str):
+                    result["data"] = json.loads(file_path)
                 else:
-                    result["data"] = content
+                    result["data"] = file_path
                 return result
 
         # Handle bytes (binary data - likely image)
-        if isinstance(content, bytes):
+        if isinstance(file_path, bytes):
             result["display_type"] = "image"
-            result["data"] = base64.b64encode(content).decode('utf-8')
+            result["data"] = base64.b64encode(file_path).decode('utf-8')
             return result
 
         # Handle pandas DataFrame
         if obj_module.startswith('pandas') and obj_type == 'DataFrame':
-            return _process_dataframe_for_display(content, title)
+            return _process_dataframe_for_display(file_path, title)
 
         # Handle matplotlib Figure
         if obj_module.startswith('matplotlib') and 'Figure' in obj_type:
             buf = io.BytesIO()
-            content.savefig(buf, format='png', bbox_inches='tight', dpi=100)
+            file_path.savefig(buf, format='png', bbox_inches='tight', dpi=100)
             buf.seek(0)
             img_data = buf.read()
             buf.close()
@@ -1115,13 +1128,13 @@ def _display_inline_impl(
         # Handle Plotly Figure
         if obj_module.startswith('plotly') and 'Figure' in obj_type:
             result["display_type"] = "plotly"
-            result["data"] = json.loads(content.to_json())
+            result["data"] = json.loads(file_path.to_json())
             return result
 
         # Handle dict (check for Plotly JSON structure or serialization artifacts)
-        if isinstance(content, dict):
+        if isinstance(file_path, dict):
             # Check if this looks like a serialized matplotlib/plotly reference (common mistake)
-            if content.get('type') in ('matplotlib', 'plotly') and 'figure' in content:
+            if file_path.get('type') in ('matplotlib', 'plotly') and 'figure' in file_path:
                 result["status"] = "error"
                 result["display_type"] = "error"
                 result["error"] = (
@@ -1131,22 +1144,22 @@ def _display_inline_impl(
                     "  display_inline('chart.png')\n"
                     "Or use add_to_canvas(fig) inside a notebook cell."
                 )
-                result["data"] = str(content)
+                result["data"] = str(file_path)
                 return result
             # Check for Plotly JSON structure
-            if 'data' in content and isinstance(content.get('data'), list):
+            if 'data' in file_path and isinstance(file_path.get('data'), list):
                 result["display_type"] = "plotly"
-                result["data"] = content
+                result["data"] = file_path
                 return result
             else:
                 result["display_type"] = "json"
-                result["data"] = content
+                result["data"] = file_path
                 return result
 
         # Handle PIL Image
         if obj_module.startswith('PIL') and 'Image' in obj_type:
             buf = io.BytesIO()
-            content.save(buf, format='PNG')
+            file_path.save(buf, format='PNG')
             buf.seek(0)
             img_data = buf.read()
             buf.close()
@@ -1157,25 +1170,25 @@ def _display_inline_impl(
             return result
 
         # Handle list (could be data for table)
-        if isinstance(content, list) and len(content) > 0:
-            if isinstance(content[0], dict):
+        if isinstance(file_path, list) and len(file_path) > 0:
+            if isinstance(file_path[0], dict):
                 # List of dicts - render as table
                 try:
                     import pandas as pd
-                    df = pd.DataFrame(content)
+                    df = pd.DataFrame(file_path)
                     return _process_dataframe_for_display(df, title)
                 except Exception:
                     result["display_type"] = "json"
-                    result["data"] = content
+                    result["data"] = file_path
                     return result
             else:
                 result["display_type"] = "json"
-                result["data"] = content
+                result["data"] = file_path
                 return result
 
         # Default: convert to string
         result["display_type"] = "text"
-        result["data"] = str(content)
+        result["data"] = str(file_path)
         return result
 
     except Exception as e:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -45,6 +45,7 @@ export default function App() {
     sendMessage,
     respondToInterrupt,
     cancelStream,
+    resetSession,
   } = useAgentStream();
 
   const {
@@ -111,6 +112,7 @@ export default function App() {
       onDeleteCanvasItem={deleteItem}
       onClearCanvas={clearAll}
       onExportCanvas={exportMarkdown}
+      onNewSession={resetSession}
     />
   );
 }

--- a/frontend/src/components/InterruptDialog.tsx
+++ b/frontend/src/components/InterruptDialog.tsx
@@ -15,20 +15,33 @@ export function InterruptDialog({ interrupt, onRespond }: InterruptDialogProps) 
   const [editingIdx, setEditingIdx] = useState<number | null>(null);
   const [editedArgs, setEditedArgs] = useState("");
   const allowed = new Set(interrupt.allowed_decisions);
+  const hasActions = interrupt.action_requests.length > 0;
 
   const handleApproveAll = () => {
-    onRespond(interrupt.action_requests.map(() => ({ type: "approve" })));
+    if (hasActions) {
+      onRespond(interrupt.action_requests.map(() => ({ type: "approve" })));
+    } else {
+      // Fallback: send a single approve decision
+      onRespond([{ type: "approve" }]);
+    }
   };
 
   const handleRejectAll = () => {
-    onRespond(interrupt.action_requests.map(() => ({ type: "reject" })));
+    if (hasActions) {
+      onRespond(interrupt.action_requests.map(() => ({ type: "reject" })));
+    } else {
+      onRespond([{ type: "reject" }]);
+    }
   };
 
   const handleEditSubmit = (idx: number) => {
     try {
       const parsed = JSON.parse(editedArgs);
+      const action = interrupt.action_requests[idx];
       const decisions: Decision[] = interrupt.action_requests.map((_, i) =>
-        i === idx ? { type: "edit" as const, args: parsed } : { type: "approve" as const }
+        i === idx
+          ? { type: "edit" as const, edited_action: { name: action.tool, args: parsed } }
+          : { type: "approve" as const }
       );
       onRespond(decisions);
     } catch {
@@ -45,57 +58,70 @@ export function InterruptDialog({ interrupt, onRespond }: InterruptDialogProps) 
             Action Requires Approval
           </h3>
           <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
-            The agent wants to perform the following action{interrupt.action_requests.length > 1 ? "s" : ""}
+            {hasActions
+              ? `The agent wants to perform the following action${interrupt.action_requests.length > 1 ? "s" : ""}`
+              : "The agent needs your approval to continue"}
           </p>
         </div>
 
         {/* Actions */}
         <div className="px-5 py-4 space-y-3">
-          {interrupt.action_requests.map((action, idx) => (
-            <div
-              key={idx}
-              className="border border-[var(--color-border)] rounded p-3"
-            >
-              <div className="mb-2">
-                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
-                  {action.tool}
-                </span>
-              </div>
-              <pre className="bg-[var(--color-surface-3)] rounded p-2 text-xs overflow-x-auto whitespace-pre-wrap break-all text-[var(--color-text)]">
-                {JSON.stringify(action.args, null, 2)}
-              </pre>
-
-              {editingIdx === idx && (
-                <div className="mt-2">
-                  <textarea
-                    value={editedArgs}
-                    onChange={(e) => setEditedArgs(e.target.value)}
-                    className="w-full h-24 p-2 text-xs font-mono bg-[var(--color-surface-3)] border border-[var(--color-border)] rounded resize-none focus:outline-none focus:border-[var(--color-text-muted)] text-[var(--color-text)]"
-                    placeholder="Edit args JSON..."
-                  />
-                  <div className="flex gap-2 mt-1">
-                    <button
-                      onClick={() => handleEditSubmit(idx)}
-                      className="px-3 py-1 text-xs font-medium bg-[var(--color-text)] text-[var(--color-surface)] rounded hover:opacity-80 transition-opacity"
-                    >
-                      Submit
-                    </button>
-                    <button
-                      onClick={() => setEditingIdx(null)}
-                      className="px-3 py-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
-                    >
-                      Cancel
-                    </button>
-                  </div>
+          {hasActions ? (
+            interrupt.action_requests.map((action, idx) => (
+              <div
+                key={idx}
+                className="border border-[var(--color-border)] rounded p-3"
+              >
+                <div className="mb-2">
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-secondary)]">
+                    {action.tool}
+                  </span>
                 </div>
-              )}
+                {action.description && (
+                  <p className="text-xs text-[var(--color-text-secondary)] mb-2 leading-relaxed whitespace-pre-wrap">
+                    {action.description}
+                  </p>
+                )}
+                <pre className="bg-[var(--color-surface-3)] rounded p-2 text-xs overflow-x-auto whitespace-pre-wrap break-all text-[var(--color-text)]">
+                  {JSON.stringify(action.args, null, 2)}
+                </pre>
+
+                {editingIdx === idx && (
+                  <div className="mt-2">
+                    <textarea
+                      value={editedArgs}
+                      onChange={(e) => setEditedArgs(e.target.value)}
+                      className="w-full h-24 p-2 text-xs font-mono bg-[var(--color-surface-3)] border border-[var(--color-border)] rounded resize-none focus:outline-none focus:border-[var(--color-text-muted)] text-[var(--color-text)]"
+                      placeholder="Edit args JSON..."
+                    />
+                    <div className="flex gap-2 mt-1">
+                      <button
+                        onClick={() => handleEditSubmit(idx)}
+                        className="px-3 py-1 text-xs font-medium bg-[var(--color-text)] text-[var(--color-surface)] rounded hover:opacity-80 transition-opacity"
+                      >
+                        Submit
+                      </button>
+                      <button
+                        onClick={() => setEditingIdx(null)}
+                        className="px-3 py-1 text-xs text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          ) : (
+            <div className="text-xs text-[var(--color-text-muted)] italic">
+              No action details available.
             </div>
-          ))}
+          )}
         </div>
 
         {/* Buttons */}
         <div className="px-5 py-3 border-t border-[var(--color-border)] flex justify-end gap-2">
-          {allowed.has("edit") && (
+          {allowed.has("edit") && hasActions && (
             <button
               onClick={() => {
                 setEditingIdx(0);

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -54,6 +54,7 @@ interface LayoutProps {
   onDeleteCanvasItem: (id: string) => void;
   onClearCanvas: () => void;
   onExportCanvas: () => Promise<string>;
+  onNewSession: () => void;
 }
 
 export function Layout(props: LayoutProps) {
@@ -91,6 +92,7 @@ export function Layout(props: LayoutProps) {
             isStreaming={props.isStreaming}
             tokenUsage={props.tokenUsage}
             usageHistory={props.usageHistory}
+            onNewSession={props.onNewSession}
           />
           <div className="w-px h-4 bg-[var(--color-border)]" />
           <ThemeToggle initialTheme={props.config.theme} />

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Loader2, Zap } from "lucide-react";
+import { Loader2, RotateCcw, Zap } from "lucide-react";
 import type { ConnectionStatus, TokenUsage, TurnUsage } from "../types";
 import { TokenUsageChart } from "./TokenUsageChart";
 
@@ -14,6 +14,7 @@ interface StatusBarProps {
   isStreaming: boolean;
   tokenUsage: TokenUsage;
   usageHistory: TurnUsage[];
+  onNewSession: () => void;
 }
 
 export function StatusBar({
@@ -21,6 +22,7 @@ export function StatusBar({
   isStreaming,
   tokenUsage,
   usageHistory,
+  onNewSession,
 }: StatusBarProps) {
   const [showChart, setShowChart] = useState(false);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -46,6 +48,19 @@ export function StatusBar({
 
   return (
     <div className="flex items-center gap-2.5 text-[11px]">
+      <button
+        onClick={() => {
+          if (window.confirm("Start a new session? This will clear all messages and cannot be undone.")) {
+            onNewSession();
+          }
+        }}
+        disabled={isStreaming}
+        className="flex items-center gap-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+        title="New session"
+      >
+        <RotateCcw size={10} />
+        New
+      </button>
       {isStreaming && (
         <span className="flex items-center gap-1 text-[var(--color-text-secondary)]">
           <Loader2 size={10} className="animate-spin" />

--- a/frontend/src/components/ToolCallCard.tsx
+++ b/frontend/src/components/ToolCallCard.tsx
@@ -133,7 +133,7 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
 
       {extraction?.extracted_type === "display_inline" && (
         <div className="border-t border-[var(--color-border)]">
-          <InlineDisplay data={extraction.data as Record<string, unknown>} />
+          <SafeInlineDisplay data={extraction.data as Record<string, unknown>} />
         </div>
       )}
 
@@ -185,12 +185,25 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
   );
 }
 
+function SafeInlineDisplay({ data }: { data: Record<string, unknown> }) {
+  try {
+    return <InlineDisplay data={data} />;
+  } catch (err) {
+    return (
+      <div className="px-3 py-2 flex items-start gap-2 text-xs text-[var(--color-error)]">
+        <AlertTriangle size={12} className="flex-shrink-0 mt-0.5" />
+        <span>Display error: {String(err)}</span>
+      </div>
+    );
+  }
+}
+
 function InlineDisplay({ data }: { data: Record<string, unknown> }) {
-  const displayType = data.display_type as string;
-  const title = data.title as string | null;
-  const content = data.data;
-  const status = data.status as string;
-  const error = data.error as string | null;
+  const displayType = data?.display_type as string | undefined;
+  const title = data?.title as string | null;
+  const content = data?.data;
+  const status = data?.status as string;
+  const error = data?.error as string | null;
 
   if (status === "error") {
     return (
@@ -232,7 +245,7 @@ function InlineDisplay({ data }: { data: Record<string, unknown> }) {
         <HtmlIframe html={String(content)} title={title} />
       )}
 
-      {displayType === "plotly" && (
+      {displayType === "plotly" && content != null && (
         <PlotlyIframe data={content} title={title} />
       )}
 
@@ -240,40 +253,7 @@ function InlineDisplay({ data }: { data: Record<string, unknown> }) {
         !!content &&
         typeof content === "object" &&
         "columns" in (content as Record<string, unknown>) && (
-          <div className="overflow-x-auto max-h-[300px] overflow-y-auto">
-            <table className="w-full text-xs border-collapse">
-              <thead>
-                <tr>
-                  {(
-                    (content as Record<string, unknown>).columns as string[]
-                  ).map((col) => (
-                    <th
-                      key={col}
-                      className="border border-[var(--color-border)] bg-[var(--color-surface-3)] px-2 py-1 text-left font-medium text-[var(--color-text-secondary)]"
-                    >
-                      {col}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {(
-                  (content as Record<string, unknown>).data as unknown[][]
-                ).map((row, i) => (
-                  <tr key={i}>
-                    {(row as unknown[]).map((cell, j) => (
-                      <td
-                        key={j}
-                        className="border border-[var(--color-border)] px-2 py-1 text-[var(--color-text)]"
-                      >
-                        {String(cell ?? "")}
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <DataFrameTable content={content as Record<string, unknown>} />
         )}
 
       {displayType === "pdf" && typeof content === "string" && (
@@ -297,6 +277,64 @@ function InlineDisplay({ data }: { data: Record<string, unknown> }) {
           {String(content)}
         </pre>
       )}
+
+      {/* Fallback for unrecognized display types */}
+      {displayType && !["image", "html", "plotly", "dataframe", "csv", "pdf", "json", "text"].includes(displayType) && (
+        <pre className="bg-[var(--color-surface-3)] rounded p-2 text-xs overflow-x-auto whitespace-pre-wrap break-all text-[var(--color-text)]">
+          {typeof content === "string"
+            ? content
+            : JSON.stringify(content, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function DataFrameTable({ content }: { content: Record<string, unknown> }) {
+  const columns = content.columns as string[];
+  // Backend sends "records" (array of objects) not "data" (array of arrays)
+  const records = content.records as Record<string, unknown>[] | undefined;
+  const dataArrays = content.data as unknown[][] | undefined;
+
+  if (!columns || !Array.isArray(columns)) return null;
+
+  // Build rows from either records or data arrays
+  const rows: unknown[][] = records
+    ? records.map((rec) => columns.map((col) => rec[col]))
+    : Array.isArray(dataArrays)
+      ? dataArrays
+      : [];
+
+  return (
+    <div className="overflow-x-auto max-h-[300px] overflow-y-auto">
+      <table className="w-full text-xs border-collapse">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col}
+                className="border border-[var(--color-border)] bg-[var(--color-surface-3)] px-2 py-1 text-left font-medium text-[var(--color-text-secondary)]"
+              >
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i}>
+              {(row as unknown[]).map((cell, j) => (
+                <td
+                  key={j}
+                  className="border border-[var(--color-border)] px-2 py-1 text-[var(--color-text)]"
+                >
+                  {String(cell ?? "")}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/frontend/src/hooks/useAgentStream.ts
+++ b/frontend/src/hooks/useAgentStream.ts
@@ -1,6 +1,7 @@
 /**
  * WebSocket connection + event dispatch hook.
  * Handles buffered content streaming with requestAnimationFrame batching.
+ * Persists session state to localStorage for survival across page refresh.
  */
 
 import { useState, useEffect, useRef, useCallback } from "react";
@@ -16,32 +17,108 @@ import type {
   ConnectionStatus,
 } from "../types";
 
+const STORAGE_KEY = "cowork-dash-session";
+
+interface PersistedState {
+  sessionId: string | null;
+  messages: ChatMessage[];
+  todos: TodoItem[];
+  tokenUsage: TokenUsage;
+  usageHistory: TurnUsage[];
+  turnCounter: number;
+}
+
+function loadPersistedState(): PersistedState | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as PersistedState;
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedState(state: PersistedState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // localStorage full or unavailable — silently ignore
+  }
+}
+
 let messageIdCounter = 0;
 function nextId() {
   return `msg-${++messageIdCounter}`;
 }
 
 export function useAgentStream() {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // Restore persisted state on first render
+  const persisted = useRef(loadPersistedState());
+  const initial = persisted.current;
+
+  const [messages, setMessages] = useState<ChatMessage[]>(
+    initial?.messages ?? []
+  );
   const [isStreaming, setIsStreaming] = useState(false);
   const [interrupt, setInterrupt] = useState<InterruptEventMsg | null>(null);
-  const [todos, setTodos] = useState<TodoItem[]>([]);
+  const [todos, setTodos] = useState<TodoItem[]>(initial?.todos ?? []);
   const [connectionStatus, setConnectionStatus] =
     useState<ConnectionStatus>("connecting");
-  const [tokenUsage, setTokenUsage] = useState<TokenUsage>({
-    input: 0,
-    output: 0,
-    total: 0,
-  });
-  const [usageHistory, setUsageHistory] = useState<TurnUsage[]>([]);
-  const turnCounterRef = useRef(0);
+  const [tokenUsage, setTokenUsage] = useState<TokenUsage>(
+    initial?.tokenUsage ?? { input: 0, output: 0, total: 0 }
+  );
+  const [usageHistory, setUsageHistory] = useState<TurnUsage[]>(
+    initial?.usageHistory ?? []
+  );
+  const turnCounterRef = useRef(initial?.turnCounter ?? 0);
   const [fileChanges, setFileChanges] = useState<
     { event: string; path: string }[]
   >([]);
 
+  // Session ID for backend thread continuity
+  const sessionIdRef = useRef<string | null>(initial?.sessionId ?? null);
+
+  // Reconnect key — changing this re-runs the WebSocket useEffect
+  const [reconnectKey, setReconnectKey] = useState(0);
+
   const wsRef = useRef<WebSocket | null>(null);
   const contentBufferRef = useRef("");
   const rafRef = useRef<number | null>(null);
+
+  // Sync messageIdCounter to avoid collisions with restored messages
+  if (initial?.messages?.length) {
+    const maxId = initial.messages.reduce((max, m) => {
+      const num = parseInt(m.id.replace("msg-", ""), 10);
+      return isNaN(num) ? max : Math.max(max, num);
+    }, 0);
+    if (maxId > messageIdCounter) messageIdCounter = maxId;
+  }
+
+  // --- Debounced localStorage persistence ---
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current = isStreaming;
+
+  useEffect(() => {
+    // Don't persist while streaming — wait until stream completes
+    if (isStreaming) return;
+
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    persistTimerRef.current = setTimeout(() => {
+      savePersistedState({
+        sessionId: sessionIdRef.current,
+        messages,
+        todos,
+        tokenUsage,
+        usageHistory,
+        turnCounter: turnCounterRef.current,
+      });
+    }, 500);
+
+    return () => {
+      if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    };
+  }, [messages, todos, tokenUsage, usageHistory, isStreaming]);
 
   const flushContentBuffer = useCallback(() => {
     const buffered = contentBufferRef.current;
@@ -86,6 +163,10 @@ export function useAgentStream() {
   const dispatch = useCallback(
     (event: AgentEvent) => {
       switch (event.type) {
+        case "session_init":
+          sessionIdRef.current = event.session_id;
+          break;
+
         case "tool_start":
           // Flush content before tool events
           if (contentBufferRef.current) flushContentBuffer();
@@ -296,7 +377,11 @@ export function useAgentStream() {
 
   useEffect(() => {
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const ws = new WebSocket(`${protocol}//${window.location.host}/ws/chat`);
+    let url = `${protocol}//${window.location.host}/ws/chat`;
+    if (sessionIdRef.current) {
+      url += `?session_id=${encodeURIComponent(sessionIdRef.current)}`;
+    }
+    const ws = new WebSocket(url);
 
     ws.onopen = () => setConnectionStatus("connected");
     ws.onclose = () => setConnectionStatus("disconnected");
@@ -324,7 +409,7 @@ export function useAgentStream() {
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
       ws.close();
     };
-  }, [dispatch, flushContentBuffer]);
+  }, [dispatch, flushContentBuffer, reconnectKey]);
 
   const sendMessage = useCallback(
     (content: string, meta?: { cwd?: string }) => {
@@ -370,6 +455,40 @@ export function useAgentStream() {
     // isStreaming will be set to false when the "cancelled" event arrives
   }, [flushContentBuffer]);
 
+  const resetSession = useCallback(() => {
+    // Clean up backend session
+    const oldSessionId = sessionIdRef.current;
+    if (oldSessionId) {
+      fetch(`/api/session/${encodeURIComponent(oldSessionId)}`, {
+        method: "DELETE",
+      }).catch(() => {});
+    }
+
+    // Close current WebSocket
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    // Clear persisted state
+    localStorage.removeItem(STORAGE_KEY);
+
+    // Reset all state
+    sessionIdRef.current = null;
+    setMessages([]);
+    setTodos([]);
+    setTokenUsage({ input: 0, output: 0, total: 0 });
+    setUsageHistory([]);
+    turnCounterRef.current = 0;
+    setIsStreaming(false);
+    setInterrupt(null);
+    setFileChanges([]);
+    contentBufferRef.current = "";
+
+    // Reconnect with a fresh session
+    setReconnectKey((k) => k + 1);
+  }, []);
+
   return {
     messages,
     isStreaming,
@@ -382,5 +501,6 @@ export function useAgentStream() {
     sendMessage,
     respondToInterrupt,
     cancelStream,
+    resetSession,
   };
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -15,7 +15,8 @@ export type AgentEvent =
   | ErrorEvent
   | StateUpdateEvent
   | FileChangedEvent
-  | CancelledEvent;
+  | CancelledEvent
+  | SessionInitEvent;
 
 export interface ContentEvent {
   type: "content";
@@ -98,6 +99,11 @@ export interface FileChangedEvent {
 
 export interface CancelledEvent {
   type: "cancelled";
+}
+
+export interface SessionInitEvent {
+  type: "session_init";
+  session_id: string;
 }
 
 // Client → Server messages

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -61,6 +61,7 @@ export interface ActionRequest {
   tool: string;
   tool_call_id?: string;
   args: Record<string, unknown>;
+  description?: string;
 }
 
 export interface ReviewConfig {
@@ -123,7 +124,8 @@ export interface SendCancel {
 
 export interface Decision {
   type: "approve" | "reject" | "edit";
-  args?: Record<string, unknown>;
+  edited_action?: { name: string; args: Record<string, unknown> };
+  message?: string;
 }
 
 // UI state types

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -96,3 +96,11 @@ async def test_canvas_export_empty(client):
     resp = await client.get("/api/canvas/export")
     assert resp.status_code == 200
     assert resp.json()["content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_delete_session_endpoint(client):
+    """DELETE /api/session/{id} returns ok even for nonexistent sessions."""
+    resp = await client.delete("/api/session/fake-session-id")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}

--- a/tests/test_event_serializer.py
+++ b/tests/test_event_serializer.py
@@ -66,3 +66,72 @@ def test_interrupt_event():
     )
     assert result["type"] == "interrupt"
     assert len(result["action_requests"]) == 1
+
+
+def test_interrupt_event_hitl_format():
+    """Interrupt with HITL middleware ActionRequest format (name, not tool)."""
+    from langgraph_stream_parser.extractors.interrupts import process_interrupt
+
+    # Simulate what LangGraph produces: tuple of Interrupt objects
+    # Each Interrupt has .value = HITLRequest dict
+    class FakeInterrupt:
+        def __init__(self, value):
+            self.value = value
+            self.id = "test-id"
+
+    hitl_request = {
+        "action_requests": [
+            {"name": "bash", "args": {"command": "rm -rf /tmp/test"}, "description": "Tool execution requires approval\n\nTool: bash\nArgs: {'command': 'rm -rf /tmp/test'}"},
+        ],
+        "review_configs": [
+            {"action_name": "bash", "allowed_decisions": ["approve", "edit", "reject"]},
+        ],
+    }
+    interrupt_tuple = (FakeInterrupt(hitl_request),)
+
+    # process_interrupt should extract and serialize correctly
+    interrupt_data = process_interrupt(interrupt_tuple)
+    assert len(interrupt_data["action_requests"]) == 1
+    assert interrupt_data["action_requests"][0]["tool"] == "bash"
+    assert interrupt_data["action_requests"][0]["args"]["command"] == "rm -rf /tmp/test"
+    assert interrupt_data["action_requests"][0]["description"] is not None
+    assert len(interrupt_data["review_configs"]) == 1
+    assert "approve" in interrupt_data["review_configs"][0]["allowed_decisions"]
+
+    # Verify it serializes correctly through EventSerializer
+    ser = EventSerializer()
+    event = InterruptEvent(
+        action_requests=interrupt_data["action_requests"],
+        review_configs=interrupt_data["review_configs"],
+    )
+    result = ser.serialize(event)
+    assert result["type"] == "interrupt"
+    assert result["action_requests"][0]["tool"] == "bash"
+    assert result["action_requests"][0]["args"]["command"] == "rm -rf /tmp/test"
+    assert "approve" in result["allowed_decisions"]
+
+
+def test_interrupt_event_multi_interrupt():
+    """Multiple Interrupt objects in tuple (multiple tool calls needing approval)."""
+    from langgraph_stream_parser.extractors.interrupts import process_interrupt
+
+    class FakeInterrupt:
+        def __init__(self, value):
+            self.value = value
+            self.id = "test-id"
+
+    hitl1 = {
+        "action_requests": [{"name": "bash", "args": {"command": "ls"}}],
+        "review_configs": [{"allowed_decisions": ["approve", "reject"]}],
+    }
+    hitl2 = {
+        "action_requests": [{"name": "write_file", "args": {"path": "/tmp/x"}}],
+        "review_configs": [{"allowed_decisions": ["approve", "edit", "reject"]}],
+    }
+    interrupt_tuple = (FakeInterrupt(hitl1), FakeInterrupt(hitl2))
+
+    interrupt_data = process_interrupt(interrupt_tuple)
+    assert len(interrupt_data["action_requests"]) == 2
+    assert interrupt_data["action_requests"][0]["tool"] == "bash"
+    assert interrupt_data["action_requests"][1]["tool"] == "write_file"
+    assert len(interrupt_data["review_configs"]) == 2

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,39 +1,135 @@
-"""Tests for session management."""
+"""Tests for session management with persistence across reconnects."""
 
+import asyncio
 from unittest.mock import MagicMock
 from cowork_dash.stream.session_manager import SessionManager, AgentSession
 
 
-def test_create_session():
+def test_create_new_session():
+    """get_or_create with no session_id creates a fresh session."""
     mgr = SessionManager()
     ws = MagicMock()
-    session = mgr.create_session(ws)
+    session = mgr.get_or_create(ws)
     assert isinstance(session, AgentSession)
     assert session.thread_id  # non-empty UUID
     assert mgr.active_count == 1
 
 
 def test_get_session():
+    """get_session returns the session linked to a websocket."""
     mgr = SessionManager()
     ws = MagicMock()
-    session = mgr.create_session(ws)
+    session = mgr.get_or_create(ws)
     assert mgr.get_session(ws) is session
 
 
-def test_remove_session():
+def test_get_session_unknown_ws():
+    """get_session returns None for an unknown websocket."""
     mgr = SessionManager()
     ws = MagicMock()
-    mgr.create_session(ws)
-    mgr.remove(ws)
-    assert mgr.active_count == 0
     assert mgr.get_session(ws) is None
 
 
+def test_remove_unlinks_but_preserves_session():
+    """remove() unlinks websocket but keeps the session alive."""
+    mgr = SessionManager()
+    ws = MagicMock()
+    session = mgr.get_or_create(ws)
+    session_id = session.thread_id
+
+    mgr.remove(ws)
+
+    # WebSocket is unlinked
+    assert mgr.active_count == 0
+    assert mgr.get_session(ws) is None
+
+    # But session still exists and can be resumed
+    ws2 = MagicMock()
+    resumed = mgr.get_or_create(ws2, session_id=session_id)
+    assert resumed is session
+    assert resumed.thread_id == session_id
+    assert mgr.active_count == 1
+
+
+def test_resume_existing_session():
+    """get_or_create with a valid session_id resumes the existing session."""
+    mgr = SessionManager()
+    ws1 = MagicMock()
+    session = mgr.get_or_create(ws1)
+    session_id = session.thread_id
+
+    # Simulate disconnect
+    mgr.remove(ws1)
+
+    # Reconnect with the same session_id
+    ws2 = MagicMock()
+    resumed = mgr.get_or_create(ws2, session_id=session_id)
+    assert resumed is session
+    assert resumed.thread_id == session_id
+    assert mgr.get_session(ws2) is session
+
+
+def test_resume_nonexistent_session_creates_new():
+    """get_or_create with an unknown session_id creates a new session."""
+    mgr = SessionManager()
+    ws = MagicMock()
+    session = mgr.get_or_create(ws, session_id="nonexistent-id")
+    assert session.thread_id != "nonexistent-id"
+    assert mgr.active_count == 1
+
+
+def test_delete_session():
+    """delete_session permanently removes a session."""
+    mgr = SessionManager()
+    ws = MagicMock()
+    session = mgr.get_or_create(ws)
+    session_id = session.thread_id
+
+    mgr.remove(ws)
+    assert mgr.delete_session(session_id) is True
+
+    # Session is gone — can't resume it
+    ws2 = MagicMock()
+    new_session = mgr.get_or_create(ws2, session_id=session_id)
+    assert new_session is not session
+    assert new_session.thread_id != session_id
+
+
+def test_delete_session_nonexistent():
+    """delete_session returns False for unknown session."""
+    mgr = SessionManager()
+    assert mgr.delete_session("nonexistent") is False
+
+
 def test_multiple_sessions():
+    """Multiple websockets create independent sessions."""
     mgr = SessionManager()
     ws1 = MagicMock()
     ws2 = MagicMock()
-    s1 = mgr.create_session(ws1)
-    s2 = mgr.create_session(ws2)
+    s1 = mgr.get_or_create(ws1)
+    s2 = mgr.get_or_create(ws2)
     assert s1.thread_id != s2.thread_id
     assert mgr.active_count == 2
+
+
+def test_session_config_has_thread_id():
+    """AgentSession.config contains the thread_id."""
+    session = AgentSession()
+    assert session.config == {"configurable": {"thread_id": session.thread_id}}
+
+
+def test_active_count_tracks_websockets_not_sessions():
+    """active_count reflects connected websockets, not total sessions."""
+    mgr = SessionManager()
+    ws1 = MagicMock()
+    ws2 = MagicMock()
+
+    mgr.get_or_create(ws1)
+    mgr.get_or_create(ws2)
+    assert mgr.active_count == 2
+
+    mgr.remove(ws1)
+    assert mgr.active_count == 1  # 1 websocket, but 2 sessions exist
+
+    mgr.remove(ws2)
+    assert mgr.active_count == 0  # 0 websockets, 2 sessions still in memory


### PR DESCRIPTION
## Summary

- Add session persistence across page refresh (localStorage)
- Fix display_inline crash and blank screen rendering (records vs data format)
- Rename display_inline param from content to file_path to stress filepath-only usage
- Fix HITL interrupt dialog: blank display, empty decisions, edit format

## Changes

- **Session persistence**: Messages, todos, token usage, and usage history survive page refresh via localStorage
- **display_inline**: Fix DataFrame table rendering (records format), add error boundaries, rename param to `file_path`
- **Interrupt dialog**: Fix blank tool name/args display, fallback UI for empty action_requests, correct Decision type for edit actions, add description field support
- **Tests**: Added HITL-format and multi-interrupt serialization tests (40 total)

## Test plan

- [x] All 40 pytest tests pass
- [x] Frontend builds clean (tsc + vite)