### PR TITLE
Link the LangStage docs site in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ langstage is the web stage (and namesake) of the **LangStage family**: write you
 | Reference agent | [langstage-hermes](https://github.com/dkedar7/langstage-hermes) | `LANGSTAGE_AGENT_SPEC=langstage_hermes.agent:graph` on any stage |
 | Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every stage |
 
+📖 **Full documentation:** <https://dkedar7.github.io/langstage-docs/>
+
 ## Features
 
 - **Chat** with real-time token streaming via WebSocket


### PR DESCRIPTION
Adds a **Full documentation** link to https://dkedar7.github.io/langstage-docs/ right below the family table. The docs site was created after the READMEs were rewritten, so none of them pointed to it yet. 🤖 Generated with [Claude Code](https://claude.com/claude-code)