### PR TITLE
Adopt shared HostConfig: AppConfig(HostConfig) + deepagents.toml

### DIFF
--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -46,8 +46,10 @@ class CoworkApp:
         show_files: bool | None = None,
         stream_parser_config: dict | None = None,
     ):
-        self.config = AppConfig.from_env().merge({
-            "workspace": Path(workspace) if workspace else None,
+        # Resolve through the shared chain: defaults < deepagents.toml <
+        # DEEPAGENT_* env < these Python/CLI overrides (None values ignored).
+        self.config = AppConfig.resolve(overrides={
+            "workspace_root": Path(workspace) if workspace else None,
             "agent_spec": agent_spec,
             "host": host,
             "port": port,
@@ -69,7 +71,7 @@ class CoworkApp:
         })
 
         # Ensure workspace directory exists
-        self.config.workspace.mkdir(parents=True, exist_ok=True)
+        self.config.workspace_root.mkdir(parents=True, exist_ok=True)
 
         self.agent = self._resolve_agent(agent)
         self.stream_parser_config = stream_parser_config or {}
@@ -120,7 +122,7 @@ class CoworkApp:
         spec = self.config.agent_spec
         if spec:
             return load_agent_spec(spec)
-        return create_default_agent(self.config.workspace)
+        return create_default_agent(self.config.workspace_root)
 
     def run(self, open_browser: bool = True) -> None:
         """Start the FastAPI server with uvicorn. Blocks."""
@@ -146,7 +148,7 @@ class CoworkApp:
         """
         return create_fastapi_app(
             agent=self.agent,
-            workspace=self.config.workspace.resolve(),
+            workspace=self.config.workspace_root.resolve(),
             config=self.config,
             stream_parser_config=self.stream_parser_config,
             icon_local_path=self._icon_local_path,

--- a/cowork_dash/cli.py
+++ b/cowork_dash/cli.py
@@ -59,5 +59,14 @@ def run(agent_spec, workspace, port, host, debug, title, subtitle, welcome_messa
     app.run(open_browser=not no_browser)
 
 
+@main.command()
+@click.option("--workspace", default=None, type=click.Path(), help="Workspace directory")
+def config(workspace):
+    """Show the resolved configuration: each value, its source, and the
+    env var / deepagents.toml key that sets it."""
+    overrides = {"workspace_root": workspace} if workspace else None
+    click.echo(AppConfig.resolve(overrides=overrides).describe())
+
+
 if __name__ == "__main__":
     main()

--- a/cowork_dash/config.py
+++ b/cowork_dash/config.py
@@ -1,38 +1,61 @@
-"""Configuration resolution: Python args > CLI args > env vars > defaults."""
+"""Configuration for cowork-dash.
 
-from dataclasses import dataclass, field
-from pathlib import Path
-from typing import Optional
+`AppConfig` is a `HostConfig` subclass: it inherits the shared keys (agent_spec,
+workspace_root, host, port, debug, title) and adds cowork's UI keys, all
+resolved through the shared chain — defaults < deepagents.toml < DEEPAGENT_* env
+< overrides (Python/CLI args). cowork gains `deepagents.toml` support this way.
+"""
 import os
+from dataclasses import dataclass, fields, replace
+from pathlib import Path
+from typing import Any, ClassVar, Optional
+
+from langgraph_stream_parser.host import HostConfig
 
 
 def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
     """Parse an env-var string into an optional bool.
 
-    Returns True for '1'/'true'/'yes', False for '0'/'false'/'no', and
-    None for empty/unset (auto-detect mode).
+    True for '1'/'true'/'yes'/'on', False for '0'/'false'/'no'/'off', None for
+    empty/unrecognized (auto-detect mode).
     """
     if value is None or value == "":
         return None
-    lowered = value.strip().lower()
-    if lowered in ("1", "true", "yes"):
+    lowered = str(value).strip().lower()
+    if lowered in ("1", "true", "yes", "on"):
         return True
-    if lowered in ("0", "false", "no"):
+    if lowered in ("0", "false", "no", "off"):
         return False
     return None
 
-# Module-level constants used by tools.py and agent.py
+
+# Module-level constants used by tools.py and default_agent.py (independent of
+# AppConfig — read directly from the environment at import).
 WORKSPACE_ROOT = Path(os.getenv("DEEPAGENT_WORKSPACE_ROOT", os.getcwd()))
 VIRTUAL_FS = os.getenv("DEEPAGENT_VIRTUAL_FS", "").lower() in ("1", "true", "yes")
 
+_SAVE_PROMPT = (
+    "Please capture this conversation as a detailed workflow markdown file in "
+    "the ./workflows/ directory. Include: a title, description of the goal, "
+    "step-by-step instructions that could be followed to reproduce this "
+    "workflow, any configuration or parameters needed, and expected outputs."
+)
+_RUN_PROMPT = (
+    "Please read and follow the workflow defined in ./workflows/{filename}. "
+    "Execute each step as described in the workflow file."
+)
+_CREATE_PROMPT = (
+    "Please create a new workflow markdown file in the ./workflows/ directory. "
+    "Include: a title, description of the goal, step-by-step instructions to "
+    "execute the workflow, any configuration or parameters needed, and "
+    "expected outputs."
+)
+
 
 @dataclass
-class AppConfig:
-    workspace: Path = field(default_factory=lambda: Path("."))
-    agent_spec: str | None = None
-    host: str = "localhost"
-    port: int = 8050
-    debug: bool = False
+class AppConfig(HostConfig):
+    # Shared keys (agent_spec, workspace_root, host, port, debug) come from
+    # HostConfig; cowork only overrides the title default and adds UI keys.
     title: str = "Cowork Dash"
     subtitle: str = "AI-Powered Workspace"
     welcome_message: str = ""
@@ -41,80 +64,69 @@ class AppConfig:
     icon_url: str = ""
     auth_username: str = ""
     auth_password: str = ""
-    save_workflow_prompt: str = "Please capture this conversation as a detailed workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions that could be followed to reproduce this workflow, any configuration or parameters needed, and expected outputs."
-    run_workflow_prompt: str = "Please read and follow the workflow defined in ./workflows/{filename}. Execute each step as described in the workflow file."
-    create_workflow_prompt: str = "Please create a new workflow markdown file in the ./workflows/ directory. Include: a title, description of the goal, step-by-step instructions to execute the workflow, any configuration or parameters needed, and expected outputs."
+    save_workflow_prompt: str = _SAVE_PROMPT
+    run_workflow_prompt: str = _RUN_PROMPT
+    create_workflow_prompt: str = _CREATE_PROMPT
     custom_css: str = ""
-    # Tab visibility — None means auto-resolve (canvas auto-detects middleware;
-    # files defaults to True). Explicit True/False overrides auto-detection.
+    # None means auto-resolve (canvas auto-detects middleware; files defaults True).
     show_canvas: Optional[bool] = None
     show_files: Optional[bool] = None
 
+    _ENV: ClassVar[dict] = {
+        "subtitle": ("DEEPAGENT_SUBTITLE", str),
+        "welcome_message": ("DEEPAGENT_WELCOME_MESSAGE", str),
+        "theme": ("DEEPAGENT_THEME", str),
+        "agent_name": ("DEEPAGENT_AGENT_NAME", str),
+        "icon_url": ("DEEPAGENT_ICON_URL", str),
+        "auth_username": ("DEEPAGENT_AUTH_USERNAME", str),
+        "auth_password": ("DEEPAGENT_AUTH_PASSWORD", str),
+        "save_workflow_prompt": ("DEEPAGENT_SAVE_WORKFLOW_PROMPT", str),
+        "run_workflow_prompt": ("DEEPAGENT_RUN_WORKFLOW_PROMPT", str),
+        "create_workflow_prompt": ("DEEPAGENT_CREATE_WORKFLOW_PROMPT", str),
+        "custom_css": ("DEEPAGENT_CUSTOM_CSS", str),
+        "show_canvas": ("DEEPAGENT_SHOW_CANVAS", _parse_optional_bool),
+        "show_files": ("DEEPAGENT_SHOW_FILES", _parse_optional_bool),
+    }
+    _TOML: ClassVar[dict] = {
+        "subtitle": "ui.subtitle",
+        "welcome_message": "ui.welcome_message",
+        "theme": "ui.theme",
+        "agent_name": "ui.agent_name",
+        "icon_url": "ui.icon_url",
+        "auth_username": "auth.username",
+        "auth_password": "auth.password",
+        "save_workflow_prompt": "workflow.save_prompt",
+        "run_workflow_prompt": "workflow.run_prompt",
+        "create_workflow_prompt": "workflow.create_prompt",
+        "custom_css": "ui.custom_css",
+        "show_canvas": "ui.show_canvas",
+        "show_files": "ui.show_files",
+    }
+
     @classmethod
     def from_env(cls) -> "AppConfig":
-        """Build config from DEEPAGENT_* environment variables."""
-        return cls(
-            workspace=Path(os.getenv("DEEPAGENT_WORKSPACE_ROOT", ".")),
-            agent_spec=os.getenv("DEEPAGENT_AGENT_SPEC"),
-            host=os.getenv("DEEPAGENT_HOST", "localhost"),
-            port=int(os.getenv("DEEPAGENT_PORT", "8050")),
-            debug=os.getenv("DEEPAGENT_DEBUG", "").lower() in ("1", "true", "yes"),
-            title=os.getenv("DEEPAGENT_TITLE", "Cowork Dash"),
-            subtitle=os.getenv("DEEPAGENT_SUBTITLE", "AI-Powered Workspace"),
-            welcome_message=os.getenv("DEEPAGENT_WELCOME_MESSAGE", ""),
-            theme=os.getenv("DEEPAGENT_THEME", "auto"),
-            agent_name=os.getenv("DEEPAGENT_AGENT_NAME", "Agent"),
-            icon_url=os.getenv("DEEPAGENT_ICON_URL", ""),
-            auth_username=os.getenv("DEEPAGENT_AUTH_USERNAME", ""),
-            auth_password=os.getenv("DEEPAGENT_AUTH_PASSWORD", ""),
-            save_workflow_prompt=os.getenv("DEEPAGENT_SAVE_WORKFLOW_PROMPT", AppConfig.save_workflow_prompt),
-            run_workflow_prompt=os.getenv("DEEPAGENT_RUN_WORKFLOW_PROMPT", AppConfig.run_workflow_prompt),
-            create_workflow_prompt=os.getenv("DEEPAGENT_CREATE_WORKFLOW_PROMPT", AppConfig.create_workflow_prompt),
-            custom_css=os.getenv("DEEPAGENT_CUSTOM_CSS", ""),
-            show_canvas=_parse_optional_bool(os.getenv("DEEPAGENT_SHOW_CANVAS")),
-            show_files=_parse_optional_bool(os.getenv("DEEPAGENT_SHOW_FILES")),
-        )
+        """Env + defaults view (no TOML). Use resolve() for the full chain."""
+        return cls.resolve(use_toml=False)
 
     def merge(self, overrides: dict) -> "AppConfig":
-        """Return new config with non-None overrides applied."""
-        updates = {k: v for k, v in overrides.items() if v is not None}
-        current = {
-            "workspace": self.workspace,
-            "agent_spec": self.agent_spec,
-            "host": self.host,
-            "port": self.port,
-            "debug": self.debug,
-            "title": self.title,
-            "subtitle": self.subtitle,
-            "welcome_message": self.welcome_message,
-            "theme": self.theme,
-            "agent_name": self.agent_name,
-            "icon_url": self.icon_url,
-            "auth_username": self.auth_username,
-            "auth_password": self.auth_password,
-            "save_workflow_prompt": self.save_workflow_prompt,
-            "run_workflow_prompt": self.run_workflow_prompt,
-            "create_workflow_prompt": self.create_workflow_prompt,
-            "custom_css": self.custom_css,
-            "show_canvas": self.show_canvas,
-            "show_files": self.show_files,
-        }
-        current.update(updates)
-        return AppConfig(**current)
+        """Return a copy with non-None overrides applied (dict-based)."""
+        valid = {f.name for f in fields(self)}
+        applied = {k: v for k, v in overrides.items() if v is not None and k in valid}
+        return replace(self, **applied)
 
     def to_client_dict(self) -> dict:
-        """Return config values needed by the frontend.
+        """Config values the frontend needs.
 
-        Unresolved show_* flags (None) are surfaced as True so the UI stays
-        permissive — the resolver in CoworkApp is responsible for turning
-        None into a concrete bool before the config reaches the client.
+        Unresolved show_* flags (None) surface as True so the UI stays
+        permissive — CoworkApp resolves None to a concrete bool before this
+        reaches the client.
         """
         return {
             "title": self.title,
             "subtitle": self.subtitle,
             "welcome_message": self.welcome_message,
             "theme": self.theme,
-            "workspace_name": self.workspace.name,
+            "workspace_name": self.workspace_root.name,
             "agent_name": self.agent_name,
             "icon_url": self.icon_url,
             "save_workflow_prompt": self.save_workflow_prompt,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -29,7 +29,7 @@ def mock_agent():
 @pytest.fixture
 def app(workspace, mock_agent):
     config = AppConfig(
-        workspace=workspace,
+        workspace_root=workspace,
         title="Test App",
         subtitle="Test Sub",
         welcome_message="Welcome!",
@@ -111,7 +111,7 @@ async def test_delete_session_endpoint(client):
 @pytest.fixture
 def auth_app(workspace, mock_agent):
     config = AppConfig(
-        workspace=workspace,
+        workspace_root=workspace,
         title="Auth App",
         auth_username="myuser",
         auth_password="mypass",
@@ -168,7 +168,7 @@ async def test_no_auth_still_works(client):
 async def test_auth_default_username(workspace, mock_agent):
     """When only password is set, username defaults to 'admin'."""
     config = AppConfig(
-        workspace=workspace,
+        workspace_root=workspace,
         auth_password="secret",
     )
     app = create_fastapi_app(

--- a/tests/test_custom_css.py
+++ b/tests/test_custom_css.py
@@ -23,7 +23,7 @@ def mock_agent():
 @pytest.mark.asyncio
 async def test_custom_css_not_configured(workspace, mock_agent):
     """Without custom CSS, /api/custom-css returns 404."""
-    config = AppConfig(workspace=workspace)
+    config = AppConfig(workspace_root=workspace)
     app = create_fastapi_app(
         agent=mock_agent,
         workspace=workspace,
@@ -39,7 +39,7 @@ async def test_custom_css_not_configured(workspace, mock_agent):
 async def test_custom_css_served(workspace, mock_agent):
     """With custom CSS content, /api/custom-css returns it with text/css type."""
     css_content = ":root { --color-primary: #ff0000; }"
-    config = AppConfig(workspace=workspace)
+    config = AppConfig(workspace_root=workspace)
     app = create_fastapi_app(
         agent=mock_agent,
         workspace=workspace,
@@ -65,7 +65,7 @@ async def test_custom_css_content_matches(workspace, mock_agent):
 .dark {
   --color-surface: #0a1628;
 }"""
-    config = AppConfig(workspace=workspace)
+    config = AppConfig(workspace_root=workspace)
     app = create_fastapi_app(
         agent=mock_agent,
         workspace=workspace,

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -23,7 +23,7 @@ def mock_agent():
 
 @pytest.fixture
 def app(workspace, mock_agent):
-    config = AppConfig(workspace=workspace)
+    config = AppConfig(workspace_root=workspace)
     return create_fastapi_app(agent=mock_agent, workspace=workspace, config=config)
 
 


### PR DESCRIPTION
Final host to adopt the unified config layer (langgraph-stream-parser#11). Completes the config-streamlining wave (deepagent-code, deepagent-lab, now cowork-dash).

> Stacked on #9 (`feat/shared-runtime`). Merge order: parser #10 → #11 → release → this repo #9 → this PR.

## Changes
- **`AppConfig(HostConfig)`** — inherits the shared keys, adds cowork's UI keys (`subtitle`, `theme`, `agent_name`, `icon_url`, `auth_*`, workflow prompts, `custom_css`, `show_canvas`/`show_files`) to `_ENV`/`_TOML`. Resolves through `defaults < deepagents.toml < DEEPAGENT_* env < overrides`. **cowork gains `deepagents.toml` support.**
- **Field rename `workspace` → `workspace_root`** (matches `HostConfig`). `CoworkApp` builds its config via `AppConfig.resolve(overrides=...)`. The public `CoworkApp(workspace=...)` kwarg is unchanged — only the internal config field renamed.
- `merge()` kept dict-based (call sites untouched); `to_client_dict` uses `workspace_root.name`.
- **`cowork-dash config`** prints the resolved config with each value's source + env var / TOML key.

## Tests
Updated the `AppConfig(workspace_root=...)` constructions (3 test files). **90 pass.**