### PR TITLE
Add /create-workflow command and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Web UI for [LangGraph](https://github.com/langchain-ai/langgraph) and [deepagent
 - **File browser** — workspace file tree with syntax-highlighted viewer and live file change detection
 - **Task tracking** — sidebar todo list with progress bar, synced with agent `write_todos` calls
 - **Human-in-the-loop** — interrupt dialog for reviewing and approving agent actions
+- **Slash commands** — `/save-workflow`, `/create-workflow`, and `/run-workflow` with autocomplete
+- **Print / export** — print conversations via browser Print dialog with optimized CSS
 - **Token usage** — cumulative counter with per-turn breakdown chart
+- **Authentication** — optional HTTP Basic Auth for all endpoints
 - **Theming** — light, dark, and system-auto modes
 - **Customization** — title, subtitle, welcome message, agent name, and custom icon
 
@@ -77,6 +80,31 @@ Configuration priority: **Python args > CLI args > environment variables > defau
 | Theme | `--theme` | `DEEPAGENT_THEME` | `auto` |
 | Agent name | `--agent-name` | `DEEPAGENT_AGENT_NAME` | Agent's `.name` or `"Agent"` |
 | Icon URL | `--icon-url` | `DEEPAGENT_ICON_URL` | _(none)_ |
+| Auth username | `--auth-username` | `DEEPAGENT_AUTH_USERNAME` | `admin` |
+| Auth password | `--auth-password` | `DEEPAGENT_AUTH_PASSWORD` | _(none — auth disabled)_ |
+| Save workflow prompt | `--save-workflow-prompt` | `DEEPAGENT_SAVE_WORKFLOW_PROMPT` | _(built-in)_ |
+| Run workflow prompt | `--run-workflow-prompt` | `DEEPAGENT_RUN_WORKFLOW_PROMPT` | _(built-in, use `{filename}`)_ |
+| Create workflow prompt | `--create-workflow-prompt` | `DEEPAGENT_CREATE_WORKFLOW_PROMPT` | _(built-in)_ |
+
+## Slash Commands
+
+Type `/` in the chat input to access built-in commands:
+
+| Command | Description |
+|---------|-------------|
+| `/save-workflow` | Capture the current conversation as a reusable workflow in `./workflows/` |
+| `/create-workflow` | Create a new workflow from scratch — prompts for a topic description |
+| `/run-workflow` | Execute a saved workflow — shows an autocomplete dropdown of `.md` files from `./workflows/` |
+
+All commands support inline arguments:
+
+```
+/save-workflow focus on the data cleaning steps
+/create-workflow daily sales report pipeline
+/run-workflow etl-pipeline.md skip step 3
+```
+
+The prompt templates behind each command are configurable via Python API, CLI flags, or environment variables (see Configuration table above).
 
 ## Stream Parser Config
 

--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -39,6 +39,7 @@ class CoworkApp:
         auth_password: str | None = None,
         save_workflow_prompt: str | None = None,
         run_workflow_prompt: str | None = None,
+        create_workflow_prompt: str | None = None,
         stream_parser_config: dict | None = None,
     ):
         self.config = AppConfig.from_env().merge({
@@ -57,6 +58,7 @@ class CoworkApp:
             "auth_password": auth_password,
             "save_workflow_prompt": save_workflow_prompt,
             "run_workflow_prompt": run_workflow_prompt,
+            "create_workflow_prompt": create_workflow_prompt,
         })
 
         # Ensure workspace directory exists

--- a/cowork_dash/cli.py
+++ b/cowork_dash/cli.py
@@ -28,8 +28,9 @@ def main():
 @click.option("--auth-password", default=None, help="Basic auth password (enables auth when set)")
 @click.option("--save-workflow-prompt", default=None, help="Custom prompt template for /save-workflow command")
 @click.option("--run-workflow-prompt", default=None, help="Custom prompt template for /run-workflow command (use {filename} placeholder)")
+@click.option("--create-workflow-prompt", default=None, help="Custom prompt template for /create-workflow command")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't auto-open browser")
-def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, save_workflow_prompt, run_workflow_prompt, no_browser):
+def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, save_workflow_prompt, run_workflow_prompt, create_workflow_prompt, no_browser):
     """Start the Cowork Dash server."""
     app = CoworkApp(
         agent_spec=agent_spec,
@@ -47,6 +48,7 @@ def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_messa
         auth_password=auth_password,
         save_workflow_prompt=save_workflow_prompt,
         run_workflow_prompt=run_workflow_prompt,
+        create_workflow_prompt=create_workflow_prompt,
     )
     app.run(open_browser=not no_browser)
 

--- a/cowork_dash/config.py
+++ b/cowork_dash/config.py
@@ -26,6 +26,7 @@ class AppConfig:
     auth_password: str = ""
     save_workflow_prompt: str = "Please capture this conversation as a detailed workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions that could be followed to reproduce this workflow, any configuration or parameters needed, and expected outputs."
     run_workflow_prompt: str = "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file."
+    create_workflow_prompt: str = "Please create a new workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions to execute the workflow, any configuration or parameters needed, and expected outputs."
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -46,6 +47,7 @@ class AppConfig:
             auth_password=os.getenv("DEEPAGENT_AUTH_PASSWORD", ""),
             save_workflow_prompt=os.getenv("DEEPAGENT_SAVE_WORKFLOW_PROMPT", AppConfig.save_workflow_prompt),
             run_workflow_prompt=os.getenv("DEEPAGENT_RUN_WORKFLOW_PROMPT", AppConfig.run_workflow_prompt),
+            create_workflow_prompt=os.getenv("DEEPAGENT_CREATE_WORKFLOW_PROMPT", AppConfig.create_workflow_prompt),
         )
 
     def merge(self, overrides: dict) -> "AppConfig":
@@ -67,6 +69,7 @@ class AppConfig:
             "auth_password": self.auth_password,
             "save_workflow_prompt": self.save_workflow_prompt,
             "run_workflow_prompt": self.run_workflow_prompt,
+            "create_workflow_prompt": self.create_workflow_prompt,
         }
         current.update(updates)
         return AppConfig(**current)
@@ -83,4 +86,5 @@ class AppConfig:
             "icon_url": self.icon_url,
             "save_workflow_prompt": self.save_workflow_prompt,
             "run_workflow_prompt": self.run_workflow_prompt,
+            "create_workflow_prompt": self.create_workflow_prompt,
         }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ const DEFAULT_CONFIG: AppConfig = {
   icon_url: "",
   save_workflow_prompt: "",
   run_workflow_prompt: "",
+  create_workflow_prompt: "",
 };
 
 export default function App() {

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -15,6 +15,7 @@ interface ChatPanelProps {
   iconUrl?: string;
   saveWorkflowPrompt?: string;
   runWorkflowPrompt?: string;
+  createWorkflowPrompt?: string;
   onSend: (content: string) => void;
   onCancel: () => void;
 }
@@ -27,6 +28,7 @@ export function ChatPanel({
   iconUrl,
   saveWorkflowPrompt,
   runWorkflowPrompt,
+  createWorkflowPrompt,
   onSend,
   onCancel,
 }: ChatPanelProps) {
@@ -34,7 +36,7 @@ export function ChatPanel({
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const isNearBottomRef = useRef(true);
-  const slashCommands = useSlashCommands({ saveWorkflowPrompt, runWorkflowPrompt });
+  const slashCommands = useSlashCommands({ saveWorkflowPrompt, runWorkflowPrompt, createWorkflowPrompt });
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -122,6 +122,7 @@ export function Layout(props: LayoutProps) {
               iconUrl={props.config.icon_url}
               saveWorkflowPrompt={props.config.save_workflow_prompt}
               runWorkflowPrompt={props.config.run_workflow_prompt}
+              createWorkflowPrompt={props.config.create_workflow_prompt}
               onSend={props.onSend}
               onCancel={props.onCancel}
             />

--- a/frontend/src/hooks/useSlashCommands.ts
+++ b/frontend/src/hooks/useSlashCommands.ts
@@ -5,13 +5,15 @@ export interface SlashCommandDefinition {
   name: string;
   label: string;
   description: string;
-  hasArg: boolean;
+  /** "none" = fire immediately, "file-picker" = show workflow picker, "text" = prompt for free-text input */
+  secondStep: "none" | "file-picker" | "text";
   expandMessage: (arg?: string) => string;
 }
 
 interface SlashCommandsOptions {
   saveWorkflowPrompt?: string;
   runWorkflowPrompt?: string;
+  createWorkflowPrompt?: string;
 }
 
 const DEFAULT_SAVE_PROMPT =
@@ -20,21 +22,32 @@ const DEFAULT_SAVE_PROMPT =
 const DEFAULT_RUN_PROMPT =
   "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file.";
 
-function buildCommands(savePrompt: string, runPrompt: string): SlashCommandDefinition[] {
+const DEFAULT_CREATE_PROMPT =
+  "Please create a new workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions to execute the workflow, any configuration or parameters needed, and expected outputs.";
+
+function buildCommands(savePrompt: string, runPrompt: string, createPrompt: string): SlashCommandDefinition[] {
   return [
     {
       name: "save-workflow",
       label: "/save-workflow",
       description: "Save this conversation as a reusable workflow",
-      hasArg: false,
+      secondStep: "none",
       expandMessage: (arg?: string) =>
         arg ? `${savePrompt}\n\nAdditional instructions: ${arg}` : savePrompt,
+    },
+    {
+      name: "create-workflow",
+      label: "/create-workflow",
+      description: "Create a new workflow — type a description after selecting",
+      secondStep: "text",
+      expandMessage: (arg?: string) =>
+        arg ? `${createPrompt}\n\nWorkflow topic: ${arg}` : createPrompt,
     },
     {
       name: "run-workflow",
       label: "/run-workflow",
       description: "Execute a saved workflow from ./workflows/",
-      hasArg: true,
+      secondStep: "file-picker",
       expandMessage: (arg?: string) => {
         const parts = arg?.match(/^(\S+\.md)\s*(.*)$/);
         if (parts) {
@@ -52,8 +65,9 @@ export function useSlashCommands(options: SlashCommandsOptions = {}) {
     () => buildCommands(
       options.saveWorkflowPrompt || DEFAULT_SAVE_PROMPT,
       options.runWorkflowPrompt || DEFAULT_RUN_PROMPT,
+      options.createWorkflowPrompt || DEFAULT_CREATE_PROMPT,
     ),
-    [options.saveWorkflowPrompt, options.runWorkflowPrompt],
+    [options.saveWorkflowPrompt, options.runWorkflowPrompt, options.createWorkflowPrompt],
   );
 
   const [showCommandMenu, setShowCommandMenu] = useState(false);
@@ -108,11 +122,14 @@ export function useSlashCommands(options: SlashCommandsOptions = {}) {
         return;
       }
 
-      // Case 2: starts with "/run-workflow " → workflow picker
-      if (value.startsWith("/run-workflow ") || value === "/run-workflow") {
+      // Case 2: starts with a file-picker command (e.g. "/run-workflow ") → workflow picker
+      const filePickerCmd = commands.find(
+        (c) => c.secondStep === "file-picker" && (value.startsWith(`/${c.name} `) || value === `/${c.name}`),
+      );
+      if (filePickerCmd) {
         setShowCommandMenu(false);
         setShowWorkflowPicker(true);
-        const filter = value.replace(/^\/run-workflow\s*/, "").toLowerCase();
+        const filter = value.replace(new RegExp(`^\\/${filePickerCmd.name}\\s*`), "").toLowerCase();
         fetchWorkflowFiles().then((files) => {
           const filtered = filter
             ? files.filter((f) => f.toLowerCase().includes(filter))
@@ -171,17 +188,23 @@ export function useSlashCommands(options: SlashCommandsOptions = {}) {
       if (showCommandMenu) {
         const cmd = filteredCommands[index];
         if (!cmd) return { expanded: null, newInput: null };
-        if (!cmd.hasArg) {
+        if (cmd.secondStep === "none") {
           return { expanded: cmd.expandMessage(), newInput: null };
         }
-        // /run-workflow → switch to file picker
+        if (cmd.secondStep === "text") {
+          // Dismiss menu, fill input with command prefix for free-text typing
+          setShowCommandMenu(false);
+          setShowWorkflowPicker(false);
+          return { expanded: null, newInput: `/${cmd.name} ` };
+        }
+        // file-picker: switch to workflow file picker
         setShowCommandMenu(false);
         setShowWorkflowPicker(true);
         setSelectedIndex(0);
         fetchWorkflowFiles().then((files) => {
           setFilteredWorkflowFiles(files);
         });
-        return { expanded: null, newInput: "/run-workflow " };
+        return { expanded: null, newInput: `/${cmd.name} ` };
       }
 
       if (showWorkflowPicker) {
@@ -198,15 +221,15 @@ export function useSlashCommands(options: SlashCommandsOptions = {}) {
 
   const tryExecute = useCallback((input: string): string | null => {
     const trimmed = input.trim();
-    // /save-workflow [optional instructions]
-    const saveMatch = trimmed.match(/^\/save-workflow(?:\s+(.+))?$/);
-    if (saveMatch) {
-      return commands[0].expandMessage(saveMatch[1]?.trim());
-    }
-    // /run-workflow <file> [optional instructions]
-    const runMatch = trimmed.match(/^\/run-workflow\s+(.+)$/);
-    if (runMatch) {
-      return commands[1].expandMessage(runMatch[1].trim());
+    for (const cmd of commands) {
+      // Commands with a second step require an argument; others accept an optional one
+      const re = cmd.secondStep !== "none"
+        ? new RegExp(`^\\/${cmd.name}\\s+(.+)$`)
+        : new RegExp(`^\\/${cmd.name}(?:\\s+(.+))?$`);
+      const match = trimmed.match(re);
+      if (match) {
+        return cmd.expandMessage(match[1]?.trim());
+      }
     }
     return null;
   }, [commands]);

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -199,6 +199,7 @@ export interface AppConfig {
   icon_url: string;
   save_workflow_prompt: string;
   run_workflow_prompt: string;
+  create_workflow_prompt: string;
 }
 
 export interface TokenUsage {


### PR DESCRIPTION
## Summary
- Add `/create-workflow` slash command with two-step text input flow
- Refactor slash command `hasArg` boolean to `secondStep` union type (`"none"` | `"file-picker"` | `"text"`)
- Generalize `tryExecute` and `handleInputChange` to work with any command definition
- Update README with slash commands, auth, and workflow prompt configuration docs

## Changes
- `useSlashCommands.ts`: New command definition, generalized input parsing
- Backend: `create_workflow_prompt` field in AppConfig, CLI, CoworkApp
- Frontend: Prop plumbing through Layout → ChatPanel → hook
- `README.md`: Features, config table, and Slash Commands section