### PR TITLE
Adopt AG-UI: widen parser ceiling + [agui] extra (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.0 — 2026-06-14
+
+Adopt AG-UI: widen the langgraph-stream-parser ceiling to <0.5 and add an [agui] extra so this surface's agent can be served over AG-UI via langstage-agui. Additive; no runtime changes.
+
 ## 0.7.0 — 2026-06-12
 
 **cowork-dash is now `langstage`** — the web stage (and namesake) of the LangStage family ("every stage for your LangGraph agent"). The rename also clears the collision with Anthropic's Claude Cowork.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ langstage is the web stage (and namesake) of the **LangStage family**: write you
 | Reference agent | [langstage-hermes](https://github.com/dkedar7/langstage-hermes) | `LANGSTAGE_AGENT_SPEC=langstage_hermes.agent:graph` on any stage |
 | Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every stage |
 
+### Serve over AG-UI
+
+This surface's agent — any LangGraph `CompiledGraph` — can also be served over the [AG-UI protocol](https://github.com/dkedar7/langgraph-stream-parser) for use with AG-UI compatible clients:
+
+```bash
+pip install "langgraph-stream-parser[agui]"
+langstage-agui --agent my_agent.py:graph
+```
+
 📖 **Full documentation:** <https://dkedar7.github.io/langstage-docs/>
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.7.0"
+version = "0.8.0"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    "langgraph-stream-parser>=0.3,<0.4",
+    "langgraph-stream-parser>=0.3,<0.5",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -27,6 +27,9 @@ dependencies = [
 [project.optional-dependencies]
 deepagents = [
     "deepagents>=0.3",
+]
+agui = [
+    "langgraph-stream-parser[agui]>=0.4,<0.5",
 ]
 dev = [
     "pytest>=8",


### PR DESCRIPTION
Additive, low-risk adoption of the AG-UI capability shipped in langgraph-stream-parser 0.4.0. Widens the parser dependency ceiling to <0.5 and adds an [agui] optional extra so this surface's agent (any LangGraph CompiledGraph) can be served over the AG-UI protocol via the langstage-agui console script.

No runtime behavior changes and no frontend/TS changes — only a dependency-ceiling widen plus README/CHANGELOG docs. Python suite passes (107 passed).