### PR TITLE
feat(tasks): async task board — Slice 1 (durable backend + Board UI)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useAgentStream } from "./hooks/useAgentStream";
 import { useFileTree } from "./hooks/useFileTree";
 import { useCanvas } from "./hooks/useCanvas";
 import { useCron } from "./hooks/useCron";
+import { useTasks } from "./hooks/useTasks";
 import { Layout } from "./components/Layout";
 import type { AppConfig } from "./types";
 
@@ -93,6 +94,13 @@ export default function App() {
 
   const { jobs: cronJobs, createJob, deleteJob, runNow } = useCron();
 
+  const {
+    tasks,
+    createTask,
+    cancelTask,
+    retryTask,
+  } = useTasks();
+
   const handleSend = useCallback(
     (content: string) => sendMessage(content, { cwd: workspacePath }),
     [sendMessage, workspacePath]
@@ -144,6 +152,10 @@ export default function App() {
       onCreateCron={createJob}
       onDeleteCron={deleteJob}
       onRunCron={runNow}
+      tasks={tasks}
+      onCreateTask={createTask}
+      onCancelTask={cancelTask}
+      onRetryTask={retryTask}
       onNewSession={resetSession}
     />
   );

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Allotment } from "allotment";
 import "allotment/dist/style.css";
-import { FolderTree, Palette, ListTodo, AlarmClock, PanelRightClose, PanelRightOpen, Sparkles } from "lucide-react";
+import { FolderTree, Palette, ListTodo, AlarmClock, KanbanSquare, PanelRightClose, PanelRightOpen, Sparkles } from "lucide-react";
 import type {
   ChatMessage,
   TodoItem,
@@ -11,6 +11,7 @@ import type {
   Decision,
   CanvasItem,
   CronJob,
+  Task,
   FileEntry,
   FilePreview,
   ConnectionStatus,
@@ -21,12 +22,13 @@ import { FileBrowser } from "./FileBrowser";
 import { FileViewer } from "./FileViewer";
 import { CanvasPanel } from "./CanvasPanel";
 import { SchedulesPanel } from "./SchedulesPanel";
+import { TaskBoard } from "./TaskBoard";
 import { TodoPanel } from "./TodoPanel";
 import { InterruptDialog } from "./InterruptDialog";
 import { ThemeToggle } from "./ThemeToggle";
 import { StatusBar } from "./StatusBar";
 
-type RightTab = "files" | "canvas" | "tasks" | "schedules";
+type RightTab = "files" | "canvas" | "tasks" | "board" | "schedules";
 
 interface LayoutProps {
   config: AppConfig;
@@ -60,6 +62,10 @@ interface LayoutProps {
   onCreateCron: (name: string, cron: string, prompt: string) => Promise<void>;
   onDeleteCron: (id: string) => void;
   onRunCron: (id: string) => void;
+  tasks: Task[];
+  onCreateTask: (prompt: string, title?: string) => Promise<void>;
+  onCancelTask: (id: string) => void;
+  onRetryTask: (id: string) => void;
   onNewSession: () => void;
 }
 
@@ -210,6 +216,27 @@ export function Layout(props: LayoutProps) {
                     </span>
                   )}
                 </button>
+                <button
+                  onClick={() => setActiveTab("board")}
+                  className={`flex items-center gap-1.5 px-4 h-full text-xs font-medium tracking-wide uppercase transition-colors border-b-2 ${
+                    activeTab === "board"
+                      ? "border-[var(--color-text)] text-[var(--color-text)]"
+                      : "border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+                  }`}
+                >
+                  <KanbanSquare size={13} />
+                  Board
+                  {(() => {
+                    const active = props.tasks.filter(
+                      (t) => t.state === "queued" || t.state === "ongoing" || t.state === "review_needed"
+                    ).length;
+                    return active > 0 ? (
+                      <span className="ml-1 min-w-[16px] h-4 px-1 rounded-full bg-[var(--color-surface-3)] text-[10px] tabular-nums text-[var(--color-text-muted)] inline-flex items-center justify-center">
+                        {active}
+                      </span>
+                    ) : null;
+                  })()}
+                </button>
               </div>
 
               <div className="flex-1 overflow-hidden">
@@ -244,6 +271,14 @@ export function Layout(props: LayoutProps) {
                       onDelete={props.onDeletePath}
                     />
                   )
+                )}
+                {activeTab === "board" && (
+                  <TaskBoard
+                    tasks={props.tasks}
+                    onCreate={props.onCreateTask}
+                    onCancel={props.onCancelTask}
+                    onRetry={props.onRetryTask}
+                  />
                 )}
                 {activeTab === "schedules" && (
                   <SchedulesPanel

--- a/frontend/src/components/TaskBoard.tsx
+++ b/frontend/src/components/TaskBoard.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import {
+  Clock,
+  Loader2,
+  Eye,
+  CheckCircle2,
+  XCircle,
+  Ban,
+  RotateCcw,
+  X,
+  KanbanSquare,
+} from "lucide-react";
+import type { Task, TaskState } from "../types";
+
+interface TaskBoardProps {
+  tasks: Task[];
+  onCreate: (prompt: string, title?: string) => Promise<void>;
+  onCancel: (id: string) => void;
+  onRetry: (id: string) => void;
+}
+
+const COLUMNS: { key: string; label: string; states: TaskState[] }[] = [
+  { key: "queued", label: "Queued", states: ["queued"] },
+  { key: "ongoing", label: "Ongoing", states: ["ongoing"] },
+  { key: "review", label: "Review", states: ["review_needed"] },
+  { key: "done", label: "Done", states: ["done", "failed", "cancelled"] },
+];
+
+const STATE_META: Record<TaskState, { label: string; cls: string; Icon: typeof Clock }> = {
+  queued: { label: "queued", cls: "text-[var(--color-text-muted)]", Icon: Clock },
+  ongoing: { label: "running", cls: "text-amber-500", Icon: Loader2 },
+  review_needed: { label: "review", cls: "text-violet-500", Icon: Eye },
+  done: { label: "done", cls: "text-emerald-500", Icon: CheckCircle2 },
+  failed: { label: "failed", cls: "text-red-500", Icon: XCircle },
+  cancelled: { label: "cancelled", cls: "text-[var(--color-text-muted)]", Icon: Ban },
+};
+
+const CANCELLABLE: TaskState[] = ["queued", "ongoing", "review_needed"];
+const RETRYABLE: TaskState[] = ["failed", "cancelled"];
+
+function StateBadge({ state }: { state: TaskState }) {
+  const m = STATE_META[state];
+  const Icon = m.Icon;
+  return (
+    <span className={`inline-flex items-center gap-1 text-[10px] ${m.cls}`}>
+      <Icon size={11} className={state === "ongoing" ? "animate-spin" : ""} />
+      {m.label}
+    </span>
+  );
+}
+
+function TaskCard({
+  task,
+  onCancel,
+  onRetry,
+}: {
+  task: Task;
+  onCancel: (id: string) => void;
+  onRetry: (id: string) => void;
+}) {
+  return (
+    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-2)] p-2.5">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-medium text-[var(--color-text)] truncate min-w-0">
+          {task.title}
+        </span>
+        <div className="flex items-center gap-1 shrink-0">
+          {CANCELLABLE.includes(task.state) && (
+            <button
+              onClick={() => onCancel(task.task_id)}
+              title="Cancel"
+              className="p-0.5 rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-secondary)] hover:text-red-500"
+            >
+              <X size={12} />
+            </button>
+          )}
+          {RETRYABLE.includes(task.state) && (
+            <button
+              onClick={() => onRetry(task.task_id)}
+              title="Retry"
+              className="p-0.5 rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-secondary)]"
+            >
+              <RotateCcw size={12} />
+            </button>
+          )}
+        </div>
+      </div>
+      <p className="mt-1 text-[11px] text-[var(--color-text-muted)] line-clamp-2">{task.prompt}</p>
+      {task.result && (
+        <p className="mt-1 text-[10px] text-[var(--color-text-secondary)] line-clamp-3 border-l-2 border-[var(--color-border)] pl-1.5">
+          {task.result}
+        </p>
+      )}
+      {task.error && (
+        <p className="mt-1 text-[10px] text-red-500 line-clamp-2">{task.error}</p>
+      )}
+      <div className="mt-1.5">
+        <StateBadge state={task.state} />
+      </div>
+    </div>
+  );
+}
+
+export function TaskBoard({ tasks, onCreate, onCancel, onRetry }: TaskBoardProps) {
+  const [prompt, setPrompt] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const canSubmit = prompt.trim() && !submitting;
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onCreate(prompt.trim());
+      setPrompt("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inCol = (states: TaskState[]) => tasks.filter((t) => states.includes(t.state));
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Delegate form */}
+      <form onSubmit={submit} className="p-3 border-b border-[var(--color-border)] space-y-2">
+        <div className="text-[11px] font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+          Delegate a task
+        </div>
+        <div className="flex gap-2">
+          <input
+            className="flex-1 px-2.5 py-1.5 text-xs rounded-md bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-primary)]"
+            placeholder="Describe a task to run in the background…"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="px-3 py-1 text-xs font-medium rounded-md bg-[var(--color-primary)] text-white disabled:opacity-40 hover:opacity-90 transition-opacity"
+          >
+            {submitting ? "…" : "Run"}
+          </button>
+        </div>
+        {error && <div className="text-[11px] text-red-500">{error}</div>}
+      </form>
+
+      {/* Board columns */}
+      {tasks.length === 0 ? (
+        <div className="flex flex-col items-center justify-center flex-1 text-[var(--color-text-muted)] text-xs gap-2">
+          <KanbanSquare size={20} />
+          No tasks yet — delegate one above.
+        </div>
+      ) : (
+        <div className="flex-1 flex gap-2 p-2 overflow-x-auto">
+          {COLUMNS.map((col) => {
+            const items = inCol(col.states);
+            return (
+              <div key={col.key} className="flex flex-col w-44 shrink-0">
+                <div className="flex items-center justify-between px-1 pb-1.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
+                  <span>{col.label}</span>
+                  <span className="tabular-nums">{items.length}</span>
+                </div>
+                <div className="space-y-2 overflow-y-auto">
+                  {items.map((t) => (
+                    <TaskCard key={t.task_id} task={t} onCancel={onCancel} onRetry={onRetry} />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -1,0 +1,73 @@
+/**
+ * Async task board state: list / create / cancel / retry against /api/tasks.
+ * Polls (faster than cron, since states move quickly) so the board stays fresh
+ * while the tab is open.
+ */
+import { useState, useEffect, useCallback } from "react";
+import type { Task } from "../types";
+
+export function useTasks() {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchTasks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/tasks");
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setTasks(await res.json());
+    } catch (err) {
+      console.error("Failed to fetch tasks:", err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTasks();
+    const id = setInterval(fetchTasks, 3000);
+    return () => clearInterval(id);
+  }, [fetchTasks]);
+
+  const createTask = useCallback(
+    async (prompt: string, title?: string) => {
+      const res = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt, title: title || null }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail || `HTTP ${res.status}`);
+      }
+      await fetchTasks();
+    },
+    [fetchTasks]
+  );
+
+  const cancelTask = useCallback(
+    async (id: string) => {
+      try {
+        await fetch(`/api/tasks/${id}/cancel`, { method: "POST" });
+        setTimeout(fetchTasks, 300);
+      } catch (err) {
+        console.error("Failed to cancel task:", err);
+      }
+    },
+    [fetchTasks]
+  );
+
+  const retryTask = useCallback(
+    async (id: string) => {
+      try {
+        await fetch(`/api/tasks/${id}/retry`, { method: "POST" });
+        setTimeout(fetchTasks, 300);
+      } catch (err) {
+        console.error("Failed to retry task:", err);
+      }
+    },
+    [fetchTasks]
+  );
+
+  return { tasks, loading, fetchTasks, createTask, cancelTask, retryTask };
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -192,6 +192,31 @@ export interface CronJob {
   session_id: string;
 }
 
+export type TaskState =
+  | "queued"
+  | "ongoing"
+  | "review_needed"
+  | "done"
+  | "failed"
+  | "cancelled";
+
+export interface Task {
+  task_id: string;
+  parent_id: string | null;
+  title: string;
+  prompt: string;
+  agent_spec: string | null;
+  state: TaskState;
+  thread_id: string;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+  result: string | null;
+  artifacts: unknown[] | null;
+  error: string | null;
+  interrupt: Record<string, unknown> | null;
+}
+
 export interface FileEntry {
   name: string;
   path: string;

--- a/langstage/scheduler.py
+++ b/langstage/scheduler.py
@@ -72,10 +72,12 @@ class CronJob:
 
 
 class CronScheduler:
-    """Runs ``CronJob``s on the app's asyncio loop. In-memory only."""
+    """Schedules ``CronJob``s on the app's asyncio loop. In-memory schedules;
+    on each fire it *enqueues* a task onto the durable TaskRunner (the runner
+    owns execution, persistence, and the board). The scheduler is a producer."""
 
-    def __init__(self, adapter: Any):
-        self._adapter = adapter
+    def __init__(self, runner: Any):
+        self._runner = runner
         self._jobs: dict[str, CronJob] = {}
         self._tasks: dict[str, asyncio.Task] = {}
         self._started = False
@@ -144,7 +146,10 @@ class CronScheduler:
     def _compute_next(expr: str) -> Optional[str]:
         if croniter is None:  # pragma: no cover
             return None
-        nxt = croniter(expr, datetime.now()).get_next(datetime)
+        # Compute entirely in UTC: croniter interprets the cron expression
+        # relative to its (tz-aware) base, so the displayed next_run and the
+        # fire delay agree regardless of the host's local timezone.
+        nxt = croniter(expr, datetime.now(timezone.utc)).get_next(datetime)
         return nxt.astimezone(timezone.utc).isoformat(timespec="seconds")
 
     def _start_job(self, job: CronJob) -> None:
@@ -152,11 +157,12 @@ class CronScheduler:
 
     async def _run_loop(self, job: CronJob) -> None:
         try:
-            itr = croniter(job.cron, datetime.now())
+            # UTC base + UTC "now" for the delay → no local/UTC skew.
+            itr = croniter(job.cron, datetime.now(timezone.utc))
             while True:
                 nxt = itr.get_next(datetime)
                 job.next_run = nxt.astimezone(timezone.utc).isoformat(timespec="seconds")
-                delay = (nxt - datetime.now()).total_seconds()
+                delay = (nxt - datetime.now(timezone.utc)).total_seconds()
                 if delay > 0:
                     await asyncio.sleep(delay)
                 await self._fire(job)
@@ -167,27 +173,20 @@ class CronScheduler:
             job.last_status = "error: loop crashed"
 
     async def _fire(self, job: CronJob) -> None:
-        job.last_status = "running"
+        # Producer: enqueue a task onto the durable runner and return. The
+        # runner executes it on the board (queued → ongoing → done), so the
+        # scheduler no longer runs the agent or drains queues itself.
         try:
-            session = self._adapter.submit_message(
-                job.session_id, job.prompt,
-                context_parts=[f"[Scheduled run: {job.name}]"],
+            await self._runner.enqueue(
+                title=job.name,
+                prompt=job.prompt,
             )
-            task = getattr(session, "current_task", None)
-            if task is not None:
-                await task
-            # Headless run with no SSE consumer: drain the queue so it can't
-            # grow unbounded across repeated fires.
-            if not getattr(session, "sse_connected", False):
-                q = getattr(session, "event_queue", None)
-                while q is not None and not q.empty():
-                    q.get_nowait()
-            job.last_status = "ok"
+            job.last_status = "queued"
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001
             job.last_status = f"error: {type(exc).__name__}: {exc}"
-            logger.exception("cron job %s fire failed", job.id)
+            logger.exception("cron job %s enqueue failed", job.id)
         finally:
             job.last_run = _now_iso()
             job.run_count += 1

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -1,5 +1,6 @@
 """FastAPI application factory."""
 
+import os
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -7,6 +8,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, Response
 
 from langgraph_stream_parser.adapters import SessionAdapter
+from langgraph_stream_parser.tasks import TaskRunner, set_runner
 
 from langstage.config import AppConfig
 from langstage.server.middleware import add_middleware
@@ -16,7 +18,9 @@ from langstage.server.routes_canvas import create_canvas_router
 from langstage.server.routes_session import create_session_router
 from langstage.server.routes_chat import create_chat_router
 from langstage.server.routes_cron import create_cron_router
+from langstage.server.routes_tasks import create_tasks_router
 from langstage.scheduler import CronScheduler, set_scheduler
+from langstage.tasks import SqliteTaskStore
 from langstage.workspace.file_manager import FileManager
 from langstage.workspace.canvas_manager import CanvasManager
 
@@ -60,24 +64,42 @@ def create_fastapi_app(
     app.include_router(create_session_router(adapter))
     app.include_router(create_chat_router(adapter, file_manager=file_manager))
 
-    # In-memory cron scheduler — recurring agent runs while the app is alive.
+    # Durable task board: a SQLite-backed store + the shared TaskRunner worker
+    # pool. The runner owns async task execution (queued → ongoing → done);
+    # registered process-globally so agent tools can reach it later.
+    task_db = workspace / ".langstage" / "tasks.db"
+    task_db.parent.mkdir(parents=True, exist_ok=True)
+    task_store = SqliteTaskStore(task_db)
+    task_concurrency = int(os.getenv("LANGSTAGE_TASK_CONCURRENCY", "3"))
+    runner = TaskRunner(adapter, task_store, concurrency=task_concurrency)
+    set_runner(runner)
+    app.include_router(create_tasks_router(runner, task_store))
+
+    # In-memory cron schedules — now a *producer* that enqueues onto the runner.
     # Registered process-globally so the agent's schedule_run tool can reach it.
-    scheduler = CronScheduler(adapter)
+    scheduler = CronScheduler(runner)
     set_scheduler(scheduler)
     app.include_router(create_cron_router(scheduler))
 
     @app.on_event("startup")
-    async def _start_scheduler() -> None:
+    async def _start_services() -> None:
+        await task_store.setup()
+        await runner.start()
         scheduler.start()
 
     @app.on_event("shutdown")
-    async def _stop_scheduler() -> None:
+    async def _stop_services() -> None:
         scheduler.shutdown()
+        await runner.shutdown()
+        await task_store.close()
         set_scheduler(None)
+        set_runner(None)
 
     # Expose for testing
     app.state.session_adapter = adapter
     app.state.scheduler = scheduler
+    app.state.task_runner = runner
+    app.state.task_store = task_store
 
     # Serve custom CSS (always register so it returns 404 instead of SPA catch-all)
     @app.get("/api/custom-css")

--- a/langstage/server/routes_tasks.py
+++ b/langstage/server/routes_tasks.py
@@ -1,0 +1,64 @@
+"""REST endpoints for the async task board (Tasks/Board tab).
+
+Reads come from the durable store; mutations go through the TaskRunner so the
+worker pool and state machine stay authoritative. Approve/reject (the HITL
+review gate) land in Slice 2.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from langgraph_stream_parser.tasks import TaskRunner
+from langgraph_stream_parser.tasks.store import TaskStore
+
+
+class TaskCreate(BaseModel):
+    prompt: str
+    title: Optional[str] = None
+    agent_spec: Optional[str] = None
+    parent_id: Optional[str] = None
+
+
+def create_tasks_router(runner: TaskRunner, store: TaskStore) -> APIRouter:
+    router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+    @router.get("")
+    async def list_tasks(state: Optional[str] = None, parent_id: Optional[str] = None):
+        return await store.list(state=state, parent_id=parent_id)
+
+    @router.get("/{task_id}")
+    async def get_task(task_id: str):
+        task = await store.get(task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return task
+
+    @router.post("", status_code=201)
+    async def create_task(body: TaskCreate):
+        try:
+            task_id = await runner.enqueue(
+                title=body.title or body.prompt,
+                prompt=body.prompt,
+                agent_spec=body.agent_spec,
+                parent_id=body.parent_id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return await store.get(task_id)
+
+    @router.post("/{task_id}/cancel")
+    async def cancel_task(task_id: str):
+        if not await runner.cancel(task_id):
+            raise HTTPException(status_code=400, detail="Task not found or already finished")
+        return {"ok": True}
+
+    @router.post("/{task_id}/retry")
+    async def retry_task(task_id: str):
+        if not await runner.retry(task_id):
+            raise HTTPException(status_code=400, detail="Task not found or not retryable")
+        return {"ok": True}
+
+    return router

--- a/langstage/tasks/__init__.py
+++ b/langstage/tasks/__init__.py
@@ -1,0 +1,10 @@
+"""Web-stage task persistence: a durable SQLite-backed task store.
+
+The task-delegation *engine* (TaskRunner, the TaskStore protocol, the
+Task/TaskState machine) lives in the shared core,
+``langgraph_stream_parser.tasks``. This package provides only langstage-web's
+concrete store — durable across restarts so the task board survives a bounce.
+"""
+from .sqlite_store import SqliteTaskStore
+
+__all__ = ["SqliteTaskStore"]

--- a/langstage/tasks/sqlite_store.py
+++ b/langstage/tasks/sqlite_store.py
@@ -1,0 +1,182 @@
+"""SQLite-backed :class:`~langgraph_stream_parser.tasks.TaskStore`.
+
+Durable across restarts (the task board survives a bounce). Single-process by
+design: an :class:`asyncio.Lock` serializes the claim so two workers never grab
+the same row. That guarantee holds within one process / one event loop — which
+is exactly the single-uvicorn-worker constraint the task board runs under. A
+multi-worker deployment would need SQL-level locking (e.g. ``BEGIN IMMEDIATE``
++ a status guard) instead; documented, not implemented.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+import aiosqlite
+
+from langgraph_stream_parser.tasks import Task
+from langgraph_stream_parser.tasks.state import ONGOING, QUEUED
+from langgraph_stream_parser.tasks.store import now_iso
+
+_COLUMNS = [
+    "task_id", "parent_id", "title", "prompt", "agent_spec", "state",
+    "thread_id", "created_at", "started_at", "finished_at", "result",
+    "artifacts", "error", "interrupt",
+]
+#: Columns stored as JSON text and decoded back to Python on read.
+_JSON_COLUMNS = {"artifacts", "interrupt"}
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id     TEXT PRIMARY KEY,
+    parent_id   TEXT,
+    title       TEXT NOT NULL,
+    prompt      TEXT NOT NULL,
+    agent_spec  TEXT,
+    state       TEXT NOT NULL DEFAULT 'queued',
+    thread_id   TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    started_at  TEXT,
+    finished_at TEXT,
+    result      TEXT,
+    artifacts   TEXT,
+    error       TEXT,
+    interrupt   TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_tasks_state  ON tasks(state);
+CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
+"""
+
+
+def _encode(task: dict[str, Any]) -> dict[str, Any]:
+    """Map a Task dict to a row dict (JSON-encode the structured columns)."""
+    row: dict[str, Any] = {}
+    for col in _COLUMNS:
+        val = task.get(col)
+        if col in _JSON_COLUMNS and val is not None:
+            val = json.dumps(val)
+        row[col] = val
+    return row
+
+
+def _decode(row: aiosqlite.Row) -> Task:
+    """Map a DB row back to a Task (JSON-decode the structured columns)."""
+    task: dict[str, Any] = {}
+    for col in _COLUMNS:
+        val = row[col]
+        if col in _JSON_COLUMNS and val is not None:
+            try:
+                val = json.loads(val)
+            except (ValueError, TypeError):  # pragma: no cover - defensive
+                val = None
+        task[col] = val
+    return task  # type: ignore[return-value]
+
+
+class SqliteTaskStore:
+    """Durable :class:`TaskStore` on an aiosqlite database file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self._db: Optional[aiosqlite.Connection] = None
+        self._lock = asyncio.Lock()
+
+    async def setup(self) -> None:
+        if self._db is None:
+            self._db = await aiosqlite.connect(self._path)
+            self._db.row_factory = aiosqlite.Row
+            await self._db.execute("PRAGMA journal_mode=WAL")
+            await self._db.executescript(_DDL)
+            await self._db.commit()
+
+    async def close(self) -> None:
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+
+    def _conn(self) -> aiosqlite.Connection:
+        if self._db is None:
+            raise RuntimeError("SqliteTaskStore.setup() must be awaited first")
+        return self._db
+
+    async def create(self, task: Task) -> Task:
+        row = _encode(dict(task))
+        cols = ", ".join(_COLUMNS)
+        placeholders = ", ".join(f":{c}" for c in _COLUMNS)
+        db = self._conn()
+        await db.execute(f"INSERT INTO tasks ({cols}) VALUES ({placeholders})", row)
+        await db.commit()
+        return task
+
+    async def get(self, task_id: str) -> Optional[Task]:
+        db = self._conn()
+        async with db.execute("SELECT * FROM tasks WHERE task_id = ?", (task_id,)) as cur:
+            row = await cur.fetchone()
+        return _decode(row) if row is not None else None
+
+    async def list(
+        self,
+        *,
+        state: Optional[str] = None,
+        parent_id: Optional[str] = None,
+    ) -> list[Task]:
+        clauses, params = [], []
+        if state is not None:
+            clauses.append("state = ?"); params.append(state)
+        if parent_id is not None:
+            clauses.append("parent_id = ?"); params.append(parent_id)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        db = self._conn()
+        async with db.execute(
+            f"SELECT * FROM tasks{where} ORDER BY created_at DESC", params
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_decode(r) for r in rows]
+
+    async def claim_next(self) -> Optional[Task]:
+        # Serialize the read-then-update so two workers can't claim one task.
+        async with self._lock:
+            db = self._conn()
+            async with db.execute(
+                "SELECT task_id FROM tasks WHERE state = ? ORDER BY created_at LIMIT 1",
+                (QUEUED,),
+            ) as cur:
+                row = await cur.fetchone()
+            if row is None:
+                return None
+            task_id = row["task_id"]
+            await db.execute(
+                "UPDATE tasks SET state = ?, started_at = ? WHERE task_id = ?",
+                (ONGOING, now_iso(), task_id),
+            )
+            await db.commit()
+            return await self.get(task_id)
+
+    async def update(self, task_id: str, **fields: Any) -> Optional[Task]:
+        if not fields:
+            return await self.get(task_id)
+        sets, params = [], []
+        for col, val in fields.items():
+            if col not in _COLUMNS:
+                raise ValueError(f"Unknown task column: {col!r}")
+            if col in _JSON_COLUMNS and val is not None:
+                val = json.dumps(val)
+            sets.append(f"{col} = ?"); params.append(val)
+        params.append(task_id)
+        db = self._conn()
+        await db.execute(
+            f"UPDATE tasks SET {', '.join(sets)} WHERE task_id = ?", params
+        )
+        await db.commit()
+        return await self.get(task_id)
+
+    async def requeue_orphans(self) -> int:
+        db = self._conn()
+        cur = await db.execute(
+            "UPDATE tasks SET state = ?, started_at = NULL WHERE state = ?",
+            (QUEUED, ONGOING),
+        )
+        await db.commit()
+        return cur.rowcount or 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    "langgraph-stream-parser>=0.3,<0.5",
+    "langgraph-stream-parser>=0.5,<0.6",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -22,6 +22,8 @@ dependencies = [
     "pydantic>=2.0",
     "python-multipart>=0.0.12",
     "croniter>=2.0",
+    # Durable task store for the async task board (TaskRunner persistence).
+    "aiosqlite>=0.19",
 ]
 
 [project.optional-dependencies]
@@ -29,7 +31,7 @@ deepagents = [
     "deepagents>=0.3",
 ]
 agui = [
-    "langgraph-stream-parser[agui]>=0.4,<0.5",
+    "langgraph-stream-parser[agui]>=0.5,<0.6",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_routes_tasks.py
+++ b/tests/test_routes_tasks.py
@@ -1,0 +1,100 @@
+"""Contract tests for the /api/tasks REST router.
+
+Wires a real TaskRunner + SqliteTaskStore + SessionAdapter (fake agent) behind
+the router and drives it over HTTP. (httpx ASGITransport doesn't fire lifespan,
+so the store/runner are set up explicitly here rather than via app startup.)
+"""
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from langgraph_stream_parser.adapters import SessionAdapter
+from langgraph_stream_parser.tasks import TaskRunner
+from langgraph_stream_parser.tasks.state import DONE
+from langstage.server.routes_tasks import create_tasks_router
+from langstage.tasks import SqliteTaskStore
+
+from .test_streaming import FakeStreamingAgent
+
+
+async def _wait(store, task_id, target, timeout=4.0):
+    loop = asyncio.get_event_loop()
+    end = loop.time() + timeout
+    last = None
+    while loop.time() < end:
+        last = await store.get(task_id)
+        if last and last["state"] == target:
+            return last
+        await asyncio.sleep(0.02)
+    raise AssertionError(f"{task_id} never reached {target}; last={last}")
+
+
+@pytest.fixture
+async def ctx(tmp_path):
+    store = SqliteTaskStore(tmp_path / "tasks.db")
+    await store.setup()
+    adapter = SessionAdapter(graph=FakeStreamingAgent(chunks=["all ", "done"]))
+    runner = TaskRunner(adapter, store, concurrency=2, poll_interval=0.05)
+    await runner.start()
+    app = FastAPI()
+    app.include_router(create_tasks_router(runner, store))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        yield client, store
+    await runner.shutdown()
+    await store.close()
+
+
+async def test_create_runs_and_completes(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "say hi", "title": "greet"})
+    assert r.status_code == 201
+    body = r.json()
+    tid = body["task_id"]
+    assert body["state"] in ("queued", "ongoing", "done")
+
+    row = await _wait(store, tid, DONE)
+    assert row["result"]  # final text captured
+
+    # GET single + list reflect it
+    g = await client.get(f"/api/tasks/{tid}")
+    assert g.status_code == 200 and g.json()["state"] == "done"
+    listed = await client.get("/api/tasks")
+    assert any(t["task_id"] == tid for t in listed.json())
+
+
+async def test_list_filter_by_state(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "x"})
+    tid = r.json()["task_id"]
+    await _wait(store, tid, DONE)
+    done = await client.get("/api/tasks", params={"state": "done"})
+    assert all(t["state"] == "done" for t in done.json())
+    assert any(t["task_id"] == tid for t in done.json())
+
+
+async def test_get_unknown_404(ctx):
+    client, _ = ctx
+    assert (await client.get("/api/tasks/nope")).status_code == 404
+
+
+async def test_create_requires_prompt(ctx):
+    client, _ = ctx
+    r = await client.post("/api/tasks", json={"prompt": "   "})
+    assert r.status_code == 400
+
+
+async def test_cancel_unknown_400(ctx):
+    client, _ = ctx
+    assert (await client.post("/api/tasks/nope/cancel")).status_code == 400
+
+
+async def test_retry_done_task_is_400(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "x"})
+    tid = r.json()["task_id"]
+    await _wait(store, tid, DONE)
+    # a completed task is not retryable
+    assert (await client.post(f"/api/tasks/{tid}/retry")).status_code == 400

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,24 +13,17 @@ from langstage.scheduler import (
 )
 
 
-class FakeSession:
-    def __init__(self):
-        self.current_task = None
-        self.sse_connected = False
-        self.event_queue = asyncio.Queue()
-
-
-class FakeAdapter:
-    """Records submit_message calls; returns a headless session."""
+class FakeRunner:
+    """Records enqueue calls (the scheduler is now a producer onto the runner)."""
 
     def __init__(self):
-        self.calls = []
+        self.enqueued = []
 
-    def submit_message(self, session_id, content, *, context_parts=None):
-        self.calls.append(
-            {"session_id": session_id, "content": content, "context_parts": context_parts}
+    async def enqueue(self, *, title, prompt, agent_spec=None, parent_id=None):
+        self.enqueued.append(
+            {"title": title, "prompt": prompt, "agent_spec": agent_spec, "parent_id": parent_id}
         )
-        return FakeSession()
+        return "task-fake"
 
 
 # ── cron validation ──────────────────────────────────────────────────
@@ -52,7 +45,7 @@ def test_validate_cron_rejects_invalid():
 
 
 def test_add_list_remove():
-    s = CronScheduler(FakeAdapter())
+    s = CronScheduler(FakeRunner())
     job = s.add_job(name="daily report", cron="0 9 * * *", prompt="write the report")
     assert job.id
     assert job.created_by == "user"
@@ -68,7 +61,7 @@ def test_add_list_remove():
 
 
 def test_add_job_validates():
-    s = CronScheduler(FakeAdapter())
+    s = CronScheduler(FakeRunner())
     with pytest.raises(ValueError):
         s.add_job(name="x", cron="nope", prompt="p")
     with pytest.raises(ValueError):
@@ -80,36 +73,35 @@ def test_add_job_validates():
 # ── firing ───────────────────────────────────────────────────────────
 
 
-async def test_fire_runs_agent_on_its_own_session():
-    adapter = FakeAdapter()
-    s = CronScheduler(adapter)
+async def test_fire_enqueues_onto_runner():
+    runner = FakeRunner()
+    s = CronScheduler(runner)
     job = s.add_job(name="j", cron="* * * * *", prompt="do it")
 
     await s._fire(job)
 
-    assert len(adapter.calls) == 1
-    assert adapter.calls[0]["session_id"] == f"cron-{job.id}"
-    assert adapter.calls[0]["content"] == "do it"
-    assert any("Scheduled run" in p for p in adapter.calls[0]["context_parts"])
-    assert job.last_status == "ok"
+    assert len(runner.enqueued) == 1
+    assert runner.enqueued[0]["title"] == "j"
+    assert runner.enqueued[0]["prompt"] == "do it"
+    assert job.last_status == "queued"
     assert job.run_count == 1
     assert job.last_run
 
 
 async def test_run_now():
-    adapter = FakeAdapter()
-    s = CronScheduler(adapter)
+    runner = FakeRunner()
+    s = CronScheduler(runner)
     job = s.add_job(name="j", cron="* * * * *", prompt="p")
     assert await s.run_now(job.id) is True
     assert await s.run_now("missing") is False
-    assert len(adapter.calls) == 1
+    assert len(runner.enqueued) == 1
 
 
 # ── agent tools ──────────────────────────────────────────────────────
 
 
 def test_tools_schedule_list_cancel():
-    s = CronScheduler(FakeAdapter())
+    s = CronScheduler(FakeRunner())
     set_scheduler(s)
     try:
         out = schedule_run.invoke({"name": "nightly", "cron": "0 0 * * *", "prompt": "summarize"})
@@ -126,7 +118,7 @@ def test_tools_schedule_list_cancel():
 
 
 def test_tool_reports_invalid_cron():
-    s = CronScheduler(FakeAdapter())
+    s = CronScheduler(FakeRunner())
     set_scheduler(s)
     try:
         out = schedule_run.invoke({"name": "x", "cron": "bad", "prompt": "p"})

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -1,0 +1,118 @@
+"""Tests for the durable SqliteTaskStore.
+
+The in-memory store's atomic-claim guarantee (an asyncio.Lock) does NOT transfer
+to SQLite, so the claim atomicity + durability are proven here independently.
+"""
+import asyncio
+
+from langgraph_stream_parser.tasks.state import DONE, ONGOING, QUEUED
+from langgraph_stream_parser.tasks.store import now_iso
+from langstage.tasks import SqliteTaskStore
+
+
+def _row(task_id, *, state=QUEUED, created_at=None, parent_id=None):
+    return {
+        "task_id": task_id,
+        "parent_id": parent_id,
+        "title": task_id,
+        "prompt": "do",
+        "agent_spec": None,
+        "state": state,
+        "thread_id": f"task-{task_id}",
+        "created_at": created_at or now_iso(),
+        "started_at": None,
+        "finished_at": None,
+        "result": None,
+        "artifacts": None,
+        "error": None,
+        "interrupt": None,
+    }
+
+
+async def test_create_get_roundtrip_with_json_columns(tmp_path):
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        row = _row("a")
+        row["artifacts"] = ["out.csv", "plot.png"]
+        row["interrupt"] = {"type": "interrupt", "action_requests": [{"tool": "bash"}]}
+        await store.create(row)
+        got = await store.get("a")
+        assert got["artifacts"] == ["out.csv", "plot.png"]      # JSON round-trips
+        assert got["interrupt"]["action_requests"][0]["tool"] == "bash"
+        assert got["thread_id"] == "task-a"
+    finally:
+        await store.close()
+
+
+async def test_claim_is_atomic_and_fifo(tmp_path):
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        await store.create(_row("a", created_at="2026-01-01T00:00:00+00:00"))
+        await store.create(_row("b", created_at="2026-01-01T00:00:01+00:00"))
+        c1, c2 = await asyncio.gather(store.claim_next(), store.claim_next())
+        assert {c1["task_id"], c2["task_id"]} == {"a", "b"}   # no double-claim
+        assert c1["task_id"] == "a"                            # FIFO
+        assert all(c["state"] == ONGOING for c in (c1, c2))
+        assert await store.claim_next() is None
+    finally:
+        await store.close()
+
+
+async def test_durable_across_reopen(tmp_path):
+    path = tmp_path / "t.db"
+    s1 = SqliteTaskStore(path)
+    await s1.setup()
+    await s1.create(_row("x", state=DONE))
+    await s1.update("x", result="the answer")
+    await s1.close()
+
+    s2 = SqliteTaskStore(path)   # simulate a process restart
+    await s2.setup()
+    try:
+        got = await s2.get("x")
+        assert got is not None and got["state"] == DONE
+        assert got["result"] == "the answer"
+    finally:
+        await s2.close()
+
+
+async def test_requeue_orphans(tmp_path):
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        await store.create(_row("running", state=ONGOING))
+        await store.create(_row("finished", state=DONE))
+        n = await store.requeue_orphans()
+        assert n == 1
+        assert (await store.get("running"))["state"] == QUEUED
+        assert (await store.get("finished"))["state"] == DONE
+    finally:
+        await store.close()
+
+
+async def test_list_filters(tmp_path):
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        await store.create(_row("p", state=DONE))
+        await store.create(_row("c", parent_id="p"))
+        assert {t["task_id"] for t in await store.list(state=DONE)} == {"p"}
+        assert {t["task_id"] for t in await store.list(parent_id="p")} == {"c"}
+        assert len(await store.list()) == 2
+    finally:
+        await store.close()
+
+
+async def test_update_rejects_unknown_column(tmp_path):
+    import pytest
+
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        await store.create(_row("a"))
+        with pytest.raises(ValueError):
+            await store.update("a", bogus_column="x")
+    finally:
+        await store.close()


### PR DESCRIPTION
## Async task board — Slice 1 (durable backend + Board UI)

Lets you delegate a task to a background copy of the agent, watch it move across a board (**queued → ongoing → done**), and stay responsive — built on the core `langgraph-stream-parser` **0.5.0** task engine. Single-process, no Docker/Postgres.

### Backend
- **`SqliteTaskStore`** (aiosqlite) — durable `TaskStore` impl; atomic claim via a per-process lock, survives restarts. WAL mode.
- **`/api/tasks`** — list (state/parent filters), get, create (non-blocking enqueue), cancel, retry. (Approve/reject HITL → Slice 2.)
- **`main.py`** wires `SqliteTaskStore` + `TaskRunner` (`set_runner`) + the router; async startup/shutdown (`store.setup → runner.start → scheduler.start`).
- **Scheduler is now a producer** — `CronScheduler(runner)`; `_fire` enqueues onto the runner instead of executing directly. **Fixed the cron timezone bug** (next-run and fire-delay both computed in UTC).
- deps: parser `>=0.5,<0.6` (+ `[agui]`); add `aiosqlite`.

### Frontend
- `Task`/`TaskState` types, `useTasks` hook (3s poll + create/cancel/retry), **`TaskBoard`** component (delegate form + 4 columns + per-card cancel/retry + state badges), new **Board** tab in `Layout` with an active-count badge.

### Scope note
Ships on the existing `InMemorySaver` — task **rows** persist via `SqliteTaskStore` so the board survives a restart; durable agent-checkpoint resume (`AsyncSqliteSaver`) is a deferred hardening pass.

### Verification
- Backend: `test_sqlite_store` (durability + atomic claim — proven independently of the in-memory store's lock guarantee), `test_routes_tasks` (API contract over httpx), updated `test_scheduler` (producer model). **Full web suite: 119 passed.**
- Frontend: tsc + vite build clean.
- **End-to-end smoke test** against the keyless `--demo` server: `queued→ongoing→done`, agent result captured, WAL SQLite db persisted to disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
