### PR TITLE
Lazy-import default agent (base install works without deepagents)

### DIFF
--- a/cowork_dash/app.py
+++ b/cowork_dash/app.py
@@ -8,9 +8,11 @@ import uvicorn
 
 from langgraph_stream_parser import load_agent_spec
 from cowork_dash.config import AppConfig
-from cowork_dash.default_agent import create_default_agent
-from cowork_dash.middleware import agent_uses_canvas_middleware
 from cowork_dash.server.main import create_fastapi_app
+
+# NOTE: cowork_dash.default_agent and cowork_dash.middleware are imported lazily
+# (inside the methods below) because they pull in `langchain`/`deepagents`, which
+# are optional. This keeps `import cowork_dash` working on a base install.
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +81,7 @@ class CoworkApp:
         # Resolve show_canvas: explicit value wins; otherwise auto-detect from
         # the agent's middleware. show_files stays True unless explicitly off.
         if self.config.show_canvas is None:
+            from cowork_dash.middleware import agent_uses_canvas_middleware
             self.config.show_canvas = agent_uses_canvas_middleware(self.agent)
         if self.config.show_files is None:
             self.config.show_files = True
@@ -122,6 +125,7 @@ class CoworkApp:
         spec = self.config.agent_spec
         if spec:
             return load_agent_spec(spec)
+        from cowork_dash.default_agent import create_default_agent
         return create_default_agent(self.config.workspace_root)
 
     def run(self, open_browser: bool = True) -> None:


### PR DESCRIPTION
`pip install cowork-dash` (without the `[deepagents]` extra) installed fine but `import cowork_dash` crashed: the import chain `__init__ → app → default_agent → middleware/canvas` does a top-level `import langchain`, which only comes via the optional `deepagents` extra. (Found by a clean-room PyPI smoke of 0.4.0.)

Fix: defer the `default_agent` and `middleware` imports into the methods that use them (`_resolve_agent`, canvas auto-detect). Base `import cowork_dash` + `CoworkApp` construction now work without deepagents/langchain; those are only imported when the bundled default agent or canvas auto-detection actually runs.

Verified in a clean venv with langchain **not** installed: `import cowork_dash` + `from cowork_dash.app import CoworkApp` succeed.