### PR TITLE
Release v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.3.7 — 2026-04-18
+
+### Added
+
+- `CanvasMiddleware` — opt-in LangChain agent middleware that injects canvas tools and report-building guidance into any `create_deep_agent` call. Downstream users enable the canvas feature via `middleware=[CanvasMiddleware()]` without touching tool lists or system prompts.
+- Canvas **section** item type (`add_canvas_section(title, level=1)`) — structural headings that render as `h1`–`h6` in the UI for report organization.
+- `reorder_canvas(item_ids)` tool — rewrite canvas items in a new order.
+- **Provenance**: canvas items now record `source_cell` and `execution_count` from the most recent notebook cell execution; surfaced as a "cell N" pill in the UI.
+- **Tab visibility controls**: `show_canvas` / `show_files` on `CoworkApp`, `--show-canvas/--no-show-canvas` and `--show-files/--no-show-files` CLI flags, `DEEPAGENT_SHOW_CANVAS` / `DEEPAGENT_SHOW_FILES` env vars. Canvas tab defaults to auto-detect (on when `CanvasMiddleware` is attached, off otherwise); files tab defaults to on.
+- `agent_uses_canvas_middleware(agent)` helper for downstream detection.
+- Integration tests for the SSE streaming pipe (`tests/test_sse_adapter.py`) using a conformant fake agent — catches API drift in `langgraph-stream-parser` before it hangs the UI.
+- API contract guards for `prepare_agent_input` and `create_resume_input` signatures.
+- `demo/plain_agent.py` — minimal example of a custom agent without canvas middleware.
+
+### Fixed
+
+- Agent streaming hung silently when `prepare_agent_input()` was called with an unsupported `context_parts=` kwarg. Context is now prepended to the user message directly.
+- `CanvasMiddleware.awrap_model_call` async variant — the sync-only `wrap_model_call` crashed with `NotImplementedError` under `agent.astream()`.
+- `run_agent_stream` / `run_interrupt_response` now wrap the full function body in a try/except and emit `error` events for uncaught exceptions instead of dying silently in the background task.
+
+### Changed
+
+- Canvas tools are no longer baked into `AGENT_TOOLS` — they are injected exclusively via `CanvasMiddleware` to avoid double-registration.
+- Default-agent system prompt no longer embeds canvas guidance; the prompt is appended at call time by `CanvasMiddleware`.
+
+### Removed
+
+- Dead `NotebookState._canvas_items` list and `get_canvas_items` / `clear_canvas_items` methods (never populated; replaced by file-backed canvas state).
+- Dead `create_session_agent` factory that imported a non-existent `cowork_dash.backends` module.
+
 ## 0.3.6 — 2026-04-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Web UI for [LangGraph](https://github.com/langchain-ai/langgraph) and [deepagent
 - **Chat** with real-time token streaming via WebSocket
 - **Tool call visualization** — inline display of arguments, results, duration, and status
 - **Rich inline content** — HTML, Plotly charts, images, DataFrames, PDFs, and JSON rendered directly in the chat
-- **Canvas panel** — persistent visualizations (Plotly, matplotlib, Mermaid diagrams, DataFrames, Markdown, images)
+- **Canvas panel** — persistent report surface for charts, tables, diagrams, images, and narrative markdown. Opt-in via `CanvasMiddleware`; auto-detected by the UI.
 - **File browser** — workspace file tree with syntax-highlighted viewer and live file change detection
 - **Task tracking** — sidebar todo list with progress bar, synced with agent `write_todos` calls
 - **Human-in-the-loop** — interrupt dialog for reviewing and approving agent actions
@@ -63,6 +63,28 @@ from cowork_dash import run_app
 run_app(agent=your_agent, workspace="./workspace")
 ```
 
+### Enabling the Canvas
+
+The canvas is opt-in. Attach `CanvasMiddleware` to your agent and the Canvas tab appears in the UI automatically:
+
+```python
+from deepagents import create_deep_agent
+from cowork_dash import CoworkApp
+from cowork_dash.middleware import CanvasMiddleware
+
+agent = create_deep_agent(
+    tools=[...],
+    middleware=[CanvasMiddleware()],   # <-- adds canvas tools + report guidance
+    ...
+)
+
+CoworkApp(agent=agent, workspace="./workspace").run()
+```
+
+The middleware injects five tools (`add_to_canvas`, `update_canvas_item`, `remove_canvas_item`, `add_canvas_section`, `reorder_canvas`) and appends report-building instructions to the system prompt at each model call. Canvas items persist to `.canvas/canvas.md` in the workspace.
+
+To force the tabs on/off regardless of middleware: `--show-canvas/--no-show-canvas`, `--show-files/--no-show-files`, or the Python-API `show_canvas` / `show_files` kwargs.
+
 ## Configuration
 
 Configuration priority: **Python args > CLI args > environment variables > defaults**.
@@ -85,6 +107,8 @@ Configuration priority: **Python args > CLI args > environment variables > defau
 | Save workflow prompt | `--save-workflow-prompt` | `DEEPAGENT_SAVE_WORKFLOW_PROMPT` | _(built-in)_ |
 | Run workflow prompt | `--run-workflow-prompt` | `DEEPAGENT_RUN_WORKFLOW_PROMPT` | _(built-in, use `{filename}`)_ |
 | Create workflow prompt | `--create-workflow-prompt` | `DEEPAGENT_CREATE_WORKFLOW_PROMPT` | _(built-in)_ |
+| Show Canvas tab | `--show-canvas/--no-show-canvas` | `DEEPAGENT_SHOW_CANVAS` | Auto — on when `CanvasMiddleware` is attached |
+| Show Files tab | `--show-files/--no-show-files` | `DEEPAGENT_SHOW_FILES` | `true` |
 
 ## Slash Commands
 

--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -9,6 +9,7 @@ import uvicorn
 from cowork_dash.agent_loader import load_agent_from_spec
 from cowork_dash.config import AppConfig
 from cowork_dash.default_agent import create_default_agent
+from cowork_dash.middleware import agent_uses_canvas_middleware
 from cowork_dash.server.main import create_fastapi_app
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,8 @@ class CoworkApp:
         run_workflow_prompt: str | None = None,
         create_workflow_prompt: str | None = None,
         custom_css: str | None = None,
+        show_canvas: bool | None = None,
+        show_files: bool | None = None,
         stream_parser_config: dict | None = None,
     ):
         self.config = AppConfig.from_env().merge({
@@ -61,6 +64,8 @@ class CoworkApp:
             "run_workflow_prompt": run_workflow_prompt,
             "create_workflow_prompt": create_workflow_prompt,
             "custom_css": custom_css,
+            "show_canvas": show_canvas,
+            "show_files": show_files,
         })
 
         # Ensure workspace directory exists
@@ -68,6 +73,13 @@ class CoworkApp:
 
         self.agent = self._resolve_agent(agent)
         self.stream_parser_config = stream_parser_config or {}
+
+        # Resolve show_canvas: explicit value wins; otherwise auto-detect from
+        # the agent's middleware. show_files stays True unless explicitly off.
+        if self.config.show_canvas is None:
+            self.config.show_canvas = agent_uses_canvas_middleware(self.agent)
+        if self.config.show_files is None:
+            self.config.show_files = True
 
         # Default title and agent_name from the agent object's .name if not explicitly set
         inferred_name = getattr(self.agent, "name", None)

--- a/cowork_dash/canvas.py
+++ b/cowork_dash/canvas.py
@@ -149,7 +149,9 @@ def parse_canvas_object(
     obj: Any,
     workspace_root: AnyRoot,
     title: Optional[str] = None,
-    item_id: Optional[str] = None
+    item_id: Optional[str] = None,
+    source_cell: Optional[int] = None,
+    execution_count: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Parse Python objects into canvas-renderable format.
 
@@ -158,6 +160,8 @@ def parse_canvas_object(
         workspace_root: Path to the workspace root directory (Path or VirtualFilesystem)
         title: Optional title for the canvas item
         item_id: Optional ID for the canvas item (auto-generated if not provided)
+        source_cell: Optional cell index that produced this item
+        execution_count: Optional execution count at the time of creation
 
     Supports:
     - pd.DataFrame (inline in markdown)
@@ -180,11 +184,23 @@ def parse_canvas_object(
         result["created_at"] = created_at
         if title:
             result["title"] = title
+        if source_cell is not None:
+            result["source_cell"] = int(source_cell)
+        if execution_count is not None:
+            result["execution_count"] = int(execution_count)
         return result
 
     # Ensure .canvas directory exists
     canvas_dir = _get_path(workspace_root, ".canvas")
     canvas_dir.mkdir(exist_ok=True)
+
+    # Section header — structural item for report organization
+    if isinstance(obj, dict) and obj.get("__canvas_kind__") == "section":
+        return add_metadata({
+            "type": "section",
+            "data": obj.get("text", ""),
+            "level": int(obj.get("level", 1)),
+        })
 
     # Pandas DataFrame - keep inline
     if module.startswith('pandas') and obj_type == 'DataFrame':
@@ -344,6 +360,10 @@ def export_canvas_to_markdown(
             metadata["created_at"] = created_at
         if "title" in parsed:
             metadata["title"] = parsed["title"]
+        if "source_cell" in parsed:
+            metadata["source_cell"] = parsed["source_cell"]
+        if "execution_count" in parsed:
+            metadata["execution_count"] = parsed["execution_count"]
         lines.append(f"\n<!-- canvas-item: {json.dumps(metadata)} -->")
 
         # Add title if present
@@ -352,6 +372,11 @@ def export_canvas_to_markdown(
 
         if item_type == "markdown":
             lines.append(f"\n{parsed.get('data', '')}\n")
+
+        elif item_type == "section":
+            level = max(1, min(int(parsed.get("level", 1)), 6))
+            hashes = "#" * level
+            lines.append(f"\n{hashes} {parsed.get('data', '')}\n")
 
         elif item_type == "mermaid":
             lines.append(f"\n```mermaid\n{parsed.get('data', '')}\n```\n")
@@ -463,6 +488,10 @@ def _parse_item_content(
         item["title"] = metadata["title"]
     if "created_at" in metadata:
         item["created_at"] = metadata["created_at"]
+    if "source_cell" in metadata:
+        item["source_cell"] = metadata["source_cell"]
+    if "execution_count" in metadata:
+        item["execution_count"] = metadata["execution_count"]
 
     # Remove title heading if present (we already have it in metadata)
     if "title" in metadata:
@@ -518,6 +547,17 @@ def _parse_item_content(
         if match:
             item["html"] = match.group(0)
             return item
+
+    elif item_type == "section":
+        match = re.search(r'^(#{1,6})\s+(.+?)\s*$', content.strip(), re.MULTILINE)
+        if match:
+            item["level"] = len(match.group(1))
+            item["data"] = match.group(2).strip()
+            return item
+        # Fallback: treat whole content as section text
+        item["level"] = 1
+        item["data"] = content.strip()
+        return item
 
     elif item_type == "markdown":
         # Clean up the content

--- a/cowork_dash/cli.py
+++ b/cowork_dash/cli.py
@@ -30,8 +30,10 @@ def main():
 @click.option("--run-workflow-prompt", default=None, help="Custom prompt template for /run-workflow command (use {filename} placeholder)")
 @click.option("--create-workflow-prompt", default=None, help="Custom prompt template for /create-workflow command")
 @click.option("--custom-css", default=None, type=click.Path(exists=True), help="Path to custom CSS file for theming")
+@click.option("--show-canvas/--no-show-canvas", "show_canvas", default=None, help="Force-show or force-hide the Canvas tab (default: auto-detect from CanvasMiddleware)")
+@click.option("--show-files/--no-show-files", "show_files", default=None, help="Show or hide the Files tab (default: shown)")
 @click.option("--no-browser", is_flag=True, default=False, help="Don't auto-open browser")
-def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, save_workflow_prompt, run_workflow_prompt, create_workflow_prompt, custom_css, no_browser):
+def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_message, theme, agent_name, icon_url, auth_username, auth_password, save_workflow_prompt, run_workflow_prompt, create_workflow_prompt, custom_css, show_canvas, show_files, no_browser):
     """Start the Cowork Dash server."""
     app = CoworkApp(
         agent_spec=agent_spec,
@@ -51,6 +53,8 @@ def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_messa
         run_workflow_prompt=run_workflow_prompt,
         create_workflow_prompt=create_workflow_prompt,
         custom_css=custom_css,
+        show_canvas=show_canvas,
+        show_files=show_files,
     )
     app.run(open_browser=not no_browser)
 

--- a/cowork_dash/config.py
+++ b/cowork_dash/config.py
@@ -2,7 +2,24 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Optional
 import os
+
+
+def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
+    """Parse an env-var string into an optional bool.
+
+    Returns True for '1'/'true'/'yes', False for '0'/'false'/'no', and
+    None for empty/unset (auto-detect mode).
+    """
+    if value is None or value == "":
+        return None
+    lowered = value.strip().lower()
+    if lowered in ("1", "true", "yes"):
+        return True
+    if lowered in ("0", "false", "no"):
+        return False
+    return None
 
 # Module-level constants used by tools.py and agent.py
 WORKSPACE_ROOT = Path(os.getenv("DEEPAGENT_WORKSPACE_ROOT", os.getcwd()))
@@ -28,6 +45,10 @@ class AppConfig:
     run_workflow_prompt: str = "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file."
     create_workflow_prompt: str = "Please create a new workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions to execute the workflow, any configuration or parameters needed, and expected outputs."
     custom_css: str = ""
+    # Tab visibility — None means auto-resolve (canvas auto-detects middleware;
+    # files defaults to True). Explicit True/False overrides auto-detection.
+    show_canvas: Optional[bool] = None
+    show_files: Optional[bool] = None
 
     @classmethod
     def from_env(cls) -> "AppConfig":
@@ -50,6 +71,8 @@ class AppConfig:
             run_workflow_prompt=os.getenv("DEEPAGENT_RUN_WORKFLOW_PROMPT", AppConfig.run_workflow_prompt),
             create_workflow_prompt=os.getenv("DEEPAGENT_CREATE_WORKFLOW_PROMPT", AppConfig.create_workflow_prompt),
             custom_css=os.getenv("DEEPAGENT_CUSTOM_CSS", ""),
+            show_canvas=_parse_optional_bool(os.getenv("DEEPAGENT_SHOW_CANVAS")),
+            show_files=_parse_optional_bool(os.getenv("DEEPAGENT_SHOW_FILES")),
         )
 
     def merge(self, overrides: dict) -> "AppConfig":
@@ -73,12 +96,19 @@ class AppConfig:
             "run_workflow_prompt": self.run_workflow_prompt,
             "create_workflow_prompt": self.create_workflow_prompt,
             "custom_css": self.custom_css,
+            "show_canvas": self.show_canvas,
+            "show_files": self.show_files,
         }
         current.update(updates)
         return AppConfig(**current)
 
     def to_client_dict(self) -> dict:
-        """Return config values needed by the frontend."""
+        """Return config values needed by the frontend.
+
+        Unresolved show_* flags (None) are surfaced as True so the UI stays
+        permissive — the resolver in CoworkApp is responsible for turning
+        None into a concrete bool before the config reaches the client.
+        """
         return {
             "title": self.title,
             "subtitle": self.subtitle,
@@ -90,4 +120,6 @@ class AppConfig:
             "save_workflow_prompt": self.save_workflow_prompt,
             "run_workflow_prompt": self.run_workflow_prompt,
             "create_workflow_prompt": self.create_workflow_prompt,
+            "show_canvas": True if self.show_canvas is None else self.show_canvas,
+            "show_files": True if self.show_files is None else self.show_files,
         }

--- a/cowork_dash/default_agent.py
+++ b/cowork_dash/default_agent.py
@@ -11,8 +11,8 @@ from deepagents import create_deep_agent
 from deepagents.backends import FilesystemBackend
 from langgraph.checkpoint.memory import InMemorySaver
 
+from cowork_dash.middleware import CanvasMiddleware
 from cowork_dash.tools import (
-    add_to_canvas,
     bash,
     create_cell,
     delete_cell,
@@ -28,7 +28,6 @@ from cowork_dash.tools import (
 )
 
 SYSTEM_PROMPT = """You are a helpful AI assistant with access to a filesystem workspace and a Python code execution environment.
-You have access to a canvas, which is a markdown file located at `.canvas/canvas.md` in the workspace. This allows you to sketch out ideas, document your work, and present results to the user.
 
 CRITICAL!:
 - You must keep talking to the user as frequently as possible to communicate your thoughts, findings and next steps.
@@ -77,15 +76,6 @@ You have tools to write and execute Python code interactively, similar to a Jupy
   - Supported: images (.png, .jpg, .gif), documents (.html, .pdf), data (.csv, .json)
   - Example: `display_inline("results.csv", title="Sales Data")` as a tool call
 
-### Canvas Visualization
-- `add_to_canvas(content)` - Add content to the canvas panel (persistent note-taking area). To add images or charts, save them to files and reference them in markdown.
-- Use for: longer-term notes, sketches, charts
-- Canvas items are saved to `.canvas/` directory
-
-**When to use `display_inline` vs `add_to_canvas`:**
-- `display_inline`: For showing **saved files** (images, CSV, JSON) inline in chat
-- `add_to_canvas`: For longer-term notes, sketches, charts
-
 ## Workflow Guidelines
 
 ### For Code Tasks
@@ -121,9 +111,9 @@ The workspace is your sandbox - feel free to create files, organize content, and
 workspace_root = os.getenv("DEEPAGENT_WORKSPACE_ROOT", os.getcwd())
 backend = FilesystemBackend(root_dir=workspace_root, virtual_mode=True)
 
-# Default tools list used by both global and session agents
+# Default tools list used by both global and session agents.
+# Canvas tools are injected by CanvasMiddleware — not included here.
 AGENT_TOOLS = [
-    add_to_canvas,
     bash,
     create_cell,
     insert_cell,
@@ -133,10 +123,13 @@ AGENT_TOOLS = [
     execute_all_cells,
     get_script,
     get_variables,
-    reset_notebook, 
+    reset_notebook,
     display_inline,
-    think_tool
+    think_tool,
 ]
+
+# Middleware list — canvas is opt-in via CanvasMiddleware.
+AGENT_MIDDLEWARE = [CanvasMiddleware()]
 
 # Global agent for physical filesystem mode
 # This uses FilesystemBackend which writes to disk
@@ -145,45 +138,14 @@ agent = create_deep_agent(
     name="Cowork Dash",
     backend=backend,
     tools=AGENT_TOOLS,
+    middleware=AGENT_MIDDLEWARE,
     interrupt_on=dict(bash=True),
     checkpointer=InMemorySaver()
 )
-
-
-def create_session_agent(session_id: str):
-    """Create an agent with session-specific VirtualFilesystem backend.
-
-    This factory function creates an agent that uses the VirtualFilesystem
-    for the given session, enabling isolated file storage between sessions.
-
-    Args:
-        session_id: The session ID to use for VirtualFilesystem lookup.
-
-    Returns:
-        A configured deep agent that uses VirtualFilesystemBackend.
-    """
-    from .backends import VirtualFilesystemBackend
-    from .virtual_fs import get_session_manager
-
-    # Get the VirtualFilesystem for this session
-    fs = get_session_manager().get_filesystem(session_id)
-    if fs is None:
-        # Session doesn't exist, create it
-        get_session_manager().create_session(session_id)
-        fs = get_session_manager().get_filesystem(session_id)
-
-    # Create backend wrapping the VirtualFilesystem
-    session_backend = VirtualFilesystemBackend(fs)
-
-    # Create and return the agent
-    return create_deep_agent(
-        system_prompt=SYSTEM_PROMPT,
-        name="Cowork Dash",
-        backend=session_backend,
-        tools=AGENT_TOOLS,
-        interrupt_on=dict(bash=True),
-        checkpointer=InMemorySaver()
-    )
+# Preserve the middleware list for runtime introspection. deepagents fuses
+# middleware into the compiled graph, so we stash the originals so that
+# agent_uses_canvas_middleware() can still detect them.
+agent.middleware = AGENT_MIDDLEWARE
 
 
 def create_default_agent(workspace: Path):

--- a/cowork_dash/middleware/__init__.py
+++ b/cowork_dash/middleware/__init__.py
@@ -1,0 +1,13 @@
+"""Middleware for injecting optional agent capabilities."""
+
+from cowork_dash.middleware.canvas import (
+    CANVAS_PROMPT,
+    CanvasMiddleware,
+    agent_uses_canvas_middleware,
+)
+
+__all__ = [
+    "CanvasMiddleware",
+    "CANVAS_PROMPT",
+    "agent_uses_canvas_middleware",
+]

--- a/cowork_dash/middleware/canvas.py
+++ b/cowork_dash/middleware/canvas.py
@@ -1,0 +1,159 @@
+"""CanvasMiddleware — injects canvas tools and report-building guidance.
+
+Downstream users can opt into the canvas report-building feature by passing
+`CanvasMiddleware()` to `create_deep_agent(middleware=[...])`. The middleware
+appends canvas-specific instructions to the system prompt and extends the
+tool list with canvas tools at each model call.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+def agent_uses_canvas_middleware(agent: Any) -> bool:
+    """Best-effort check for a CanvasMiddleware instance on an agent.
+
+    `CanvasMiddleware` uses `wrap_model_call`, which doesn't add a dedicated
+    graph node — so this probes likely attribute paths (`middleware`,
+    `_middleware`, `builder.middleware`) looking for an instance. Returns
+    False if the middleware list can't be located, which causes the caller
+    to fall back to the default (canvas tab off).
+    """
+    candidates = []
+    for attr in ("middleware", "_middleware"):
+        v = getattr(agent, attr, None)
+        if v is not None:
+            candidates.append(v)
+    builder = getattr(agent, "builder", None)
+    if builder is not None:
+        for attr in ("middleware", "_middleware"):
+            v = getattr(builder, attr, None)
+            if v is not None:
+                candidates.append(v)
+
+    for candidate in candidates:
+        try:
+            iterable = candidate if hasattr(candidate, "__iter__") else [candidate]
+            for item in iterable:
+                if isinstance(item, CanvasMiddleware):
+                    return True
+        except TypeError:
+            continue
+    return False
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+)
+
+from cowork_dash.tools import (
+    add_canvas_section,
+    add_to_canvas,
+    remove_canvas_item,
+    reorder_canvas,
+    update_canvas_item,
+)
+
+
+CANVAS_PROMPT = """## Canvas (Report Builder)
+
+The canvas is a persistent report surface at `.canvas/canvas.md`. Treat it as a
+living document you co-author with the user, not a scratchpad for throwaway
+outputs. A finished canvas should read like a short report: sections, narrative,
+figures with explanations, and a conclusion.
+
+### Canvas tools
+- `add_to_canvas(content, title=None, item_id=None)` — append an item. Pass a
+  DataFrame, matplotlib/Plotly figure, PIL image, markdown string, or HTML.
+  Provide `item_id` when you expect to refine the item later.
+- `update_canvas_item(item_id, content, title=None)` — replace an existing
+  item in-place. Use this instead of appending a new item when iterating.
+- `add_canvas_section(title, level=1, item_id=None)` — structural heading.
+  Use to group related items (Overview, Methodology, Findings, etc.).
+- `reorder_canvas(item_ids)` — rewrite the canvas in a new order. Pass the
+  full list of IDs in the order you want them to appear.
+- `remove_canvas_item(item_id)` — delete an item entirely.
+
+### How to build a report
+
+1. **Open with a section + overview.** Before any charts, call
+   `add_canvas_section("Overview")` and an `add_to_canvas(markdown_text)`
+   that states the question, the approach, and what to expect.
+2. **Interleave narrative and figures.** Every chart/table should be preceded
+   by a short markdown item explaining what the figure shows and why it
+   matters. Don't dump figures back-to-back without prose.
+3. **Use sections to group.** Break the report into 2–5 sections
+   (e.g., Data, Analysis, Findings, Next Steps). Add a section header
+   before the items that belong to it.
+4. **Refine, don't duplicate.** When the user says "make the chart blue" or
+   "tighten the summary," call `update_canvas_item(id, ...)` with the same
+   `item_id` — never add a second version.
+5. **Close with a conclusion.** End with a `## Conclusion` section and a
+   markdown item summarizing findings and recommended next steps.
+6. **Reorder when structure changes.** If the user says "move the summary
+   to the top" or the narrative shifts, call `reorder_canvas(...)` with the
+   new order rather than deleting and re-adding items.
+
+### Stable IDs
+
+Always provide meaningful `item_id` values (`summary`, `revenue_chart`,
+`conclusion`) when you create an item you may refine. Auto-generated IDs
+are opaque and make refinement harder.
+"""
+
+
+class CanvasMiddleware(AgentMiddleware):
+    """Injects canvas tools and report-building guidance into the agent.
+
+    Append `CanvasMiddleware()` to `create_deep_agent(middleware=[...])` to
+    enable the canvas report feature. The middleware extends the agent's
+    tool list with the canvas toolkit and appends canvas instructions to
+    the system prompt on every model call.
+    """
+
+    def __init__(self, enabled: bool = True) -> None:
+        super().__init__()
+        self.enabled = enabled
+        self._canvas_tools: list[Any] = [
+            add_to_canvas,
+            update_canvas_item,
+            remove_canvas_item,
+            add_canvas_section,
+            reorder_canvas,
+        ]
+
+    def _apply(self, request: ModelRequest) -> None:
+        """Mutate the request in place: append canvas prompt + inject tools."""
+        existing_prompt = request.system_prompt or ""
+        if CANVAS_PROMPT not in existing_prompt:
+            request.system_prompt = (
+                f"{existing_prompt}\n\n{CANVAS_PROMPT}" if existing_prompt else CANVAS_PROMPT
+            )
+
+        existing_tools = list(request.tools or [])
+        existing_names = {getattr(t, "name", getattr(t, "__name__", "")) for t in existing_tools}
+        for tool in self._canvas_tools:
+            tool_name = getattr(tool, "name", getattr(tool, "__name__", ""))
+            if tool_name not in existing_names:
+                existing_tools.append(tool)
+        request.tools = existing_tools
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Any],
+    ) -> Any:
+        if not self.enabled:
+            return handler(request)
+        self._apply(request)
+        return handler(request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[Any]],
+    ) -> Any:
+        if not self.enabled:
+            return await handler(request)
+        self._apply(request)
+        return await handler(request)

--- a/cowork_dash/stream/sse_adapter.py
+++ b/cowork_dash/stream/sse_adapter.py
@@ -28,25 +28,26 @@ async def run_agent_stream(
     stream_parser_config: dict | None = None,
 ) -> None:
     """Stream agent response for a user message, pushing events to the session queue."""
-    serializer = EventSerializer()
-    parser = StreamParser(
-        stream_mode=DUAL_STREAM_MODE,
-        **(stream_parser_config or {}),
-    )
-
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    context_parts = [f"[Current time: {now}]"]
-    if cwd:
-        context_parts.append(f"[Working directory: {cwd}]")
-    input_data = prepare_agent_input(message=content, context_parts=context_parts)
-
-    stream = agent.astream(
-        input_data,
-        config=session.config,
-        stream_mode=DUAL_STREAM_MODE,
-    )
-
     try:
+        serializer = EventSerializer()
+        parser = StreamParser(
+            stream_mode=DUAL_STREAM_MODE,
+            **(stream_parser_config or {}),
+        )
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        context_lines = [f"[Current time: {now}]"]
+        if cwd:
+            context_lines.append(f"[Working directory: {cwd}]")
+        annotated_message = "\n".join(context_lines) + "\n\n" + content
+        input_data = prepare_agent_input(message=annotated_message)
+
+        stream = agent.astream(
+            input_data,
+            config=session.config,
+            stream_mode=DUAL_STREAM_MODE,
+        )
+
         async for event in parser.aparse(stream):
             msg = serializer.serialize(event)
             if msg.get("type") == "interrupt":
@@ -60,6 +61,12 @@ async def run_agent_stream(
     except asyncio.CancelledError:
         logger.info("Stream cancelled for session %s", session.thread_id)
         await session.push_event({"type": "cancelled"})
+    except Exception as exc:
+        logger.exception("Agent stream failed for session %s", session.thread_id)
+        await session.push_event({
+            "type": "error",
+            "error": f"{type(exc).__name__}: {exc}",
+        })
 
 
 async def run_interrupt_response(
@@ -90,3 +97,9 @@ async def run_interrupt_response(
     except asyncio.CancelledError:
         logger.info("Interrupt stream cancelled for session %s", session.thread_id)
         await session.push_event({"type": "cancelled"})
+    except Exception as exc:
+        logger.exception("Interrupt stream failed for session %s", session.thread_id)
+        await session.push_event({
+            "type": "error",
+            "error": f"{type(exc).__name__}: {exc}",
+        })

--- a/cowork_dash/tools.py
+++ b/cowork_dash/tools.py
@@ -125,9 +125,16 @@ class NotebookState:
         self._namespace: Dict[str, Any] = {}
         self._execution_count: int = 0
         self._ipython_shell = None
-        self._canvas_items: List[Dict[str, Any]] = []  # Collected canvas items
         self._session_id = session_id
+        # Tracks the most recently executed cell so canvas items added right
+        # after a cell execution can record their provenance.
+        self._last_executed_cell: Optional[Dict[str, int]] = None
         self._initialize_namespace()
+
+    @property
+    def last_executed_cell(self) -> Optional[Dict[str, int]]:
+        """Return `{cell_index, execution_count}` for the last executed cell."""
+        return self._last_executed_cell
 
     def _initialize_namespace(self):
         """Initialize the namespace with common imports and utilities."""
@@ -383,9 +390,6 @@ except (ImportError, AttributeError):
         self._execution_count += 1
         cell["execution_count"] = self._execution_count
 
-        # Track canvas items added during this cell's execution
-        canvas_count_before = len(self._canvas_items)
-
         # Capture stdout and stderr
         stdout_capture = io.StringIO()
         stderr_capture = io.StringIO()
@@ -399,7 +403,6 @@ except (ImportError, AttributeError):
             "result": None,
             "error": None,
             "status": "success",
-            "canvas_items": []  # Canvas items added during execution
         }
 
         try:
@@ -457,13 +460,16 @@ except (ImportError, AttributeError):
             result["stdout"] = stdout_capture.getvalue()
             result["stderr"] = stderr_capture.getvalue()
 
-        # Capture any canvas items added during this cell's execution
-        canvas_items_added = self._canvas_items[canvas_count_before:]
-        result["canvas_items"] = canvas_items_added
-
         # Store outputs in cell
         cell["outputs"] = [result]
         cell["status"] = result["status"]
+
+        # Record provenance: if this cell ran (success or error), it's the
+        # most recent cell context for any canvas items added right after.
+        self._last_executed_cell = {
+            "cell_index": cell_index,
+            "execution_count": self._execution_count,
+        }
 
         return result
 
@@ -502,22 +508,11 @@ except (ImportError, AttributeError):
                 user_vars[name] = f"{type(value).__name__}: <unable to repr>"
         return user_vars
 
-    def get_canvas_items(self) -> List[Dict[str, Any]]:
-        """Get all canvas items collected during execution."""
-        return self._canvas_items.copy()
-
-    def clear_canvas_items(self) -> Dict[str, Any]:
-        """Clear collected canvas items."""
-        count = len(self._canvas_items)
-        self._canvas_items = []
-        return {"cleared": count}
-
     def reset(self):
         """Reset the notebook state (clear all cells and namespace)."""
         self._cells = []
         self._namespace = {}
         self._execution_count = 0
-        self._canvas_items = []
         self._initialize_namespace()
         return {"status": "reset", "message": "Notebook state cleared"}
 
@@ -763,7 +758,28 @@ def reset_notebook() -> Dict[str, Any]:
 # CANVAS TOOLS
 # =============================================================================
 
-def add_to_canvas(content: Any, title: Optional[str] = None, item_id: Optional[str] = None) -> str:
+def _resolve_source_cell(
+    source_cell: Optional[int],
+    execution_count: Optional[int],
+) -> tuple[Optional[int], Optional[int]]:
+    """Fill in provenance from the most recently executed notebook cell if unset."""
+    if source_cell is not None:
+        return source_cell, execution_count
+
+    session_id = get_tool_session_context()
+    state = get_notebook_state(session_id)
+    last = state.last_executed_cell
+    if last is None:
+        return None, execution_count
+    return last.get("cell_index"), execution_count if execution_count is not None else last.get("execution_count")
+
+
+def add_to_canvas(
+    content: Any,
+    title: Optional[str] = None,
+    item_id: Optional[str] = None,
+    source_cell: Optional[int] = None,
+) -> str:
     """Add an item to the canvas for visualization. Canvas is like a note-taking tool where
     you can store charts, dataframes, images, and markdown text for the user to see.
 
@@ -776,6 +792,8 @@ def add_to_canvas(content: Any, title: Optional[str] = None, item_id: Optional[s
         title: Optional title for the canvas item (displayed as a header)
         item_id: Optional unique ID for the item. If provided, can be used to update
                 or remove the item later. Auto-generated if not provided.
+        source_cell: Optional explicit cell index that produced this item. If omitted,
+                the most recently executed cell is used automatically.
 
     Returns:
         Confirmation string describing what was added.
@@ -800,6 +818,7 @@ def add_to_canvas(content: Any, title: Optional[str] = None, item_id: Optional[s
     """
     try:
         workspace_root = _get_workspace_root_for_context()
+        src_cell, exec_count = _resolve_source_cell(source_cell, None)
 
         # Parse the content into canvas format
         parsed = parse_canvas_object(
@@ -807,6 +826,8 @@ def add_to_canvas(content: Any, title: Optional[str] = None, item_id: Optional[s
             workspace_root=workspace_root,
             title=title,
             item_id=item_id,
+            source_cell=src_cell,
+            execution_count=exec_count,
         )
 
         # Load existing items, append new one, write back
@@ -826,7 +847,12 @@ def add_to_canvas(content: Any, title: Optional[str] = None, item_id: Optional[s
         return f"Failed to add to canvas: {e}"
 
 
-def update_canvas_item(item_id: str, content: Any, title: Optional[str] = None) -> str:
+def update_canvas_item(
+    item_id: str,
+    content: Any,
+    title: Optional[str] = None,
+    source_cell: Optional[int] = None,
+) -> str:
     """Update an existing canvas item by its ID. If the item doesn't exist, it will be added.
 
     This is useful for updating charts or data that change over time, like progress
@@ -852,12 +878,15 @@ def update_canvas_item(item_id: str, content: Any, title: Optional[str] = None) 
     """
     try:
         workspace_root = _get_workspace_root_for_context()
+        src_cell, exec_count = _resolve_source_cell(source_cell, None)
 
         parsed = parse_canvas_object(
             content,
             workspace_root=workspace_root,
             title=title,
             item_id=item_id,
+            source_cell=src_cell,
+            execution_count=exec_count,
         )
 
         # Load existing items, replace matching ID or append
@@ -875,6 +904,67 @@ def update_canvas_item(item_id: str, content: Any, title: Optional[str] = None) 
         return f"Updated canvas item: {item_id}"
     except Exception as e:
         return f"Failed to update canvas item: {e}"
+
+
+def add_canvas_section(title: str, level: int = 1, item_id: Optional[str] = None) -> str:
+    """Add a section header to the canvas to structure the report.
+
+    Sections act as structural dividers — use them to group related items under
+    a theme (Overview, Methodology, Findings, etc.). They render as headings
+    in the canvas UI and exported reports.
+
+    Args:
+        title: The section heading text
+        level: Heading level 1-6 (default 1, like an H1)
+        item_id: Optional stable ID. Auto-generated if not provided.
+
+    Returns:
+        Confirmation string.
+
+    Examples:
+        add_canvas_section("Executive Summary")
+        add_canvas_section("Data Quality Checks", level=2)
+    """
+    try:
+        lvl = max(1, min(int(level), 6))
+        payload = {"__canvas_kind__": "section", "text": title, "level": lvl}
+        return add_to_canvas(payload, title=None, item_id=item_id)
+    except Exception as e:
+        return f"Failed to add section: {e}"
+
+
+def reorder_canvas(item_ids: List[str]) -> str:
+    """Reorder canvas items by providing the full list of item IDs in the new order.
+
+    Any IDs not in the list are dropped; unknown IDs are ignored. Use this
+    to restructure the report — e.g., move the summary to the top, push
+    methodology to the end.
+
+    Args:
+        item_ids: List of canvas item IDs in the desired final order
+
+    Returns:
+        Confirmation string with the new count.
+
+    Examples:
+        # Get current items, rearrange, then reorder
+        reorder_canvas(["summary_id", "chart_1", "chart_2", "conclusion_id"])
+    """
+    try:
+        workspace_root = _get_workspace_root_for_context()
+        items = load_canvas_from_markdown(workspace_root)
+        by_id = {item.get("id"): item for item in items if item.get("id")}
+
+        # Build the new ordered list, preserving only items whose IDs appear
+        new_items = [by_id[iid] for iid in item_ids if iid in by_id]
+
+        if not new_items:
+            return "No matching canvas items to reorder"
+
+        export_canvas_to_markdown(new_items, workspace_root)
+        return f"Reordered canvas: {len(new_items)} item(s)"
+    except Exception as e:
+        return f"Failed to reorder canvas: {e}"
 
 
 def remove_canvas_item(item_id: str) -> str:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,8 @@ const DEFAULT_CONFIG: AppConfig = {
   save_workflow_prompt: "",
   run_workflow_prompt: "",
   create_workflow_prompt: "",
+  show_canvas: true,
+  show_files: true,
 };
 
 export default function App() {

--- a/frontend/src/components/CanvasItem.tsx
+++ b/frontend/src/components/CanvasItem.tsx
@@ -12,6 +12,33 @@ interface CanvasItemProps {
 export function CanvasItemCard({ item, onDelete }: CanvasItemProps) {
   const [collapsed, setCollapsed] = useState(false);
 
+  // Sections render as plain headings, not cards.
+  if (item.type === "section") {
+    const level = Math.min(Math.max(item.level ?? 1, 1), 6);
+    const text = typeof item.data === "string" ? item.data : "";
+    const sizeClass =
+      level === 1
+        ? "text-xl font-semibold"
+        : level === 2
+          ? "text-lg font-semibold"
+          : "text-base font-medium";
+    const HeadingTag = `h${level}` as keyof React.JSX.IntrinsicElements;
+    return (
+      <div className="group flex items-baseline justify-between border-b border-[var(--color-border)] pb-1 pt-2">
+        <HeadingTag className={`${sizeClass} text-[var(--color-text)]`}>
+          {text}
+        </HeadingTag>
+        <button
+          onClick={() => onDelete(item.id)}
+          className="p-1 rounded opacity-0 group-hover:opacity-100 hover:bg-[var(--color-surface-3)] transition"
+          aria-label="Delete section"
+        >
+          <X size={14} className="text-[var(--color-text-secondary)]" />
+        </button>
+      </div>
+    );
+  }
+
   return (
     <div className="border border-[var(--color-border)] rounded-lg overflow-hidden bg-[var(--color-surface)]">
       {/* Header — click to toggle */}
@@ -32,6 +59,18 @@ export function CanvasItemCard({ item, onDelete }: CanvasItemProps) {
           <span className="text-sm font-medium text-[var(--color-text)]">
             {item.title}
           </span>
+          {typeof item.source_cell === "number" && (
+            <span
+              className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[var(--color-text-secondary)] border border-[var(--color-border)]"
+              title={
+                typeof item.execution_count === "number"
+                  ? `Produced by cell ${item.source_cell} (execution #${item.execution_count})`
+                  : `Produced by cell ${item.source_cell}`
+              }
+            >
+              cell {item.source_cell}
+            </span>
+          )}
         </div>
         <button
           onClick={(e) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
 import { FolderTree, Palette, ListTodo, PanelRightClose, PanelRightOpen, Sparkles } from "lucide-react";
@@ -60,6 +60,15 @@ interface LayoutProps {
 export function Layout(props: LayoutProps) {
   const [activeTab, setActiveTab] = useState<RightTab>("tasks");
   const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  const showCanvas = props.config.show_canvas;
+  const showFiles = props.config.show_files;
+
+  // If the currently active tab gets hidden by config, fall back to Tasks.
+  useEffect(() => {
+    if (activeTab === "canvas" && !showCanvas) setActiveTab("tasks");
+    else if (activeTab === "files" && !showFiles) setActiveTab("tasks");
+  }, [activeTab, showCanvas, showFiles]);
 
   return (
     <div className="h-full flex flex-col bg-[var(--color-surface)]">
@@ -148,40 +157,44 @@ export function Layout(props: LayoutProps) {
                     </span>
                   )}
                 </button>
-                <button
-                  onClick={() => setActiveTab("canvas")}
-                  className={`flex items-center gap-1.5 px-4 h-full text-xs font-medium tracking-wide uppercase transition-colors border-b-2 ${
-                    activeTab === "canvas"
-                      ? "border-[var(--color-text)] text-[var(--color-text)]"
-                      : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
-                  }`}
-                >
-                  <Palette size={13} />
-                  Canvas
-                  {props.canvasItems.length > 0 && (
-                    <span className="ml-1 min-w-[16px] h-4 px-1 rounded-full bg-[var(--color-surface-3)] text-[10px] tabular-nums text-[var(--color-text-muted)] inline-flex items-center justify-center">
-                      {props.canvasItems.length}
-                    </span>
-                  )}
-                </button>
-                <button
-                  onClick={() => setActiveTab("files")}
-                  className={`flex items-center gap-1.5 px-4 h-full text-xs font-medium tracking-wide uppercase transition-colors border-b-2 ${
-                    activeTab === "files"
-                      ? "border-[var(--color-text)] text-[var(--color-text)]"
-                      : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
-                  }`}
-                >
-                  <FolderTree size={13} />
-                  Files
-                </button>
+                {showCanvas && (
+                  <button
+                    onClick={() => setActiveTab("canvas")}
+                    className={`flex items-center gap-1.5 px-4 h-full text-xs font-medium tracking-wide uppercase transition-colors border-b-2 ${
+                      activeTab === "canvas"
+                        ? "border-[var(--color-text)] text-[var(--color-text)]"
+                        : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+                    }`}
+                  >
+                    <Palette size={13} />
+                    Canvas
+                    {props.canvasItems.length > 0 && (
+                      <span className="ml-1 min-w-[16px] h-4 px-1 rounded-full bg-[var(--color-surface-3)] text-[10px] tabular-nums text-[var(--color-text-muted)] inline-flex items-center justify-center">
+                        {props.canvasItems.length}
+                      </span>
+                    )}
+                  </button>
+                )}
+                {showFiles && (
+                  <button
+                    onClick={() => setActiveTab("files")}
+                    className={`flex items-center gap-1.5 px-4 h-full text-xs font-medium tracking-wide uppercase transition-colors border-b-2 ${
+                      activeTab === "files"
+                        ? "border-[var(--color-text)] text-[var(--color-text)]"
+                        : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+                    }`}
+                  >
+                    <FolderTree size={13} />
+                    Files
+                  </button>
+                )}
               </div>
 
               <div className="flex-1 overflow-hidden">
                 {activeTab === "tasks" && (
                   <TodoPanel todos={props.todos} />
                 )}
-                {activeTab === "canvas" && (
+                {activeTab === "canvas" && showCanvas && (
                   <CanvasPanel
                     items={props.canvasItems}
                     onDelete={props.onDeleteCanvasItem}
@@ -189,7 +202,7 @@ export function Layout(props: LayoutProps) {
                     onExport={props.onExportCanvas}
                   />
                 )}
-                {activeTab === "files" && (
+                {activeTab === "files" && showFiles && (
                   props.selectedFile ? (
                     <FileViewer
                       file={props.selectedFile}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -209,6 +209,8 @@ export interface AppConfig {
   save_workflow_prompt: string;
   run_workflow_prompt: string;
   create_workflow_prompt: string;
+  show_canvas: boolean;
+  show_files: boolean;
 }
 
 export interface TokenUsage {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -167,11 +167,14 @@ export interface TodoItem {
 
 export interface CanvasItem {
   id: string;
-  type: "dataframe" | "plotly" | "matplotlib" | "mermaid" | "image" | "html" | "markdown";
+  type: "dataframe" | "plotly" | "matplotlib" | "mermaid" | "image" | "html" | "markdown" | "section";
   title: string;
   data: unknown;
   file?: string;
   created_at: string;
+  level?: number;
+  source_cell?: number;
+  execution_count?: number;
 }
 
 export interface FileEntry {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cowork-dash"
-version = "0.3.6"
+version = "0.3.7"
 description = "Web UI for deepagents — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_canvas_report.py
+++ b/tests/test_canvas_report.py
@@ -1,0 +1,338 @@
+"""Tests for Stage 1 canvas-as-report features: sections, reordering, middleware."""
+
+from pathlib import Path
+
+import pytest
+
+from cowork_dash import tools as tools_mod
+from cowork_dash.canvas import (
+    export_canvas_to_markdown,
+    load_canvas_from_markdown,
+    parse_canvas_object,
+)
+from cowork_dash.middleware.canvas import CANVAS_PROMPT, CanvasMiddleware
+
+
+@pytest.fixture
+def tmp_workspace(tmp_path: Path, monkeypatch) -> Path:
+    """Provide a temporary workspace and point tools.WORKSPACE_ROOT at it."""
+    from cowork_dash import config as cfg
+
+    monkeypatch.setattr(cfg, "WORKSPACE_ROOT", tmp_path)
+    monkeypatch.setattr(cfg, "VIRTUAL_FS", False)
+    # tools.py captured WORKSPACE_ROOT at import; patch the local reference too.
+    monkeypatch.setattr(tools_mod, "WORKSPACE_ROOT", tmp_path)
+    monkeypatch.setattr(tools_mod, "VIRTUAL_FS", False)
+    return tmp_path
+
+
+# --- Section item parsing/export -------------------------------------------------
+
+
+def test_section_parsed_from_marker_dict(tmp_workspace: Path):
+    """parse_canvas_object recognizes the section marker dict."""
+    result = parse_canvas_object(
+        {"__canvas_kind__": "section", "text": "Overview", "level": 2},
+        workspace_root=tmp_workspace,
+        item_id="sec_overview",
+    )
+    assert result["type"] == "section"
+    assert result["data"] == "Overview"
+    assert result["level"] == 2
+    assert result["id"] == "sec_overview"
+
+
+def test_section_roundtrip_through_markdown(tmp_workspace: Path):
+    """Section exports to '# Title' and loads back with preserved level."""
+    item = parse_canvas_object(
+        {"__canvas_kind__": "section", "text": "Findings", "level": 2},
+        workspace_root=tmp_workspace,
+        item_id="findings",
+    )
+    export_canvas_to_markdown([item], tmp_workspace)
+    loaded = load_canvas_from_markdown(tmp_workspace)
+    assert len(loaded) == 1
+    assert loaded[0]["type"] == "section"
+    assert loaded[0]["data"] == "Findings"
+    assert loaded[0]["level"] == 2
+    assert loaded[0]["id"] == "findings"
+
+
+def test_section_level_clamped_on_export(tmp_workspace: Path):
+    """Level outside 1..6 clamps when exported as markdown hashes."""
+    item = parse_canvas_object(
+        {"__canvas_kind__": "section", "text": "Deep", "level": 9},
+        workspace_root=tmp_workspace,
+        item_id="deep",
+    )
+    # The parsed item keeps the requested level, but export clamps to <= 6.
+    export_canvas_to_markdown([item], tmp_workspace)
+    md = (tmp_workspace / ".canvas" / "canvas.md").read_text()
+    assert "###### Deep" in md
+    assert "####### Deep" not in md
+
+
+# --- add_canvas_section + reorder_canvas tools ----------------------------------
+
+
+def test_add_canvas_section_tool(tmp_workspace: Path):
+    msg = tools_mod.add_canvas_section("Overview", level=1, item_id="overview")
+    assert "Added" in msg
+    items = load_canvas_from_markdown(tmp_workspace)
+    assert len(items) == 1
+    assert items[0]["type"] == "section"
+    assert items[0]["id"] == "overview"
+    assert items[0]["level"] == 1
+
+
+def test_add_canvas_section_clamps_invalid_level(tmp_workspace: Path):
+    tools_mod.add_canvas_section("Too Deep", level=42, item_id="td")
+    items = load_canvas_from_markdown(tmp_workspace)
+    assert items[0]["level"] == 6
+
+
+def test_reorder_canvas_rewrites_file_in_new_order(tmp_workspace: Path):
+    tools_mod.add_to_canvas("first", title=None, item_id="a")
+    tools_mod.add_to_canvas("second", title=None, item_id="b")
+    tools_mod.add_to_canvas("third", title=None, item_id="c")
+
+    before = load_canvas_from_markdown(tmp_workspace)
+    assert [i["id"] for i in before] == ["a", "b", "c"]
+
+    result = tools_mod.reorder_canvas(["c", "a", "b"])
+    assert "Reordered" in result
+
+    after = load_canvas_from_markdown(tmp_workspace)
+    assert [i["id"] for i in after] == ["c", "a", "b"]
+
+
+def test_reorder_canvas_drops_ids_not_in_list(tmp_workspace: Path):
+    tools_mod.add_to_canvas("keep", title=None, item_id="keep")
+    tools_mod.add_to_canvas("drop", title=None, item_id="drop")
+
+    tools_mod.reorder_canvas(["keep"])
+    after = load_canvas_from_markdown(tmp_workspace)
+    assert [i["id"] for i in after] == ["keep"]
+
+
+def test_reorder_canvas_ignores_unknown_ids(tmp_workspace: Path):
+    tools_mod.add_to_canvas("only", title=None, item_id="only")
+    msg = tools_mod.reorder_canvas(["only", "does_not_exist"])
+    assert "1 item" in msg
+    after = load_canvas_from_markdown(tmp_workspace)
+    assert [i["id"] for i in after] == ["only"]
+
+
+def test_reorder_canvas_empty_result_is_noop(tmp_workspace: Path):
+    tools_mod.add_to_canvas("kept", title=None, item_id="kept")
+    msg = tools_mod.reorder_canvas(["nothing_matches"])
+    assert "No matching" in msg
+    after = load_canvas_from_markdown(tmp_workspace)
+    assert [i["id"] for i in after] == ["kept"]
+
+
+def test_mixed_sections_and_items_roundtrip(tmp_workspace: Path):
+    """Report-shaped canvas: section → markdown → section → markdown."""
+    tools_mod.add_canvas_section("Overview", level=1, item_id="s1")
+    tools_mod.add_to_canvas("Intro text", item_id="m1")
+    tools_mod.add_canvas_section("Findings", level=2, item_id="s2")
+    tools_mod.add_to_canvas("Conclusion text", item_id="m2")
+
+    items = load_canvas_from_markdown(tmp_workspace)
+    types = [i["type"] for i in items]
+    ids = [i["id"] for i in items]
+    assert types == ["section", "markdown", "section", "markdown"]
+    assert ids == ["s1", "m1", "s2", "m2"]
+
+
+# --- Provenance (Stage 2) --------------------------------------------------------
+
+
+@pytest.fixture
+def fresh_notebook(monkeypatch):
+    """Give each test a clean NotebookState so last_executed_cell is deterministic."""
+    from cowork_dash.tools import NotebookState
+
+    fresh = NotebookState()
+    monkeypatch.setattr(tools_mod, "_notebook_state", fresh)
+    return fresh
+
+
+def test_provenance_auto_captured_after_execute_cell(tmp_workspace: Path, fresh_notebook):
+    """add_to_canvas after execute_cell records source_cell + execution_count."""
+    tools_mod.create_cell("x = 42")
+    tools_mod.execute_cell(0)
+
+    tools_mod.add_to_canvas("A finding", item_id="finding")
+    items = load_canvas_from_markdown(tmp_workspace)
+    item = next(i for i in items if i["id"] == "finding")
+    assert item["source_cell"] == 0
+    assert item["execution_count"] == 1
+
+
+def test_provenance_survives_canvas_roundtrip(tmp_workspace: Path, fresh_notebook):
+    """source_cell + execution_count persist through canvas.md reload."""
+    tools_mod.create_cell("y = 1")
+    tools_mod.execute_cell(0)
+    tools_mod.add_to_canvas("text", item_id="m1")
+
+    reloaded = load_canvas_from_markdown(tmp_workspace)
+    item = next(i for i in reloaded if i["id"] == "m1")
+    assert item.get("source_cell") == 0
+    assert item.get("execution_count") == 1
+
+
+def test_provenance_explicit_override(tmp_workspace: Path, fresh_notebook):
+    """Explicit source_cell= overrides the last-executed-cell fallback."""
+    tools_mod.create_cell("z = 1")
+    tools_mod.execute_cell(0)
+
+    tools_mod.add_to_canvas("text", item_id="override", source_cell=5)
+    items = load_canvas_from_markdown(tmp_workspace)
+    item = next(i for i in items if i["id"] == "override")
+    assert item["source_cell"] == 5
+
+
+def test_provenance_absent_before_any_cell_runs(tmp_workspace: Path, fresh_notebook):
+    """With no executed cells, no source_cell is attached."""
+    tools_mod.add_to_canvas("freeform", item_id="f1")
+    items = load_canvas_from_markdown(tmp_workspace)
+    item = next(i for i in items if i["id"] == "f1")
+    assert "source_cell" not in item
+    assert "execution_count" not in item
+
+
+def test_provenance_updates_to_latest_cell(tmp_workspace: Path, fresh_notebook):
+    """Re-running a different cell updates the fallback provenance."""
+    tools_mod.create_cell("a = 1")
+    tools_mod.create_cell("b = 2")
+    tools_mod.execute_cell(0)
+    tools_mod.add_to_canvas("first", item_id="first")
+
+    tools_mod.execute_cell(1)
+    tools_mod.add_to_canvas("second", item_id="second")
+
+    items = {i["id"]: i for i in load_canvas_from_markdown(tmp_workspace)}
+    assert items["first"]["source_cell"] == 0
+    assert items["second"]["source_cell"] == 1
+    assert items["second"]["execution_count"] == 2
+
+
+def test_update_canvas_item_refreshes_provenance(tmp_workspace: Path, fresh_notebook):
+    """When update_canvas_item is called after a different cell runs, provenance updates."""
+    tools_mod.create_cell("a = 1")
+    tools_mod.create_cell("b = 2")
+    tools_mod.execute_cell(0)
+    tools_mod.add_to_canvas("v1", item_id="chart")
+
+    tools_mod.execute_cell(1)
+    tools_mod.update_canvas_item("chart", "v2")
+
+    items = load_canvas_from_markdown(tmp_workspace)
+    item = next(i for i in items if i["id"] == "chart")
+    assert item["source_cell"] == 1
+    assert item["execution_count"] == 2
+
+
+# --- CanvasMiddleware ------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal ModelRequest stand-in for unit-testing wrap_model_call."""
+
+    def __init__(self, system_prompt: str = "", tools=None):
+        self.system_prompt = system_prompt
+        self.tools = list(tools or [])
+
+
+def test_middleware_appends_prompt_and_injects_tools():
+    mw = CanvasMiddleware()
+    req = _FakeRequest(system_prompt="Base prompt")
+    captured = {}
+
+    def handler(r):
+        captured["prompt"] = r.system_prompt
+        captured["tools"] = list(r.tools)
+        return "ok"
+
+    assert mw.wrap_model_call(req, handler) == "ok"
+    assert "Base prompt" in captured["prompt"]
+    assert CANVAS_PROMPT in captured["prompt"]
+
+    tool_names = {getattr(t, "name", getattr(t, "__name__", "")) for t in captured["tools"]}
+    assert {
+        "add_to_canvas",
+        "update_canvas_item",
+        "remove_canvas_item",
+        "add_canvas_section",
+        "reorder_canvas",
+    }.issubset(tool_names)
+
+
+def test_middleware_is_idempotent():
+    """Calling the middleware twice doesn't duplicate prompt or tools."""
+    mw = CanvasMiddleware()
+    req = _FakeRequest()
+
+    def handler(_):
+        return None
+
+    mw.wrap_model_call(req, handler)
+    first_prompt = req.system_prompt
+    first_tool_count = len(req.tools)
+
+    mw.wrap_model_call(req, handler)
+    assert req.system_prompt == first_prompt
+    assert len(req.tools) == first_tool_count
+
+
+def test_middleware_disabled_is_passthrough():
+    mw = CanvasMiddleware(enabled=False)
+    req = _FakeRequest(system_prompt="original")
+
+    def handler(r):
+        return ("p", r.system_prompt, list(r.tools))
+
+    _, prompt, tools = mw.wrap_model_call(req, handler)
+    assert prompt == "original"
+    assert tools == []
+
+
+def test_middleware_handles_empty_initial_prompt():
+    mw = CanvasMiddleware()
+    req = _FakeRequest(system_prompt="")
+
+    def handler(_):
+        return None
+
+    mw.wrap_model_call(req, handler)
+    assert req.system_prompt == CANVAS_PROMPT
+
+
+async def test_middleware_async_variant_injects_prompt_and_tools():
+    """awrap_model_call mirrors wrap_model_call for async agents (astream/ainvoke)."""
+    mw = CanvasMiddleware()
+    req = _FakeRequest(system_prompt="Base")
+    captured = {}
+
+    async def handler(r):
+        captured["prompt"] = r.system_prompt
+        captured["tools"] = list(r.tools)
+        return "ok"
+
+    result = await mw.awrap_model_call(req, handler)
+    assert result == "ok"
+    assert CANVAS_PROMPT in captured["prompt"]
+    tool_names = {getattr(t, "name", getattr(t, "__name__", "")) for t in captured["tools"]}
+    assert "add_to_canvas" in tool_names
+
+
+async def test_middleware_async_disabled_is_passthrough():
+    mw = CanvasMiddleware(enabled=False)
+    req = _FakeRequest(system_prompt="orig")
+
+    async def handler(r):
+        return r.system_prompt
+
+    result = await mw.awrap_model_call(req, handler)
+    assert result == "orig"

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -1,0 +1,57 @@
+"""Integration tests for default_agent composition.
+
+Guards against silent degradation when `deepagents.create_deep_agent(...)` or
+related library APIs drift. If the agent factory breaks or stops attaching
+middleware, these tests fail loudly instead of the UI quietly losing features.
+
+Skipped when the `deepagents` optional extra isn't installed.
+"""
+
+import pytest
+
+pytest.importorskip("deepagents")
+
+
+def test_default_agent_imports_and_exposes_middleware():
+    """The global default agent must be importable and carry its middleware list.
+
+    We rely on the `.middleware` attribute for runtime canvas-tab auto-detection
+    ([app.py](cowork_dash/app.py) -> `agent_uses_canvas_middleware`). If that
+    attribute is lost, the UI silently defaults the Canvas tab off.
+    """
+    from cowork_dash.default_agent import agent, AGENT_MIDDLEWARE
+    from cowork_dash.middleware import CanvasMiddleware, agent_uses_canvas_middleware
+
+    # Graph is ready
+    assert hasattr(agent, "astream"), "Default agent must expose astream()"
+    assert hasattr(agent, "ainvoke"), "Default agent must expose ainvoke()"
+
+    # Middleware pinned for detection (see default_agent.py post-compile assignment)
+    assert hasattr(agent, "middleware"), (
+        "Default agent must have .middleware attribute pinned for UI auto-detection"
+    )
+    assert any(isinstance(m, CanvasMiddleware) for m in AGENT_MIDDLEWARE)
+    assert agent_uses_canvas_middleware(agent), (
+        "agent_uses_canvas_middleware must detect CanvasMiddleware on the default agent"
+    )
+
+
+def test_agent_tools_exclude_canvas_tools():
+    """Canvas tools should only be injected via CanvasMiddleware — never baked
+    into the core tool list. Regression guard against accidental re-duplication.
+    """
+    from cowork_dash.default_agent import AGENT_TOOLS
+
+    tool_names = {getattr(t, "name", getattr(t, "__name__", "")) for t in AGENT_TOOLS}
+    canvas_tool_names = {
+        "add_to_canvas",
+        "update_canvas_item",
+        "remove_canvas_item",
+        "add_canvas_section",
+        "reorder_canvas",
+    }
+    overlap = tool_names & canvas_tool_names
+    assert not overlap, (
+        f"Canvas tools leaked into AGENT_TOOLS: {overlap}. "
+        f"They must come only from CanvasMiddleware to avoid double-injection."
+    )

--- a/tests/test_sse_adapter.py
+++ b/tests/test_sse_adapter.py
@@ -1,0 +1,225 @@
+"""Integration tests for sse_adapter — exercises the full streaming pipe with a fake agent.
+
+Motivation: run_agent_stream composes langgraph-stream-parser + a live agent, which
+is exactly where API drift between those libraries lands. This file deliberately
+does *not* mock run_agent_stream — it calls it with a conformant fake agent and
+asserts the session queue receives the expected sequence of events.
+
+If someone changes langgraph-stream-parser's `prepare_agent_input` signature or
+StreamParser's output shape, these tests break loudly instead of silently
+passing while the UI hangs.
+"""
+
+from langchain_core.messages import AIMessageChunk
+
+from cowork_dash.stream.session_manager import AgentSession, SessionManager
+from cowork_dash.stream.sse_adapter import run_agent_stream, run_interrupt_response
+
+
+class FakeStreamingAgent:
+    """A minimal CompiledStateGraph-ish stand-in.
+
+    Yields tuples matching LangGraph's dual stream_mode=["updates", "messages"]
+    format: ("messages", (AIMessageChunk, metadata)) for content, and
+    ("updates", {...}) for node state updates. StreamParser should turn these
+    into ContentEvent + CompleteEvent.
+    """
+
+    def __init__(self, chunks: list[str] | None = None):
+        self._chunks = chunks if chunks is not None else ["Hello", " world"]
+        self.calls: list[dict] = []
+
+    async def astream(self, input_data, config=None, stream_mode=None):
+        self.calls.append({"input": input_data, "config": config, "stream_mode": stream_mode})
+        # Emit content tokens as AIMessageChunk via the "messages" stream
+        for text in self._chunks:
+            yield ("messages", (AIMessageChunk(content=text), {"langgraph_node": "model"}))
+        # A terminal update so StreamParser emits CompleteEvent
+        yield ("updates", {"model": {"messages": [AIMessageChunk(content="")]}})
+
+
+class FailingAgent:
+    """Agent whose astream raises partway through — exercises error handling."""
+
+    async def astream(self, input_data, config=None, stream_mode=None):
+        yield ("messages", (AIMessageChunk(content="partial"), {"langgraph_node": "model"}))
+        raise RuntimeError("synthetic model failure")
+
+
+# --- Happy path --------------------------------------------------------------
+
+
+async def test_run_agent_stream_delivers_content_and_complete():
+    """Smoke test: fake agent streams two content chunks → session queue sees them."""
+    session = AgentSession()
+    agent = FakeStreamingAgent(chunks=["Hi", " there"])
+
+    await run_agent_stream(agent=agent, session=session, content="say hi")
+
+    events: list[dict] = []
+    while not session.event_queue.empty():
+        events.append(await session.event_queue.get())
+
+    types = [e.get("type") for e in events]
+    assert "content" in types, f"Expected content events, got {types}"
+    assert "complete" in types, f"Expected complete event, got {types}"
+    # The error type must NOT appear on a happy path
+    assert "error" not in types, f"Unexpected error: {[e for e in events if e.get('type') == 'error']}"
+
+
+async def test_run_agent_stream_passes_message_through_prepare_agent_input():
+    """Guards against API drift in prepare_agent_input — the exact bug that shipped in 0.3.6.
+
+    If prepare_agent_input's signature changes (or sse_adapter misuses it), this
+    test fails immediately instead of the UI hanging silently.
+    """
+    session = AgentSession()
+    agent = FakeStreamingAgent()
+
+    await run_agent_stream(
+        agent=agent,
+        session=session,
+        content="the magic phrase",
+        cwd="/tmp/test-workspace",
+    )
+
+    assert agent.calls, "astream was never invoked"
+    input_data = agent.calls[0]["input"]
+    # The input must contain the user's message somewhere. Shape can vary
+    # across langgraph-stream-parser versions, but the message must be present.
+    serialized = str(input_data)
+    assert "the magic phrase" in serialized, f"User message lost in transit: {input_data!r}"
+    # Context annotation (cwd) should also be present
+    assert "/tmp/test-workspace" in serialized, f"cwd context missing: {input_data!r}"
+
+
+async def test_run_agent_stream_forwards_config_thread_id():
+    """Each session's thread_id must be threaded into the agent config."""
+    session = AgentSession()
+    agent = FakeStreamingAgent()
+
+    await run_agent_stream(agent=agent, session=session, content="hi")
+
+    cfg = agent.calls[0]["config"]
+    assert cfg is not None
+    assert cfg.get("configurable", {}).get("thread_id") == session.thread_id
+
+
+# --- Error path --------------------------------------------------------------
+
+
+async def test_run_agent_stream_surfaces_errors_as_events():
+    """When the agent raises, the UI must see an error event — not silent hang."""
+    session = AgentSession()
+    agent = FailingAgent()
+
+    await run_agent_stream(agent=agent, session=session, content="hi")
+
+    events: list[dict] = []
+    while not session.event_queue.empty():
+        events.append(await session.event_queue.get())
+
+    types = [e.get("type") for e in events]
+    assert "error" in types, f"Expected error event, got {types}"
+    error_event = next(e for e in events if e.get("type") == "error")
+    assert "synthetic model failure" in error_event.get("error", "")
+
+
+async def test_run_agent_stream_bad_kwargs_surface_as_error(monkeypatch):
+    """If sse_adapter ever calls a library with a bad kwarg (the 0.3.6 bug),
+    the try/except must convert it to an error event reaching the UI."""
+    session = AgentSession()
+    agent = FakeStreamingAgent()
+
+    # Simulate the exact class of bug: prepare_agent_input raising TypeError
+    def broken(*args, **kwargs):
+        raise TypeError("prepare_agent_input() got unexpected kwarg 'context_parts'")
+
+    monkeypatch.setattr("cowork_dash.stream.sse_adapter.prepare_agent_input", broken)
+
+    await run_agent_stream(agent=agent, session=session, content="hi")
+
+    events = []
+    while not session.event_queue.empty():
+        events.append(await session.event_queue.get())
+    types = [e.get("type") for e in events]
+    assert "error" in types, f"TypeError leaked instead of becoming error event: {types}"
+
+
+# --- Interrupt path ----------------------------------------------------------
+
+
+async def test_run_interrupt_response_delivers_events():
+    """Resuming from an interrupt must follow the same event pipe."""
+    session = AgentSession()
+    agent = FakeStreamingAgent(chunks=["resumed"])
+
+    await run_interrupt_response(agent=agent, session=session, decisions=[{"type": "approve"}])
+
+    events = []
+    while not session.event_queue.empty():
+        events.append(await session.event_queue.get())
+    types = [e.get("type") for e in events]
+    assert "error" not in types
+    assert "content" in types or "complete" in types, f"No stream events: {types}"
+
+
+# --- SessionManager glue -----------------------------------------------------
+
+
+def test_session_manager_get_or_create_reuses_existing():
+    sm = SessionManager()
+    a = sm.get_or_create()
+    b = sm.get_or_create(session_id=a.thread_id)
+    assert a is b
+
+
+def test_session_manager_get_or_create_new_when_unknown_id():
+    sm = SessionManager()
+    a = sm.get_or_create(session_id="never-seen")
+    assert a.thread_id != "never-seen"  # A fresh session was made
+
+
+def test_session_manager_delete_cancels_and_removes():
+    sm = SessionManager()
+    s = sm.get_or_create()
+    assert sm.delete_session(s.thread_id) is True
+    assert sm.get_session_by_id(s.thread_id) is None
+    assert sm.delete_session(s.thread_id) is False
+
+
+# --- Library API contract (guards against langgraph-stream-parser drift) ------
+
+
+def test_prepare_agent_input_contract():
+    """Regression guard for the 0.3.6 bug: prepare_agent_input's signature.
+
+    If langgraph-stream-parser renames/removes 'message', or sse_adapter starts
+    passing an unsupported kwarg, this fails fast instead of hanging the UI.
+    """
+    import inspect
+
+    from langgraph_stream_parser import prepare_agent_input
+
+    sig = inspect.signature(prepare_agent_input)
+    assert "message" in sig.parameters, (
+        f"prepare_agent_input must accept 'message' kwarg; sse_adapter depends on it. "
+        f"Got: {list(sig.parameters.keys())}"
+    )
+    # Smoke-call with the exact kwarg shape sse_adapter uses
+    result = prepare_agent_input(message="hi")
+    assert result is not None
+
+
+def test_create_resume_input_contract():
+    """Regression guard for the resume/interrupt path: create_resume_input signature."""
+    import inspect
+
+    from langgraph_stream_parser import create_resume_input
+
+    sig = inspect.signature(create_resume_input)
+    assert "decisions" in sig.parameters, (
+        f"create_resume_input must accept 'decisions' kwarg. Got: {list(sig.parameters.keys())}"
+    )
+    result = create_resume_input(decisions=[{"type": "approve"}])
+    assert result is not None

--- a/tests/test_tab_visibility.py
+++ b/tests/test_tab_visibility.py
@@ -1,0 +1,132 @@
+"""Tests for tab visibility: show_canvas / show_files config + auto-detection."""
+
+import os
+
+import pytest
+
+from cowork_dash.config import AppConfig, _parse_optional_bool
+from cowork_dash.middleware import CanvasMiddleware, agent_uses_canvas_middleware
+
+
+# --- _parse_optional_bool -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, None),
+        ("", None),
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("TRUE", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("NO", False),
+        ("garbage", None),
+    ],
+)
+def test_parse_optional_bool(value, expected):
+    assert _parse_optional_bool(value) is expected
+
+
+# --- AppConfig: env + client_dict ---------------------------------------------
+
+
+def test_appconfig_defaults_show_flags_are_none():
+    cfg = AppConfig()
+    assert cfg.show_canvas is None
+    assert cfg.show_files is None
+
+
+def test_appconfig_to_client_dict_converts_none_to_true():
+    """Unresolved (None) flags should surface to the client as True."""
+    cfg = AppConfig()
+    d = cfg.to_client_dict()
+    assert d["show_canvas"] is True
+    assert d["show_files"] is True
+
+
+def test_appconfig_to_client_dict_respects_explicit_values():
+    cfg = AppConfig(show_canvas=False, show_files=False)
+    d = cfg.to_client_dict()
+    assert d["show_canvas"] is False
+    assert d["show_files"] is False
+
+
+def test_appconfig_from_env_reads_show_flags(monkeypatch):
+    monkeypatch.setenv("DEEPAGENT_SHOW_CANVAS", "false")
+    monkeypatch.setenv("DEEPAGENT_SHOW_FILES", "true")
+    cfg = AppConfig.from_env()
+    assert cfg.show_canvas is False
+    assert cfg.show_files is True
+
+
+def test_appconfig_from_env_missing_show_flags_are_none(monkeypatch):
+    monkeypatch.delenv("DEEPAGENT_SHOW_CANVAS", raising=False)
+    monkeypatch.delenv("DEEPAGENT_SHOW_FILES", raising=False)
+    cfg = AppConfig.from_env()
+    assert cfg.show_canvas is None
+    assert cfg.show_files is None
+
+
+def test_appconfig_merge_preserves_show_flags():
+    base = AppConfig(show_canvas=True, show_files=False)
+    merged = base.merge({"show_canvas": False})
+    assert merged.show_canvas is False
+    assert merged.show_files is False
+
+
+def test_appconfig_merge_ignores_none_overrides():
+    """None in the override dict should not clobber an explicit value."""
+    base = AppConfig(show_canvas=True)
+    merged = base.merge({"show_canvas": None})
+    assert merged.show_canvas is True
+
+
+# --- agent_uses_canvas_middleware ---------------------------------------------
+
+
+class _FakeAgentWithCanvas:
+    def __init__(self):
+        self.middleware = [CanvasMiddleware()]
+
+
+class _FakeAgentWithOtherMiddleware:
+    def __init__(self):
+        # Non-CanvasMiddleware objects should not trigger detection
+        self.middleware = [object(), "not-middleware"]
+
+
+class _FakeAgentNoMiddleware:
+    pass
+
+
+class _FakeAgentViaBuilder:
+    class _Builder:
+        def __init__(self):
+            self.middleware = [CanvasMiddleware()]
+    def __init__(self):
+        self.builder = self._Builder()
+
+
+def test_detect_canvas_middleware_direct_attribute():
+    assert agent_uses_canvas_middleware(_FakeAgentWithCanvas()) is True
+
+
+def test_detect_canvas_middleware_via_builder():
+    assert agent_uses_canvas_middleware(_FakeAgentViaBuilder()) is True
+
+
+def test_detect_no_canvas_middleware_when_absent():
+    assert agent_uses_canvas_middleware(_FakeAgentNoMiddleware()) is False
+
+
+def test_detect_no_canvas_middleware_when_other_middleware_present():
+    assert agent_uses_canvas_middleware(_FakeAgentWithOtherMiddleware()) is False
+
+
+def test_detect_handles_none_agent():
+    # Should not crash on unexpected input
+    assert agent_uses_canvas_middleware(None) is False

--- a/uv.lock
+++ b/uv.lock
@@ -241,7 +241,7 @@ wheels = [
 
 [[package]]
 name = "cowork-dash"
-version = "0.3.4"
+version = "0.3.7"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -252,7 +252,6 @@ dependencies = [
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchfiles" },
-    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -281,7 +280,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "watchfiles", specifier = ">=1.0" },
-    { name = "websockets", specifier = ">=12" },
 ]
 provides-extras = ["deepagents", "dev"]
 


### PR DESCRIPTION
## Summary
- Add `CanvasMiddleware` — opt-in canvas feature via `middleware=[CanvasMiddleware()]`
- Canvas report-building: sections, `reorder_canvas`, cell provenance
- Tab visibility controls (`show_canvas`, `show_files`) with auto-detection
- Fix silent streaming hang on user send (pre-existing 0.3.6 bug — bad kwarg to `prepare_agent_input`)
- Remove dead code: `create_session_agent`, `NotebookState._canvas_items`

## Test plan
- [x] 118 tests pass (6 new test files / 23 net new tests)
- [x] Frontend typechecks + builds cleanly
- [x] Live smoke test: default agent chats end-to-end via SSE
- [x] Custom agent (`demo/plain_agent.py`) without `CanvasMiddleware` → Canvas tab auto-hidden
- [x] `--no-show-files` hides the Files tab as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)