### PR TITLE
fix(board): columns fill panel width + document the task board (0.9.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.9.1 — 2026-06-14
+
+### Fixed
+- Task board columns now expand to fill the panel width (they were fixed-width, leaving dead space when the right panel was widened).
+
+### Docs
+- README: documented the task board (delegate, live-tail detail pop-up, review gate, agent self-delegation, REST API).
+
 ## 0.9.0 — 2026-06-14
 
 **Async task board** — delegate tasks to background copies of the agent, track them on a Kanban board, and interact with each run.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ langstage-agui --agent my_agent.py:graph
 - **Rich inline content** — HTML, Plotly charts, images, DataFrames, PDFs, and JSON rendered directly in the chat
 - **Canvas panel** — persistent report surface for charts, tables, diagrams, images, and narrative markdown. Opt-in via `CanvasMiddleware`; auto-detected by the UI.
 - **File browser** — workspace file tree with syntax-highlighted viewer and live file change detection
-- **Task tracking** — sidebar todo list with progress bar, synced with agent `write_todos` calls
+- **Plan** — sidebar todo list with progress bar, synced with agent `write_todos` calls (the **Plan** tab)
+- **Async task board** — delegate tasks to background copies of the agent and track them on a Kanban board (`queued → ongoing → review → done`); click a task to live-tail its stream, approve/reject human-in-the-loop pauses, and send follow-ups. The agent can also spawn its own async sub-tasks. See [Task board](#task-board).
 - **Human-in-the-loop** — interrupt dialog for reviewing and approving agent actions
 - **Slash commands** — `/save-workflow`, `/create-workflow`, and `/run-workflow` with autocomplete
 - **Print / export** — print conversations via browser Print dialog with optimized CSS
@@ -118,6 +119,25 @@ CoworkApp(agent=agent, workspace="./workspace").run()
 The middleware injects five tools (`add_to_canvas`, `update_canvas_item`, `remove_canvas_item`, `add_canvas_section`, `reorder_canvas`) and appends report-building instructions to the system prompt at each model call. Canvas items persist to `.canvas/canvas.md` in the workspace.
 
 To force the tabs on/off regardless of middleware: `--show-canvas/--no-show-canvas`, `--show-files/--no-show-files`, or the Python-API `show_canvas` / `show_files` kwargs.
+
+## Task board
+
+The **Board** tab turns LangStage into a lightweight agent control room: delegate a task and it runs on a background copy of your agent while you keep chatting. No extra infrastructure — tasks are persisted in a local SQLite file (the board survives a restart) and executed by an in-process worker pool, built on the [`langgraph-stream-parser`](https://github.com/dkedar7/langgraph-stream-parser) task engine.
+
+- **Delegate** from the Board tab (or let the agent delegate to itself — see below). A task moves `queued → ongoing → review → done`; cancel or retry from any card.
+- **Open a task** (click its card) to **live-tail the agent's full event stream** — content and tool calls, rendered like the chat. Approve/reject a task paused for human review, or send it a **follow-up**.
+- **Agent self-delegation** — the default agent carries five tools (`start_async_task`, `check_async_task`, `list_async_tasks`, `update_async_task`, `cancel_async_task`) so it can spawn async sub-tasks; spawned tasks are linked to their parent on the board. Add them to a custom agent with:
+
+  ```python
+  from langgraph_stream_parser.tasks import TASK_TOOLS
+  agent = create_deep_agent(tools=[*your_tools, *TASK_TOOLS], ...)
+  ```
+
+- **Scheduled runs** (the Schedules tab) enqueue onto the same board.
+
+REST API: `GET /api/tasks`, `POST /api/tasks` (delegate), `GET /api/tasks/{id}/events`, and `POST /api/tasks/{id}/{cancel,retry,resume,message}`. Concurrency is bounded by `LANGSTAGE_TASK_CONCURRENCY` (default 3).
+
+> **Single-process:** run one server worker. The atomic task claim and the worker pool are scoped to one process; multiple uvicorn workers would double-run tasks.
 
 ## Configuration
 

--- a/frontend/src/components/TaskBoard.tsx
+++ b/frontend/src/components/TaskBoard.tsx
@@ -168,7 +168,7 @@ export function TaskBoard({ tasks, onCreate, onCancel, onRetry }: TaskBoardProps
           {COLUMNS.map((col) => {
             const items = inCol(col.states);
             return (
-              <div key={col.key} className="flex flex-col w-44 shrink-0">
+              <div key={col.key} className="flex flex-col flex-1 min-w-[160px]">
                 <div className="flex items-center justify-between px-1 pb-1.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
                   <span>{col.label}</span>
                   <span className="tabular-nums">{items.length}</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.9.0"
+version = "0.9.1"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Minor: board columns flex to fill the panel (were fixed-width → dead space when widened), plus a README **Task board** section. Patch release 0.9.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)