### PR TITLE
Add print, slash commands, and configurable workflow prompts

### DIFF
--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -37,6 +37,8 @@ class CoworkApp:
         icon_url: str | None = None,
         auth_username: str | None = None,
         auth_password: str | None = None,
+        save_workflow_prompt: str | None = None,
+        run_workflow_prompt: str | None = None,
         stream_parser_config: dict | None = None,
     ):
         self.config = AppConfig.from_env().merge({
@@ -53,6 +55,8 @@ class CoworkApp:
             "icon_url": icon_url,
             "auth_username": auth_username,
             "auth_password": auth_password,
+            "save_workflow_prompt": save_workflow_prompt,
+            "run_workflow_prompt": run_workflow_prompt,
         })
 
         # Ensure workspace directory exists

--- a/cowork_dash/cli.py
+++ b/cowork_dash/cli.py
@@ -26,8 +26,10 @@ def main():
 @click.option("--icon-url", default=None, help="URL to a custom icon image for the header and welcome screen")
 @click.option("--auth-username", default=None, help="Basic auth username (default: admin)")
 @click.option("--auth-password", default=None, help="Basic auth password (enables auth when set)")
+@click.option("--save-workflow-prompt", default=None, help="Custom prompt template for /save-workflow command")
+@click.option("--run-workflow-prompt", default=None, help="Custom prompt template for /run-workflow command (use {filename} placeholder)")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't auto-open browser")
-def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, no_browser):
+def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, save_workflow_prompt, run_workflow_prompt, no_browser):
     """Start the Cowork Dash server."""
     app = CoworkApp(
         agent_spec=agent_spec,
@@ -43,6 +45,8 @@ def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_messa
         icon_url=icon_url,
         auth_username=auth_username,
         auth_password=auth_password,
+        save_workflow_prompt=save_workflow_prompt,
+        run_workflow_prompt=run_workflow_prompt,
     )
     app.run(open_browser=not no_browser)
 

--- a/cowork_dash/config.py
+++ b/cowork_dash/config.py
@@ -24,6 +24,8 @@ class AppConfig:
     icon_url: str = ""
     auth_username: str = ""
     auth_password: str = ""
+    save_workflow_prompt: str = "Please capture this conversation as a detailed workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions that could be followed to reproduce this workflow, any configuration or parameters needed, and expected outputs."
+    run_workflow_prompt: str = "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file."
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -42,6 +44,8 @@ class AppConfig:
             icon_url=os.getenv("DEEPAGENT_ICON_URL", ""),
             auth_username=os.getenv("DEEPAGENT_AUTH_USERNAME", ""),
             auth_password=os.getenv("DEEPAGENT_AUTH_PASSWORD", ""),
+            save_workflow_prompt=os.getenv("DEEPAGENT_SAVE_WORKFLOW_PROMPT", AppConfig.save_workflow_prompt),
+            run_workflow_prompt=os.getenv("DEEPAGENT_RUN_WORKFLOW_PROMPT", AppConfig.run_workflow_prompt),
         )
 
     def merge(self, overrides: dict) -> "AppConfig":
@@ -61,6 +65,8 @@ class AppConfig:
             "icon_url": self.icon_url,
             "auth_username": self.auth_username,
             "auth_password": self.auth_password,
+            "save_workflow_prompt": self.save_workflow_prompt,
+            "run_workflow_prompt": self.run_workflow_prompt,
         }
         current.update(updates)
         return AppConfig(**current)
@@ -75,4 +81,6 @@ class AppConfig:
             "workspace_name": self.workspace.name,
             "agent_name": self.agent_name,
             "icon_url": self.icon_url,
+            "save_workflow_prompt": self.save_workflow_prompt,
+            "run_workflow_prompt": self.run_workflow_prompt,
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,8 @@ const DEFAULT_CONFIG: AppConfig = {
   workspace_name: "",
   agent_name: "Agent",
   icon_url: "",
+  save_workflow_prompt: "",
+  run_workflow_prompt: "",
 };
 
 export default function App() {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -4,6 +4,8 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage } from "../types";
 import { MessageBubble } from "./MessageBubble";
+import { useSlashCommands } from "../hooks/useSlashCommands";
+import { SlashCommandMenu } from "./SlashCommandMenu";
 
 interface ChatPanelProps {
   messages: ChatMessage[];
@@ -11,6 +13,8 @@ interface ChatPanelProps {
   welcomeMessage: string;
   agentName: string;
   iconUrl?: string;
+  saveWorkflowPrompt?: string;
+  runWorkflowPrompt?: string;
   onSend: (content: string) => void;
   onCancel: () => void;
 }
@@ -21,6 +25,8 @@ export function ChatPanel({
   welcomeMessage,
   agentName,
   iconUrl,
+  saveWorkflowPrompt,
+  runWorkflowPrompt,
   onSend,
   onCancel,
 }: ChatPanelProps) {
@@ -28,6 +34,7 @@ export function ChatPanel({
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isNearBottomRef = useRef(true);
+  const slashCommands = useSlashCommands({ saveWorkflowPrompt, runWorkflowPrompt });
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
@@ -43,18 +50,40 @@ export function ChatPanel({
     }
   }, [messages]);
 
+  const sendAndReset = (message: string) => {
+    isNearBottomRef.current = true;
+    onSend(message);
+    setInput("");
+    slashCommands.reset();
+    if (inputRef.current) inputRef.current.style.height = "auto";
+  };
+
   const handleSubmit = () => {
     const trimmed = input.trim();
     if (!trimmed || isStreaming) return;
-    isNearBottomRef.current = true;
-    onSend(trimmed);
-    setInput("");
-    if (inputRef.current) {
-      inputRef.current.style.height = "auto";
+    const expanded = slashCommands.tryExecute(trimmed);
+    sendAndReset(expanded ?? trimmed);
+  };
+
+  const handleSlashSelect = (index: number) => {
+    const { expanded, newInput } = slashCommands.handleSelect(index);
+    if (expanded) {
+      sendAndReset(expanded);
+    } else if (newInput !== null) {
+      setInput(newInput);
+      inputRef.current?.focus();
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Slash command menu gets first dibs on navigation keys
+    if (slashCommands.handleKeyDown(e)) {
+      // Enter/Tab consumed by menu → execute selection
+      if (e.key === "Enter" || e.key === "Tab") {
+        handleSlashSelect(slashCommands.selectedIndex);
+      }
+      return;
+    }
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
@@ -62,7 +91,9 @@ export function ChatPanel({
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInput(e.target.value);
+    const val = e.target.value;
+    setInput(val);
+    slashCommands.handleInputChange(val);
     const el = e.target;
     el.style.height = "auto";
     el.style.height = Math.min(el.scrollHeight, 200) + "px";
@@ -129,8 +160,18 @@ export function ChatPanel({
       </div>
 
       {/* Input area */}
-      <div className="border-t border-[var(--color-border)]">
-        <div className="max-w-4xl mx-auto px-5 py-3">
+      <div data-print-hide className="border-t border-[var(--color-border)]">
+        <div className="max-w-4xl mx-auto px-5 py-3 relative">
+          <SlashCommandMenu
+            showCommandMenu={slashCommands.showCommandMenu}
+            filteredCommands={slashCommands.filteredCommands}
+            showWorkflowPicker={slashCommands.showWorkflowPicker}
+            filteredWorkflowFiles={slashCommands.filteredWorkflowFiles}
+            isLoadingWorkflows={slashCommands.isLoadingWorkflows}
+            selectedIndex={slashCommands.selectedIndex}
+            onSelect={handleSlashSelect}
+            onHover={slashCommands.setSelectedIndex}
+          />
           <div className="flex items-end gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-2)] px-3 py-2 focus-within:border-[var(--color-text-muted)] transition-colors">
             <textarea
               ref={inputRef}
@@ -162,7 +203,7 @@ export function ChatPanel({
           </div>
           <div className="text-center mt-1.5">
             <span className="text-[10px] text-[var(--color-text-muted)]">
-              <kbd className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[9px] font-mono">Enter</kbd> to send, <kbd className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[9px] font-mono">Shift+Enter</kbd> for new line
+              <kbd className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[9px] font-mono">Enter</kbd> to send, <kbd className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[9px] font-mono">Shift+Enter</kbd> for new line, <kbd className="px-1 py-0.5 rounded bg-[var(--color-surface-3)] text-[9px] font-mono">/</kbd> for commands
             </span>
           </div>
         </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -64,7 +64,7 @@ export function Layout(props: LayoutProps) {
   return (
     <div className="h-full flex flex-col bg-[var(--color-surface)]">
       {/* Header */}
-      <header className="flex items-center justify-between px-5 h-11 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
+      <header data-print-hide className="flex items-center justify-between px-5 h-11 border-b border-[var(--color-border)] bg-[var(--color-surface)]">
         <div className="flex items-center gap-2.5">
           {props.config.icon_url ? (
             <img
@@ -120,13 +120,15 @@ export function Layout(props: LayoutProps) {
               welcomeMessage={props.config.welcome_message}
               agentName={props.config.agent_name}
               iconUrl={props.config.icon_url}
+              saveWorkflowPrompt={props.config.save_workflow_prompt}
+              runWorkflowPrompt={props.config.run_workflow_prompt}
               onSend={props.onSend}
               onCancel={props.onCancel}
             />
           </Allotment.Pane>
 
           <Allotment.Pane minSize={250} visible={sidebarOpen}>
-            <div className="flex flex-col h-full bg-[var(--color-surface)]">
+            <div data-print-hide className="flex flex-col h-full bg-[var(--color-surface)]">
               {/* Tab bar */}
               <div className="flex items-center h-10 border-b border-[var(--color-border)]">
                 <button

--- a/frontend/src/components/SlashCommandMenu.tsx
+++ b/frontend/src/components/SlashCommandMenu.tsx
@@ -1,0 +1,110 @@
+import { useRef, useEffect } from "react";
+import { FileText, Terminal, Loader2 } from "lucide-react";
+import type { SlashCommandDefinition } from "../hooks/useSlashCommands";
+
+interface SlashCommandMenuProps {
+  showCommandMenu: boolean;
+  filteredCommands: SlashCommandDefinition[];
+  showWorkflowPicker: boolean;
+  filteredWorkflowFiles: string[];
+  isLoadingWorkflows: boolean;
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  onHover: (index: number) => void;
+}
+
+export function SlashCommandMenu({
+  showCommandMenu,
+  filteredCommands,
+  showWorkflowPicker,
+  filteredWorkflowFiles,
+  isLoadingWorkflows,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: SlashCommandMenuProps) {
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (!showCommandMenu && !showWorkflowPicker) return null;
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 mb-2 z-10">
+      <div className="bg-[var(--color-surface-2)] border border-[var(--color-border)] rounded-lg shadow-lg overflow-hidden max-h-[200px] overflow-y-auto">
+        {showCommandMenu && (
+          <div className="py-1">
+            {filteredCommands.map((cmd, i) => (
+              <button
+                key={cmd.name}
+                ref={i === selectedIndex ? selectedRef : undefined}
+                onClick={() => onSelect(i)}
+                onMouseEnter={() => onHover(i)}
+                className={`w-full text-left px-3 py-2 flex items-start gap-2.5 transition-colors ${
+                  i === selectedIndex
+                    ? "bg-[var(--color-surface-3)]"
+                    : "hover:bg-[var(--color-surface-3)]"
+                }`}
+              >
+                <Terminal
+                  size={14}
+                  className="text-[var(--color-text-muted)] mt-0.5 flex-shrink-0"
+                />
+                <div>
+                  <div className="text-sm font-medium text-[var(--color-text)]">
+                    {cmd.label}
+                  </div>
+                  <div className="text-xs text-[var(--color-text-muted)]">
+                    {cmd.description}
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {showWorkflowPicker && (
+          <div className="py-1">
+            <div className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+              Workflows
+            </div>
+            {isLoadingWorkflows ? (
+              <div className="flex items-center gap-2 px-3 py-2 text-xs text-[var(--color-text-muted)]">
+                <Loader2 size={12} className="animate-spin" />
+                Loading workflows...
+              </div>
+            ) : filteredWorkflowFiles.length === 0 ? (
+              <div className="px-3 py-2 text-xs text-[var(--color-text-muted)] italic">
+                No workflows found. Use /save-workflow to create one.
+              </div>
+            ) : (
+              filteredWorkflowFiles.map((file, i) => (
+                <button
+                  key={file}
+                  ref={i === selectedIndex ? selectedRef : undefined}
+                  onClick={() => onSelect(i)}
+                  onMouseEnter={() => onHover(i)}
+                  className={`w-full text-left px-3 py-1.5 flex items-center gap-2 transition-colors ${
+                    i === selectedIndex
+                      ? "bg-[var(--color-surface-3)]"
+                      : "hover:bg-[var(--color-surface-3)]"
+                  }`}
+                >
+                  <FileText
+                    size={14}
+                    className="text-[var(--color-text-secondary)] flex-shrink-0"
+                  />
+                  <span className="text-sm text-[var(--color-text)] truncate">
+                    {file}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/StatusBar.tsx
+++ b/frontend/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Loader2, RotateCcw, Zap } from "lucide-react";
+import { Loader2, Printer, RotateCcw, Zap } from "lucide-react";
 import type { ConnectionStatus, TokenUsage, TurnUsage } from "../types";
 import { TokenUsageChart } from "./TokenUsageChart";
 
@@ -60,6 +60,14 @@ export function StatusBar({
       >
         <RotateCcw size={10} />
         New
+      </button>
+      <button
+        onClick={() => window.print()}
+        className="flex items-center gap-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors cursor-pointer"
+        title="Print conversation"
+      >
+        <Printer size={10} />
+        Print
       </button>
       {isStreaming && (
         <span className="flex items-center gap-1 text-[var(--color-text-secondary)]">

--- a/frontend/src/hooks/useSlashCommands.ts
+++ b/frontend/src/hooks/useSlashCommands.ts
@@ -1,0 +1,236 @@
+import { useState, useCallback, useRef, useMemo } from "react";
+import type { FileEntry } from "../types";
+
+export interface SlashCommandDefinition {
+  name: string;
+  label: string;
+  description: string;
+  hasArg: boolean;
+  expandMessage: (arg?: string) => string;
+}
+
+interface SlashCommandsOptions {
+  saveWorkflowPrompt?: string;
+  runWorkflowPrompt?: string;
+}
+
+const DEFAULT_SAVE_PROMPT =
+  "Please capture this conversation as a detailed workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions that could be followed to reproduce this workflow, any configuration or parameters needed, and expected outputs.";
+
+const DEFAULT_RUN_PROMPT =
+  "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file.";
+
+function buildCommands(savePrompt: string, runPrompt: string): SlashCommandDefinition[] {
+  return [
+    {
+      name: "save-workflow",
+      label: "/save-workflow",
+      description: "Save this conversation as a reusable workflow",
+      hasArg: false,
+      expandMessage: (arg?: string) =>
+        arg ? `${savePrompt}\n\nAdditional instructions: ${arg}` : savePrompt,
+    },
+    {
+      name: "run-workflow",
+      label: "/run-workflow",
+      description: "Execute a saved workflow from ./workflows/",
+      hasArg: true,
+      expandMessage: (arg?: string) => {
+        const parts = arg?.match(/^(\S+\.md)\s*(.*)$/);
+        if (parts) {
+          const base = runPrompt.replace("{filename}", parts[1]);
+          return parts[2] ? `${base}\n\nAdditional instructions: ${parts[2]}` : base;
+        }
+        return runPrompt.replace("{filename}", arg ?? "");
+      },
+    },
+  ];
+}
+
+export function useSlashCommands(options: SlashCommandsOptions = {}) {
+  const commands = useMemo(
+    () => buildCommands(
+      options.saveWorkflowPrompt || DEFAULT_SAVE_PROMPT,
+      options.runWorkflowPrompt || DEFAULT_RUN_PROMPT,
+    ),
+    [options.saveWorkflowPrompt, options.runWorkflowPrompt],
+  );
+
+  const [showCommandMenu, setShowCommandMenu] = useState(false);
+  const [showWorkflowPicker, setShowWorkflowPicker] = useState(false);
+  const [filteredCommands, setFilteredCommands] = useState<SlashCommandDefinition[]>([]);
+  const [filteredWorkflowFiles, setFilteredWorkflowFiles] = useState<string[]>([]);
+  const [isLoadingWorkflows, setIsLoadingWorkflows] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const workflowCacheRef = useRef<{ files: string[]; fetchedAt: number }>({
+    files: [],
+    fetchedAt: 0,
+  });
+
+  const fetchWorkflowFiles = useCallback(async (): Promise<string[]> => {
+    const now = Date.now();
+    if (
+      now - workflowCacheRef.current.fetchedAt < 30_000 &&
+      workflowCacheRef.current.files.length > 0
+    ) {
+      return workflowCacheRef.current.files;
+    }
+
+    setIsLoadingWorkflows(true);
+    try {
+      const res = await fetch("/api/files/tree?path=/workflows&depth=1");
+      if (!res.ok) return [];
+      const data = await res.json();
+      const entries: FileEntry[] = data.entries ?? [];
+      const mdFiles = entries
+        .filter((e) => !e.is_dir && e.name.endsWith(".md"))
+        .map((e) => e.name);
+      workflowCacheRef.current = { files: mdFiles, fetchedAt: now };
+      return mdFiles;
+    } catch {
+      return [];
+    } finally {
+      setIsLoadingWorkflows(false);
+    }
+  }, []);
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      // Case 1: starts with "/" and no space yet → command menu
+      if (value.startsWith("/") && !value.includes(" ") && value.length < 30) {
+        const prefix = value.toLowerCase();
+        const matches = commands.filter((cmd) => cmd.label.startsWith(prefix));
+        setFilteredCommands(matches);
+        setShowCommandMenu(matches.length > 0);
+        setShowWorkflowPicker(false);
+        setSelectedIndex(0);
+        return;
+      }
+
+      // Case 2: starts with "/run-workflow " → workflow picker
+      if (value.startsWith("/run-workflow ") || value === "/run-workflow") {
+        setShowCommandMenu(false);
+        setShowWorkflowPicker(true);
+        const filter = value.replace(/^\/run-workflow\s*/, "").toLowerCase();
+        fetchWorkflowFiles().then((files) => {
+          const filtered = filter
+            ? files.filter((f) => f.toLowerCase().includes(filter))
+            : files;
+          setFilteredWorkflowFiles(filtered);
+          setSelectedIndex(0);
+        });
+        return;
+      }
+
+      // Case 3: not a slash command
+      setShowCommandMenu(false);
+      setShowWorkflowPicker(false);
+      setSelectedIndex(0);
+    },
+    [commands, fetchWorkflowFiles],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!showCommandMenu && !showWorkflowPicker) return false;
+
+      const items = showCommandMenu ? filteredCommands : filteredWorkflowFiles;
+      const count = items.length;
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev + 1) % Math.max(count, 1));
+          return true;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev - 1 + Math.max(count, 1)) % Math.max(count, 1));
+          return true;
+        case "Escape":
+          e.preventDefault();
+          setShowCommandMenu(false);
+          setShowWorkflowPicker(false);
+          return true;
+        case "Tab":
+        case "Enter":
+          if (count > 0) {
+            e.preventDefault();
+            return true;
+          }
+          return false;
+        default:
+          return false;
+      }
+    },
+    [showCommandMenu, showWorkflowPicker, filteredCommands, filteredWorkflowFiles],
+  );
+
+  const handleSelect = useCallback(
+    (index: number): { expanded: string | null; newInput: string | null } => {
+      if (showCommandMenu) {
+        const cmd = filteredCommands[index];
+        if (!cmd) return { expanded: null, newInput: null };
+        if (!cmd.hasArg) {
+          return { expanded: cmd.expandMessage(), newInput: null };
+        }
+        // /run-workflow → switch to file picker
+        setShowCommandMenu(false);
+        setShowWorkflowPicker(true);
+        setSelectedIndex(0);
+        fetchWorkflowFiles().then((files) => {
+          setFilteredWorkflowFiles(files);
+        });
+        return { expanded: null, newInput: "/run-workflow " };
+      }
+
+      if (showWorkflowPicker) {
+        const file = filteredWorkflowFiles[index];
+        if (!file) return { expanded: null, newInput: null };
+        const cmd = commands.find((c) => c.name === "run-workflow")!;
+        return { expanded: cmd.expandMessage(file), newInput: null };
+      }
+
+      return { expanded: null, newInput: null };
+    },
+    [commands, showCommandMenu, showWorkflowPicker, filteredCommands, filteredWorkflowFiles, fetchWorkflowFiles],
+  );
+
+  const tryExecute = useCallback((input: string): string | null => {
+    const trimmed = input.trim();
+    // /save-workflow [optional instructions]
+    const saveMatch = trimmed.match(/^\/save-workflow(?:\s+(.+))?$/);
+    if (saveMatch) {
+      return commands[0].expandMessage(saveMatch[1]?.trim());
+    }
+    // /run-workflow <file> [optional instructions]
+    const runMatch = trimmed.match(/^\/run-workflow\s+(.+)$/);
+    if (runMatch) {
+      return commands[1].expandMessage(runMatch[1].trim());
+    }
+    return null;
+  }, [commands]);
+
+  const reset = useCallback(() => {
+    setShowCommandMenu(false);
+    setShowWorkflowPicker(false);
+    setFilteredCommands([]);
+    setFilteredWorkflowFiles([]);
+    setSelectedIndex(0);
+  }, []);
+
+  return {
+    showCommandMenu,
+    showWorkflowPicker,
+    filteredCommands,
+    filteredWorkflowFiles,
+    isLoadingWorkflows,
+    selectedIndex,
+    setSelectedIndex,
+    handleInputChange,
+    handleKeyDown,
+    handleSelect,
+    tryExecute,
+    reset,
+  };
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -99,3 +99,23 @@ html, body, #root {
   background: var(--color-border) !important;
 }
 
+/* Print styles — show only chat messages */
+@media print {
+  /* Force light colors */
+  :root { --color-text: #111827; --color-surface: #fff; --color-surface-2: #f9fafb; --color-surface-3: #f3f4f6; --color-border: #e5e7eb; }
+  /* Hide marked elements: header, sidebar, chat input */
+  [data-print-hide] { display: none !important; }
+  /* Flatten layout so all messages flow naturally */
+  html, body, #root, #root > * { height: auto !important; overflow: visible !important; }
+  #root * { position: static !important; overflow: visible !important; height: auto !important; }
+  /* Restore flex for message spacing */
+  .space-y-5 { display: block !important; }
+  .space-y-5 > * { margin-bottom: 1.25rem; page-break-inside: avoid; }
+  /* Hide iframes (charts/HTML that won't render in print) */
+  iframe { display: none !important; }
+  /* Hide streaming indicator */
+  .animate-bounce { display: none !important; }
+  /* Clean margins */
+  .max-w-4xl { max-width: none !important; }
+}
+

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -197,6 +197,8 @@ export interface AppConfig {
   workspace_name: string;
   agent_name: string;
   icon_url: string;
+  save_workflow_prompt: string;
+  run_workflow_prompt: string;
 }
 
 export interface TokenUsage {


### PR DESCRIPTION
## Summary
- Add browser Print dialog for conversation export with print-optimized CSS
- Add `/save-workflow` and `/run-workflow` slash commands with autocomplete dropdown
- Make workflow command prompts configurable via Python API, CLI flags, and env vars

## Changes
- Print button in status bar, `@media print` stylesheet, `data-print-hide` attributes
- `useSlashCommands` hook + `SlashCommandMenu` component wired into `ChatPanel`
- `save_workflow_prompt` / `run_workflow_prompt` fields in `AppConfig`, CLI, and frontend