### PR TITLE
feat(tasks): interactive task board — stream pop-up, review gate, talk-back (Slice 2)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -76,7 +76,7 @@ export function Layout(props: LayoutProps) {
   const showCanvas = props.config.show_canvas;
   const showFiles = props.config.show_files;
 
-  // If the currently active tab gets hidden by config, fall back to Tasks.
+  // If the currently active tab gets hidden by config, fall back to Plan.
   useEffect(() => {
     if (activeTab === "canvas" && !showCanvas) setActiveTab("tasks");
     else if (activeTab === "files" && !showFiles) setActiveTab("tasks");
@@ -162,7 +162,7 @@ export function Layout(props: LayoutProps) {
                   }`}
                 >
                   <ListTodo size={13} />
-                  Tasks
+                  Plan
                   {props.todos.length > 0 && (
                     <span className="ml-1 min-w-[16px] h-4 px-1 rounded-full bg-[var(--color-surface-3)] text-[10px] tabular-nums text-[var(--color-text-muted)] inline-flex items-center justify-center">
                       {props.todos.length}

--- a/frontend/src/components/TaskBoard.tsx
+++ b/frontend/src/components/TaskBoard.tsx
@@ -11,6 +11,7 @@ import {
   KanbanSquare,
 } from "lucide-react";
 import type { Task, TaskState } from "../types";
+import { TaskDetailModal } from "./TaskDetailModal";
 
 interface TaskBoardProps {
   tasks: Task[];
@@ -53,13 +54,19 @@ function TaskCard({
   task,
   onCancel,
   onRetry,
+  onOpen,
 }: {
   task: Task;
   onCancel: (id: string) => void;
   onRetry: (id: string) => void;
+  onOpen: (id: string) => void;
 }) {
   return (
-    <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-2)] p-2.5">
+    <div
+      onClick={() => onOpen(task.task_id)}
+      title="Open task"
+      className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-2)] p-2.5 cursor-pointer hover:border-[var(--color-primary)] transition-colors"
+    >
       <div className="flex items-start justify-between gap-2">
         <span className="text-xs font-medium text-[var(--color-text)] truncate min-w-0">
           {task.title}
@@ -67,7 +74,7 @@ function TaskCard({
         <div className="flex items-center gap-1 shrink-0">
           {CANCELLABLE.includes(task.state) && (
             <button
-              onClick={() => onCancel(task.task_id)}
+              onClick={(e) => { e.stopPropagation(); onCancel(task.task_id); }}
               title="Cancel"
               className="p-0.5 rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-secondary)] hover:text-red-500"
             >
@@ -76,7 +83,7 @@ function TaskCard({
           )}
           {RETRYABLE.includes(task.state) && (
             <button
-              onClick={() => onRetry(task.task_id)}
+              onClick={(e) => { e.stopPropagation(); onRetry(task.task_id); }}
               title="Retry"
               className="p-0.5 rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-secondary)]"
             >
@@ -105,6 +112,7 @@ export function TaskBoard({ tasks, onCreate, onCancel, onRetry }: TaskBoardProps
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [openId, setOpenId] = useState<string | null>(null);
 
   const canSubmit = prompt.trim() && !submitting;
 
@@ -167,7 +175,13 @@ export function TaskBoard({ tasks, onCreate, onCancel, onRetry }: TaskBoardProps
                 </div>
                 <div className="space-y-2 overflow-y-auto">
                   {items.map((t) => (
-                    <TaskCard key={t.task_id} task={t} onCancel={onCancel} onRetry={onRetry} />
+                    <TaskCard
+                      key={t.task_id}
+                      task={t}
+                      onCancel={onCancel}
+                      onRetry={onRetry}
+                      onOpen={setOpenId}
+                    />
                   ))}
                 </div>
               </div>
@@ -175,6 +189,8 @@ export function TaskBoard({ tasks, onCreate, onCancel, onRetry }: TaskBoardProps
           })}
         </div>
       )}
+
+      {openId && <TaskDetailModal taskId={openId} onClose={() => setOpenId(null)} />}
     </div>
   );
 }

--- a/frontend/src/components/TaskDetailModal.tsx
+++ b/frontend/src/components/TaskDetailModal.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { X, Loader2, Send, Check, Ban } from "lucide-react";
+import type { ChatMessage, Task, ToolCall, Decision } from "../types";
+import { MessageBubble } from "./MessageBubble";
+
+interface TaskDetailModalProps {
+  taskId: string;
+  onClose: () => void;
+}
+
+const TERMINAL = new Set(["done", "failed", "cancelled"]);
+
+/** Reduce a task's raw event transcript into chat messages (a compact version
+ *  of the live chat reducer) so we can render it with the same MessageBubble. */
+function reduceEvents(events: Record<string, unknown>[]): ChatMessage[] {
+  const msgs: ChatMessage[] = [];
+  let counter = 0;
+  const pushAssistant = (): ChatMessage => {
+    const m: ChatMessage = { id: `a${counter++}`, role: "assistant", content: "", toolCalls: [] };
+    msgs.push(m);
+    return m;
+  };
+  const lastAssistant = (): ChatMessage | null => {
+    const m = msgs[msgs.length - 1];
+    return m && m.role === "assistant" ? m : null;
+  };
+
+  for (const e of events) {
+    const type = e.type as string;
+    if (type === "content") {
+      let m = lastAssistant();
+      if (!m || m.toolCalls.length > 0) m = pushAssistant(); // new bubble after tools
+      m.content += (e.content as string) || "";
+    } else if (type === "tool_start") {
+      const m = lastAssistant() || pushAssistant();
+      const tc: ToolCall = {
+        id: e.id as string,
+        name: e.name as string,
+        args: (e.args as Record<string, unknown>) || {},
+        status: "running",
+      };
+      m.toolCalls.push(tc);
+    } else if (type === "tool_end") {
+      for (let i = msgs.length - 1; i >= 0; i--) {
+        const tc = msgs[i].toolCalls.find((t) => t.id === e.id);
+        if (tc) {
+          tc.status = (e.status as ToolCall["status"]) || "success";
+          tc.result = e.result as string | undefined;
+          tc.errorMessage = (e.error_message as string | null) ?? null;
+          tc.durationMs = (e.duration_ms as number | null) ?? null;
+          break;
+        }
+      }
+    } else if (type === "extraction") {
+      const m = lastAssistant();
+      if (m && m.toolCalls.length) {
+        m.toolCalls[m.toolCalls.length - 1].extraction = {
+          extracted_type: e.extracted_type as string,
+          data: e.data,
+        };
+      }
+    }
+  }
+  return msgs.filter((m) => m.content.trim() || m.toolCalls.length);
+}
+
+export function TaskDetailModal({ taskId, onClose }: TaskDetailModalProps) {
+  const [task, setTask] = useState<Task | null>(null);
+  const [events, setEvents] = useState<Record<string, unknown>[]>([]);
+  const [followup, setFollowup] = useState("");
+  const [busy, setBusy] = useState(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const [t, ev] = await Promise.all([
+        fetch(`/api/tasks/${taskId}`).then((r) => (r.ok ? r.json() : null)),
+        fetch(`/api/tasks/${taskId}/events`).then((r) => (r.ok ? r.json() : [])),
+      ]);
+      setTask(t);
+      setEvents(ev);
+    } catch (err) {
+      console.error("Failed to load task detail:", err);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 1500);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  // Autoscroll as new events stream in.
+  useEffect(() => {
+    bodyRef.current?.scrollTo({ top: bodyRef.current.scrollHeight });
+  }, [events.length]);
+
+  const post = async (path: string, body: unknown) => {
+    setBusy(true);
+    try {
+      await fetch(`/api/tasks/${taskId}/${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      await refresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const respond = (decisions: Decision[]) => post("resume", { decisions });
+  const sendFollowup = async () => {
+    if (!followup.trim()) return;
+    const msg = followup.trim();
+    setFollowup("");
+    await post("message", { message: msg });
+  };
+
+  const messages = reduceEvents(events);
+  const isReview = task?.state === "review_needed";
+  const isTerminal = task ? TERMINAL.has(task.state) : false;
+  const actionRequests =
+    (task?.interrupt?.action_requests as Array<Record<string, unknown>>) || [];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="w-[min(720px,92vw)] h-[min(80vh,720px)] flex flex-col rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--color-border)] shrink-0">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-[var(--color-text)] truncate">
+              {task?.title || "Task"}
+            </div>
+            <div className="text-[11px] text-[var(--color-text-muted)] flex items-center gap-1.5">
+              {task && !isTerminal && <Loader2 size={11} className="animate-spin" />}
+              {task?.state || "loading…"}
+            </div>
+          </div>
+          <button onClick={onClose} className="p-1 rounded hover:bg-[var(--color-surface-3)] text-[var(--color-text-secondary)]">
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div ref={bodyRef} className="flex-1 overflow-y-auto p-4 space-y-3">
+          {task?.prompt && (
+            <MessageBubble
+              message={{ id: "prompt", role: "user", content: task.prompt, toolCalls: [] }}
+              showLabel={false}
+            />
+          )}
+          {messages.map((m) => (
+            <MessageBubble key={m.id} message={m} agentName="Task agent" />
+          ))}
+          {task?.error && <div className="text-xs text-red-500">{task.error}</div>}
+          {messages.length === 0 && !task?.error && (
+            <div className="text-xs text-[var(--color-text-muted)]">
+              {isTerminal ? "No stream output." : "Waiting for the agent…"}
+            </div>
+          )}
+        </div>
+
+        {/* Review gate */}
+        {isReview && (
+          <div className="px-4 py-3 border-t border-[var(--color-border)] bg-[var(--color-surface-2)] shrink-0">
+            <div className="text-[11px] text-[var(--color-text-muted)] mb-2">
+              This task is paused for your approval.
+            </div>
+            <div className="flex gap-2">
+              <button
+                disabled={busy}
+                onClick={() => respond(actionRequests.map(() => ({ type: "approve" })))}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-emerald-600 text-white disabled:opacity-40 hover:opacity-90"
+              >
+                <Check size={13} /> Approve
+              </button>
+              <button
+                disabled={busy}
+                onClick={() => respond(actionRequests.map(() => ({ type: "reject" })))}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-red-600 text-white disabled:opacity-40 hover:opacity-90"
+              >
+                <Ban size={13} /> Reject
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Follow-up (talk back to a finished task) */}
+        {isTerminal && task?.state !== "cancelled" && (
+          <div className="px-4 py-3 border-t border-[var(--color-border)] shrink-0">
+            <div className="flex gap-2">
+              <input
+                className="flex-1 px-2.5 py-1.5 text-xs rounded-md bg-[var(--color-surface-2)] border border-[var(--color-border)] text-[var(--color-text)] placeholder:text-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-primary)]"
+                placeholder="Send a follow-up to this task…"
+                value={followup}
+                onChange={(e) => setFollowup(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && sendFollowup()}
+                disabled={busy}
+              />
+              <button
+                onClick={sendFollowup}
+                disabled={busy || !followup.trim()}
+                className="px-2.5 py-1.5 rounded-md bg-[var(--color-primary)] text-white disabled:opacity-40 hover:opacity-90"
+              >
+                <Send size={13} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -8,6 +8,7 @@ load_dotenv()
 import os
 
 from langgraph_stream_parser.demo import create_default_agent as _build_default_agent
+from langgraph_stream_parser.tasks import TASK_TOOLS
 
 from langstage.middleware import CanvasMiddleware
 from langstage.scheduler import CRON_TOOLS
@@ -125,6 +126,7 @@ AGENT_TOOLS = [
     display_inline,
     think_tool,
     *CRON_TOOLS,  # schedule_run / list_scheduled_runs / cancel_scheduled_run
+    *TASK_TOOLS,  # start/check/list/update/cancel_async_task — agent self-delegation
 ]
 
 # Middleware list — canvas is opt-in via CanvasMiddleware.

--- a/langstage/server/routes_tasks.py
+++ b/langstage/server/routes_tasks.py
@@ -6,7 +6,7 @@ review gate) land in Slice 2.
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
@@ -20,6 +20,14 @@ class TaskCreate(BaseModel):
     title: Optional[str] = None
     agent_spec: Optional[str] = None
     parent_id: Optional[str] = None
+
+
+class ResumeBody(BaseModel):
+    decisions: list[dict[str, Any]]
+
+
+class MessageBody(BaseModel):
+    message: str
 
 
 def create_tasks_router(runner: TaskRunner, store: TaskStore) -> APIRouter:
@@ -59,6 +67,28 @@ def create_tasks_router(runner: TaskRunner, store: TaskStore) -> APIRouter:
     async def retry_task(task_id: str):
         if not await runner.retry(task_id):
             raise HTTPException(status_code=400, detail="Task not found or not retryable")
+        return {"ok": True}
+
+    @router.get("/{task_id}/events")
+    async def get_task_events(task_id: str):
+        if await store.get(task_id) is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return await store.get_events(task_id)
+
+    @router.post("/{task_id}/resume")
+    async def resume_task(task_id: str, body: ResumeBody):
+        # The frontend builds the decisions (approve/reject/edit/respond) the
+        # same way the chat InterruptDialog does, then posts them here.
+        if not await runner.resume(task_id, body.decisions):
+            raise HTTPException(status_code=400, detail="Task is not awaiting review")
+        return {"ok": True}
+
+    @router.post("/{task_id}/message")
+    async def message_task(task_id: str, body: MessageBody):
+        if not await runner.followup(task_id, body.message):
+            raise HTTPException(
+                status_code=400, detail="Task not found or not in a state that accepts follow-ups"
+            )
         return {"ok": True}
 
     return router

--- a/langstage/tasks/sqlite_store.py
+++ b/langstage/tasks/sqlite_store.py
@@ -47,6 +47,13 @@ CREATE TABLE IF NOT EXISTS tasks (
 );
 CREATE INDEX IF NOT EXISTS idx_tasks_state  ON tasks(state);
 CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
+
+CREATE TABLE IF NOT EXISTS task_events (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    event   TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_task_events ON task_events(task_id, id);
 """
 
 
@@ -180,3 +187,25 @@ class SqliteTaskStore:
         )
         await db.commit()
         return cur.rowcount or 0
+
+    async def append_events(self, task_id: str, events: list[dict[str, Any]]) -> None:
+        db = self._conn()
+        await db.executemany(
+            "INSERT INTO task_events (task_id, event) VALUES (?, ?)",
+            [(task_id, json.dumps(e)) for e in events],
+        )
+        await db.commit()
+
+    async def get_events(self, task_id: str) -> list[dict[str, Any]]:
+        db = self._conn()
+        async with db.execute(
+            "SELECT event FROM task_events WHERE task_id = ? ORDER BY id", (task_id,)
+        ) as cur:
+            rows = await cur.fetchall()
+        out: list[dict[str, Any]] = []
+        for r in rows:
+            try:
+                out.append(json.loads(r["event"]))
+            except (ValueError, TypeError):  # pragma: no cover - defensive
+                continue
+        return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    "langgraph-stream-parser>=0.5,<0.6",
+    "langgraph-stream-parser>=0.6,<0.7",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -31,7 +31,7 @@ deepagents = [
     "deepagents>=0.3",
 ]
 agui = [
-    "langgraph-stream-parser[agui]>=0.5,<0.6",
+    "langgraph-stream-parser[agui]>=0.6,<0.7",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_routes_tasks.py
+++ b/tests/test_routes_tasks.py
@@ -98,3 +98,42 @@ async def test_retry_done_task_is_400(ctx):
     await _wait(store, tid, DONE)
     # a completed task is not retryable
     assert (await client.post(f"/api/tasks/{tid}/retry")).status_code == 400
+
+
+async def test_events_endpoint(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "hi"})
+    tid = r.json()["task_id"]
+    await _wait(store, tid, DONE)
+    ev = await client.get(f"/api/tasks/{tid}/events")
+    assert ev.status_code == 200
+    types = [e["type"] for e in ev.json()]
+    assert "content" in types and types[-1] == "complete"
+
+
+async def test_events_404(ctx):
+    client, _ = ctx
+    assert (await client.get("/api/tasks/nope/events")).status_code == 404
+
+
+async def test_message_followup_reruns(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "hi"})
+    tid = r.json()["task_id"]
+    await _wait(store, tid, DONE)
+    m = await client.post(f"/api/tasks/{tid}/message", json={"message": "now do more"})
+    assert m.status_code == 200
+    await _wait(store, tid, DONE)
+    ev = (await client.get(f"/api/tasks/{tid}/events")).json()
+    assert sum(1 for e in ev if e["type"] == "complete") == 2  # ran twice
+
+
+async def test_resume_400_when_not_review(ctx):
+    client, store = ctx
+    r = await client.post("/api/tasks", json={"prompt": "hi"})
+    tid = r.json()["task_id"]
+    await _wait(store, tid, DONE)
+    res = await client.post(
+        f"/api/tasks/{tid}/resume", json={"decisions": [{"type": "approve"}]}
+    )
+    assert res.status_code == 400  # not awaiting review

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -105,6 +105,33 @@ async def test_list_filters(tmp_path):
         await store.close()
 
 
+async def test_events_append_get_order(tmp_path):
+    store = SqliteTaskStore(tmp_path / "t.db")
+    await store.setup()
+    try:
+        await store.append_events("a", [{"type": "content", "content": "hi"}, {"type": "complete"}])
+        await store.append_events("a", [{"type": "x"}])
+        assert [e["type"] for e in await store.get_events("a")] == ["content", "complete", "x"]
+        assert await store.get_events("missing") == []
+    finally:
+        await store.close()
+
+
+async def test_events_durable_across_reopen(tmp_path):
+    path = tmp_path / "t.db"
+    s1 = SqliteTaskStore(path)
+    await s1.setup()
+    await s1.append_events("a", [{"type": "content", "content": "x"}, {"type": "complete"}])
+    await s1.close()
+
+    s2 = SqliteTaskStore(path)
+    await s2.setup()
+    try:
+        assert len(await s2.get_events("a")) == 2
+    finally:
+        await s2.close()
+
+
 async def test_update_rejects_unknown_column(tmp_path):
     import pytest
 


### PR DESCRIPTION
## Interactive task board — stream pop-up, review gate, talk-back (Slice 2)

Builds on core `langgraph-stream-parser` **0.6.0** (event transcript + delegation tools) to make the board interactive — you can now open a task, watch its agent stream, approve/reject HITL pauses, and talk back to finished tasks.

### Backend
- **`SqliteTaskStore`** gains `append_events` / `get_events` (a `task_events` table) — the durable per-task transcript the runner streams to.
- **`/api/tasks` routes**: `GET /{id}/events`, `POST /{id}/resume` (approve/reject via HITL decisions), `POST /{id}/message` (talk-back / follow-up). Parser dep → `>=0.6,<0.7`.
- **`default_agent`** wires `*TASK_TOOLS` so the agent can spawn async copies of itself (`start/check/list/update/cancel_async_task`).

### Frontend
- **`TaskDetailModal`** — click a card to open a pop-up that reduces the event transcript into the chat's `MessageBubble` view, **live-tails** while running (1.5s poll), shows **Approve/Reject** for `review_needed` tasks, and a **follow-up** box to talk back to a finished task.
- Board cards are clickable; cancel/retry stop-propagate.
- Renamed the **"Tasks"** tab (the todo/plan list) → **"Plan"**, removing the Tasks-vs-Board name clash.

### Verification
- Backend: +2 sqlite tests (events append/get + durable across restart), +4 route tests. **Full web suite: 125 passed.**
- Frontend: tsc + vite build clean.
- **Live end-to-end against a real LLM** (OpenRouter): token-by-token transcript via `/events` (117 events), follow-up re-run, tool-use task to completion. (Found a provider quirk along the way — OpenAI rejects message `name` with spaces; documented in the demo agent config, not a board issue.)

### Notes
Ships on `InMemorySaver` still (task rows + transcript persist via SQLite; durable agent-checkpoint resume is a later pass). Small models may prefer deepagents' built-in synchronous `task` tool over the async ones — the async path is wired + unit-tested regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
