### PR TITLE
Add optional HTTP Basic Auth

### DIFF
--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -35,6 +35,8 @@ class CoworkApp:
         theme: str | None = None,
         agent_name: str | None = None,
         icon_url: str | None = None,
+        auth_username: str | None = None,
+        auth_password: str | None = None,
         stream_parser_config: dict | None = None,
     ):
         self.config = AppConfig.from_env().merge({
@@ -49,6 +51,8 @@ class CoworkApp:
             "theme": theme,
             "agent_name": agent_name,
             "icon_url": icon_url,
+            "auth_username": auth_username,
+            "auth_password": auth_password,
         })
 
         # Ensure workspace directory exists

--- a/cowork_dash/cli.py
+++ b/cowork_dash/cli.py
@@ -24,8 +24,10 @@ def main():
 @click.option("--theme", default=None, type=click.Choice(["light", "dark", "auto"]), help="UI theme")
 @click.option("--agent-name", default=None, help="Display name for the agent (default: agent's .name)")
 @click.option("--icon-url", default=None, help="URL to a custom icon image for the header and welcome screen")
+@click.option("--auth-username", default=None, help="Basic auth username (default: admin)")
+@click.option("--auth-password", default=None, help="Basic auth password (enables auth when set)")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't auto-open browser")
-def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, no_browser):
+def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, no_browser):
     """Start the Cowork Dash server."""
     app = CoworkApp(
         agent_spec=agent_spec,
@@ -39,6 +41,8 @@ def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_messa
         theme=theme,
         agent_name=agent_name,
         icon_url=icon_url,
+        auth_username=auth_username,
+        auth_password=auth_password,
     )
     app.run(open_browser=not no_browser)
 

--- a/cowork_dash/config.py
+++ b/cowork_dash/config.py
@@ -22,6 +22,8 @@ class AppConfig:
     theme: str = "auto"  # "light" | "dark" | "auto"
     agent_name: str = "Agent"
     icon_url: str = ""
+    auth_username: str = ""
+    auth_password: str = ""
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -38,6 +40,8 @@ class AppConfig:
             theme=os.getenv("DEEPAGENT_THEME", "auto"),
             agent_name=os.getenv("DEEPAGENT_AGENT_NAME", "Agent"),
             icon_url=os.getenv("DEEPAGENT_ICON_URL", ""),
+            auth_username=os.getenv("DEEPAGENT_AUTH_USERNAME", ""),
+            auth_password=os.getenv("DEEPAGENT_AUTH_PASSWORD", ""),
         )
 
     def merge(self, overrides: dict) -> "AppConfig":
@@ -55,6 +59,8 @@ class AppConfig:
             "theme": self.theme,
             "agent_name": self.agent_name,
             "icon_url": self.icon_url,
+            "auth_username": self.auth_username,
+            "auth_password": self.auth_password,
         }
         current.update(updates)
         return AppConfig(**current)

--- a/cowork_dash/server/main.py
+++ b/cowork_dash/server/main.py
@@ -29,7 +29,12 @@ def create_fastapi_app(
     app = FastAPI(title=config.title, version="2.0.0")
 
     # Middleware
-    add_middleware(app, debug=config.debug)
+    add_middleware(
+        app,
+        debug=config.debug,
+        auth_username=config.auth_username,
+        auth_password=config.auth_password,
+    )
 
     # Shared services
     session_manager = SessionManager()

--- a/cowork_dash/server/middleware.py
+++ b/cowork_dash/server/middleware.py
@@ -1,11 +1,77 @@
-"""CORS and error handling middleware."""
+"""CORS and authentication middleware."""
+
+import base64
+import secrets
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 
-def add_middleware(app: FastAPI, debug: bool = False) -> None:
-    """Add CORS middleware. In debug mode, allow Vite dev server origin."""
+class BasicAuthMiddleware:
+    """ASGI middleware for HTTP Basic Authentication.
+
+    Protects all HTTP and WebSocket endpoints. The browser shows its
+    native login dialog on 401. WebSocket connections are authenticated
+    on the upgrade request.
+    """
+
+    def __init__(self, app: ASGIApp, username: str, password: str) -> None:
+        self.app = app
+        self._username = username
+        self._password = password
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        auth_header = headers.get(b"authorization", b"").decode()
+
+        if self._check_credentials(auth_header):
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "websocket":
+            # Reject WebSocket upgrade with 403
+            response = Response("Forbidden", status_code=403)
+            await response(scope, receive, send)
+            return
+
+        # HTTP: send 401 to trigger browser login prompt
+        response = Response(
+            "Unauthorized",
+            status_code=401,
+            headers={"WWW-Authenticate": 'Basic realm="cowork-dash"'},
+        )
+        await response(scope, receive, send)
+
+    def _check_credentials(self, auth_header: str) -> bool:
+        if not auth_header.startswith("Basic "):
+            return False
+        try:
+            decoded = base64.b64decode(auth_header[6:]).decode("utf-8")
+        except Exception:
+            return False
+        if ":" not in decoded:
+            return False
+        username, password = decoded.split(":", 1)
+        return (
+            secrets.compare_digest(username, self._username)
+            and secrets.compare_digest(password, self._password)
+        )
+
+
+def add_middleware(
+    app: FastAPI,
+    debug: bool = False,
+    auth_username: str = "",
+    auth_password: str = "",
+) -> None:
+    """Add middleware stack. CORS is always added; basic auth is conditional."""
+    # CORS (added first so preflight OPTIONS work even with auth)
     origins = []
     if debug:
         origins = [
@@ -20,3 +86,8 @@ def add_middleware(app: FastAPI, debug: bool = False) -> None:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Basic auth (only when a password is configured)
+    if auth_password:
+        username = auth_username or "admin"
+        app.add_middleware(BasicAuthMiddleware, username=username, password=auth_password)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -104,3 +104,83 @@ async def test_delete_session_endpoint(client):
     resp = await client.delete("/api/session/fake-session-id")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+# --- Basic Auth tests ---
+
+@pytest.fixture
+def auth_app(workspace, mock_agent):
+    config = AppConfig(
+        workspace=workspace,
+        title="Auth App",
+        auth_username="myuser",
+        auth_password="mypass",
+    )
+    return create_fastapi_app(
+        agent=mock_agent,
+        workspace=workspace,
+        config=config,
+    )
+
+
+@pytest.fixture
+async def auth_client(auth_app):
+    transport = ASGITransport(app=auth_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_auth_rejects_unauthenticated(auth_client):
+    """Requests without credentials get 401."""
+    resp = await auth_client.get("/api/config")
+    assert resp.status_code == 401
+    assert "Basic" in resp.headers.get("www-authenticate", "")
+
+
+@pytest.mark.asyncio
+async def test_auth_accepts_correct_credentials(auth_client):
+    """Requests with valid credentials pass through."""
+    resp = await auth_client.get(
+        "/api/config", auth=("myuser", "mypass")
+    )
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "Auth App"
+
+
+@pytest.mark.asyncio
+async def test_auth_rejects_wrong_credentials(auth_client):
+    """Requests with bad credentials get 401."""
+    resp = await auth_client.get(
+        "/api/config", auth=("myuser", "wrong")
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_no_auth_still_works(client):
+    """When auth is not configured, requests pass without credentials."""
+    resp = await client.get("/api/config")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_default_username(workspace, mock_agent):
+    """When only password is set, username defaults to 'admin'."""
+    config = AppConfig(
+        workspace=workspace,
+        auth_password="secret",
+    )
+    app = create_fastapi_app(
+        agent=mock_agent,
+        workspace=workspace,
+        config=config,
+    )
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # admin/secret should work
+        resp = await c.get("/api/config", auth=("admin", "secret"))
+        assert resp.status_code == 200
+        # wrong username should fail
+        resp = await c.get("/api/config", auth=("user", "secret"))
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

- Add optional HTTP Basic Auth middleware (inspired by Dash's BasicAuth)
- Enabled by setting `DEEPAGENT_AUTH_PASSWORD` env var, `--auth-password` CLI flag, or `auth_password` Python kwarg
- Username defaults to `admin` when not specified
- Uses `secrets.compare_digest` for timing-safe credential comparison
- Protects both HTTP and WebSocket endpoints

## Test plan

- [x] 45 tests pass (5 new auth tests)
- [x] Unauthenticated request returns 401
- [x] Correct credentials return 200
- [x] Wrong credentials return 401
- [x] No auth configured preserves existing open behavior
- [x] Default username is "admin" when only password is set