### PR TITLE
feat: BYO-agent integration — auto-checkpointer, LANGSTAGE_TOOLS, doctor (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.10.0 — 2026-06-15
+
+**Bring-your-own-agent integration** — make pointing `--agent` at any LangGraph graph "just work," and tell users exactly what lights up.
+
+### Added
+- **`langstage check --agent <spec>`** — a preflight doctor that loads your agent and reports which features will light up (checkpointer, Canvas, Plan/`write_todos`, async-delegation tools) and which need a convention or tool to unlock.
+- **`LANGSTAGE_TOOLS`** — a one-import bundle (`from langstage import LANGSTAGE_TOOLS`) of the host's scheduling + async task-delegation tools, so a BYO agent unlocks agent self-delegation and agent-created schedules in one line.
+- README **"Bring your own agent"** section documenting the integration contract.
+
+### Changed
+- **Checkpointer is now auto-attached** when a loaded agent has none (was: a console warning, then silently degraded). Conversation memory, human-in-the-loop interrupts, and the task review gate now work for any BYO graph out of the box; supply your own checkpointer for durability. (Matches the AG-UI bridge's behavior.)
+- `__version__` now reads from package metadata (was a stale hardcoded constant).
+
 ## 0.9.1 — 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -120,6 +120,38 @@ The middleware injects five tools (`add_to_canvas`, `update_canvas_item`, `remov
 
 To force the tabs on/off regardless of middleware: `--show-canvas/--no-show-canvas`, `--show-files/--no-show-files`, or the Python-API `show_canvas` / `show_files` kwargs.
 
+## Bring your own agent
+
+Point `--agent` at any compiled LangGraph graph — `langstage run --agent my_agent.py:graph`. Most of the UI works immediately; a few features light up when your agent follows a convention or carries a tool.
+
+**Works out of the box (no agent changes):** chat with token streaming, tool-call visualization, the file browser, the **task board** (delegate any agent from the UI), and **schedules**.
+
+**Auto-handled:** if your graph has no checkpointer, LangStage attaches an in-memory one so conversation memory, human-in-the-loop interrupts, and the task review gate work. Supply your own checkpointer for durability across restarts.
+
+**Unlock the rest:**
+
+| Feature | How |
+| --- | --- |
+| **Plan** tab populates | agent calls `write_todos` (the deepagents convention) |
+| **Rich inline content** (charts, images, DataFrames, HTML) | a tool returns the `display_inline` shape |
+| **Canvas** tab | attach `CanvasMiddleware` to your agent |
+| **Agent self-delegation + agent-created schedules** | add the host tools — `from langstage import LANGSTAGE_TOOLS` → `tools=[*my_tools, *LANGSTAGE_TOOLS]` |
+| **Human-in-the-loop review** | use LangGraph `interrupt()` (or deepagents `interrupt_on=...`) |
+
+**Preflight your agent** with the built-in doctor — it loads your spec and reports exactly what will and won't light up:
+
+```bash
+langstage check --agent my_agent.py:graph
+```
+
+```
+[ ok ] loads
+[ ok ] checkpointer present (memory + interrupts + review gate)
+[warn] no CanvasMiddleware - Canvas hidden (attach it to enable)
+[ ok ] write_todos present - Plan tab will populate
+[warn] async task tools not found - add `from langstage import LANGSTAGE_TOOLS` ...
+```
+
 ## Task board
 
 The **Board** tab turns LangStage into a lightweight agent control room: delegate a task and it runs on a background copy of your agent while you keep chatting. No extra infrastructure — tasks are persisted in a local SQLite file (the board survives a restart) and executed by an in-process worker pool, built on the [`langgraph-stream-parser`](https://github.com/dkedar7/langgraph-stream-parser) task engine.

--- a/langstage/__init__.py
+++ b/langstage/__init__.py
@@ -1,7 +1,25 @@
 """LangStage — the web stage for your LangGraph agent."""
 
+from importlib.metadata import PackageNotFoundError, version
+
+from langgraph_stream_parser.tasks import TASK_TOOLS
+
 from langstage.app import CoworkApp, run_app
+from langstage.scheduler import CRON_TOOLS
 
-__version__ = "0.7.0"
+#: One-import bundle of host-provided agent tools. Add to a bring-your-own agent
+#: to unlock agent-driven scheduling + async task self-delegation:
+#:
+#:     from langstage import LANGSTAGE_TOOLS
+#:     agent = create_deep_agent(tools=[*my_tools, *LANGSTAGE_TOOLS], ...)
+#:
+#: The tools reach the host's process-global scheduler/runner at request time,
+#: so they only do anything when served by LangStage (no-op otherwise).
+LANGSTAGE_TOOLS = [*CRON_TOOLS, *TASK_TOOLS]
 
-__all__ = ["CoworkApp", "run_app"]
+try:
+    __version__ = version("langstage")
+except PackageNotFoundError:  # pragma: no cover - editable/source checkout
+    __version__ = "0.0.0+local"
+
+__all__ = ["CoworkApp", "run_app", "LANGSTAGE_TOOLS"]

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -110,13 +110,27 @@ class CoworkApp:
             else:
                 logger.warning("custom_css file not found: %s", css_path)
 
-        # Check for checkpointer
+        # Ensure a checkpointer. Conversation memory, human-in-the-loop
+        # interrupts, and the task board's review gate all need threaded state.
+        # Many bring-your-own graphs are compiled without one, so auto-attach an
+        # in-memory default (same approach as the AG-UI bridge) instead of
+        # silently degrading. The user can still supply their own (durable) one.
         if not _has_checkpointer(self.agent):
-            logger.warning(
-                "Agent has no checkpointer. Human-in-the-loop interrupts and "
-                "conversation persistence will not work. Pass "
-                "checkpointer=MemorySaver() to enable these features."
-            )
+            try:
+                from langgraph.checkpoint.memory import InMemorySaver
+
+                self.agent.checkpointer = InMemorySaver()
+                logger.info(
+                    "Agent had no checkpointer; attached an in-memory one "
+                    "(enables conversation memory + interrupts). Pass your own "
+                    "checkpointer for durability across restarts."
+                )
+            except Exception:  # noqa: BLE001 - best effort; warn if it won't attach
+                logger.warning(
+                    "Agent has no checkpointer and one could not be attached. "
+                    "Human-in-the-loop interrupts and conversation persistence "
+                    "will not work. Compile your graph with a checkpointer."
+                )
 
     def _resolve_agent(self, agent):
         """Resolve agent from argument, spec, env var, or create default."""

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -6,7 +6,7 @@ from langstage.app import CoworkApp
 from langstage.config import AppConfig
 
 
-# The keyless echo agent shipped with the shared core — see `--demo`.
+# The keyless echo agent shipped with the shared core - see `--demo`.
 DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
 
 
@@ -18,7 +18,7 @@ DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
 )
 @click.pass_context
 def main(ctx, show_config):
-    """LangStage — every stage for your LangGraph agent (web)."""
+    """LangStage - every stage for your LangGraph agent (web)."""
     if show_config:
         click.echo(AppConfig.resolve().describe())
         ctx.exit(0)
@@ -28,7 +28,7 @@ def main(ctx, show_config):
 
 @main.command()
 @click.option("--agent", "-a", "agent_spec", default=None, help="Agent spec (e.g., my_agent.py:agent)")
-@click.option("--demo", is_flag=True, default=False, help="Run with the built-in keyless demo agent — no API key needed")
+@click.option("--demo", is_flag=True, default=False, help="Run with the built-in keyless demo agent - no API key needed")
 @click.option("--workspace", default=None, type=click.Path(), help="Workspace directory")
 @click.option("--port", default=None, type=int, help="Server port (default: 8050)")
 @click.option("--host", default=None, help="Server host (default: localhost)")
@@ -85,6 +85,82 @@ def config(workspace):
     env var / deepagents.toml key that sets it."""
     overrides = {"workspace_root": workspace} if workspace else None
     click.echo(AppConfig.resolve(overrides=overrides).describe())
+
+
+def _agent_tool_names(agent) -> set[str] | None:
+    """Best-effort: pull bound tool names out of a compiled graph. Returns None
+    if the graph can't be introspected (capabilities may still work)."""
+    try:
+        names: set[str] = set()
+        nodes = getattr(agent, "nodes", None) or {}
+        for node in nodes.values():
+            target = getattr(node, "bound", node)
+            tbn = getattr(target, "tools_by_name", None)
+            if isinstance(tbn, dict):
+                names.update(tbn.keys())
+        return names or None
+    except Exception:  # noqa: BLE001 - introspection is inherently best-effort
+        return None
+
+
+@main.command()
+@click.option("--agent", "-a", "agent_spec", default=None, help="Agent spec to check (e.g., my_agent.py:agent)")
+@click.option("--demo", is_flag=True, default=False, help="Check the built-in demo agent instead")
+def check(agent_spec, demo):
+    """Preflight a bring-your-own agent: load it and report which LangStage
+    features will light up (and which need a convention or tool to unlock)."""
+    from langgraph_stream_parser import load_agent_spec
+    from langstage.middleware import agent_uses_canvas_middleware
+
+    spec = DEMO_AGENT_SPEC if demo else agent_spec
+    if not spec:
+        raise click.UsageError("Provide --agent <spec> (or --demo).")
+
+    ok = click.style("[ ok ]", fg="green")
+    warn = click.style("[warn]", fg="yellow")
+
+    click.echo(f"Checking agent: {spec}\n")
+    try:
+        agent = load_agent_spec(spec)
+    except Exception as e:  # noqa: BLE001 - report load failure cleanly
+        click.echo(f"{click.style('[fail]', fg='red')} failed to load: {e}")
+        raise SystemExit(1)
+    click.echo(f"{ok} loads")
+    name = getattr(agent, "name", None)
+    if name:
+        click.echo(f"{ok} agent name: {name}")
+
+    # Checkpointer - LangStage auto-attaches an in-memory one if absent.
+    if getattr(agent, "checkpointer", None) is not None:
+        click.echo(f"{ok} checkpointer present (memory + interrupts + review gate)")
+    else:
+        click.echo(f"{warn} no checkpointer - LangStage will attach an in-memory one "
+                   "(supply your own for durability across restarts)")
+
+    # Canvas
+    if agent_uses_canvas_middleware(agent):
+        click.echo(f"{ok} CanvasMiddleware detected - Canvas tab will show")
+    else:
+        click.echo(f"{warn} no CanvasMiddleware - Canvas hidden (attach it to enable)")
+
+    # Capability tools (best-effort introspection)
+    tools = _agent_tool_names(agent)
+    if tools is None:
+        click.echo(f"{warn} could not introspect tools - the checks below are best-effort")
+        tools = set()
+    has_task = any(t.endswith("async_task") or t.endswith("async_tasks") for t in tools)
+    has_cron = "schedule_run" in tools
+    has_todos = "write_todos" in tools
+    click.echo(f"{ok if has_todos else warn} write_todos "
+               + ("present - Plan tab will populate" if has_todos else "not found - Plan tab may stay empty"))
+    click.echo(f"{ok if has_task else warn} async task tools "
+               + ("present - agent can self-delegate" if has_task
+                  else "not found - add `from langstage import LANGSTAGE_TOOLS` to your agent's tools"))
+    click.echo(f"{ok if has_cron else warn} schedule tools "
+               + ("present - agent can create schedules" if has_cron else "not found (LANGSTAGE_TOOLS adds these too)"))
+
+    click.echo("\nAlways available from the UI regardless of the agent: chat, "
+               "tool-call view, file browser, the task board (delegate), and schedules.")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.9.1"
+version = "0.10.0"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_byo_integration.py
+++ b/tests/test_byo_integration.py
@@ -1,0 +1,61 @@
+"""Bring-your-own-agent integration: checkpointer auto-attach, the tool
+bundle, and the `langstage check` doctor."""
+from typing import TypedDict
+
+from click.testing import CliRunner
+from langgraph.graph import END, START, StateGraph
+
+from langstage import LANGSTAGE_TOOLS
+from langstage.app import CoworkApp
+from langstage.cli import main
+
+
+class _S(TypedDict):
+    x: int
+
+
+def _bare_graph(checkpointer=None):
+    def node(state):
+        return {"x": state.get("x", 0) + 1}
+
+    g = StateGraph(_S)
+    g.add_node("n", node)
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    return g.compile(checkpointer=checkpointer)
+
+
+def test_checkpointer_auto_attached(tmp_path):
+    graph = _bare_graph()
+    assert graph.checkpointer is None  # BYO graph with no checkpointer
+    app = CoworkApp(agent=graph, workspace=str(tmp_path))
+    assert app.agent.checkpointer is not None  # LangStage attached one
+
+
+def test_user_checkpointer_is_preserved(tmp_path):
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    saver = InMemorySaver()
+    graph = _bare_graph(checkpointer=saver)
+    app = CoworkApp(agent=graph, workspace=str(tmp_path))
+    assert app.agent.checkpointer is saver  # not replaced
+
+
+def test_langstage_tools_bundle():
+    names = {getattr(t, "name", "") for t in LANGSTAGE_TOOLS}
+    assert "schedule_run" in names                       # cron
+    assert any(n.endswith("async_task") for n in names)  # delegation
+    assert "start_async_task" in names
+
+
+def test_check_doctor_runs_on_demo():
+    result = CliRunner().invoke(main, ["check", "--demo"])
+    assert result.exit_code == 0
+    assert "loads" in result.output
+    # demo agent ships no canvas / delegation tools → doctor should flag them
+    assert "Canvas" in result.output
+
+
+def test_check_doctor_requires_a_spec():
+    result = CliRunner().invoke(main, ["check"])
+    assert result.exit_code != 0  # UsageError without --agent/--demo

--- a/tests/test_rename_shim.py
+++ b/tests/test_rename_shim.py
@@ -22,6 +22,8 @@ def test_legacy_submodules_alias_the_new_ones():
 
 def test_legacy_public_api():
     import cowork_dash
+    import langstage
 
     assert hasattr(cowork_dash, "CoworkApp")
-    assert cowork_dash.__version__ == "0.7.0"
+    # The shim mirrors the real package's version (don't hardcode — it rots).
+    assert cowork_dash.__version__ == langstage.__version__


### PR DESCRIPTION
Makes the bring-your-own-agent path robust and self-documenting.

- **Auto-attach checkpointer** when a loaded agent lacks one (was a warning → silent degrade). Memory + HITL + task review gate now work for any BYO graph; user checkpointers preserved. Mirrors the AG-UI bridge.
- **`LANGSTAGE_TOOLS`** one-import bundle (cron + async task tools) → agent self-delegation + agent-created schedules in one line.
- **`langstage check --agent <spec>`** preflight doctor reporting what will/won't light up.
- README **Bring your own agent** contract section.
- `__version__` now from metadata (fixes 0.7.0 drift).

Full web suite **130 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)