### PR TITLE
feat: durable agent checkpointer via AsyncSqliteSaver (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.11.0 — 2026-06-15
+
+### Changed
+- **Durable agent checkpointer.** The auto-attached checkpointer is now upgraded
+  to a SQLite-backed `AsyncSqliteSaver` (`<workspace>/.langstage/checkpoints.db`)
+  at server startup, so conversation + interrupt state and the task review gate
+  **survive restarts**, and orphaned tasks resume from their last checkpoint
+  instead of from scratch. Only checkpointers LangStage auto-attached are
+  upgraded — a user-supplied checkpointer is never replaced. Falls back to
+  in-memory if the SQLite saver can't initialize.
+- Picks up `langgraph-stream-parser` 0.6.1 (sharper async-delegation tool
+  descriptions, so the agent reaches for the task board for long/background work).
+
+### Added
+- Dependency: `langgraph-checkpoint-sqlite`.
+
 ## 0.10.0 — 2026-06-15
 
 **Bring-your-own-agent integration** — make pointing `--agent` at any LangGraph graph "just work," and tell users exactly what lights up.

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -120,6 +120,11 @@ class CoworkApp:
                 from langgraph.checkpoint.memory import InMemorySaver
 
                 self.agent.checkpointer = InMemorySaver()
+                # Mark it as ours so the server can upgrade it to a durable
+                # SQLite saver at startup (which needs the event loop). A
+                # user-supplied checkpointer is never marked, so it's never
+                # replaced.
+                self.agent._langstage_auto_checkpointer = True
                 logger.info(
                     "Agent had no checkpointer; attached an in-memory one "
                     "(enables conversation memory + interrupts). Pass your own "

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -149,6 +149,9 @@ agent = _build_default_agent(
 # middleware into the compiled graph, so we stash the originals so that
 # agent_uses_canvas_middleware() can still detect them.
 agent.middleware = AGENT_MIDDLEWARE
+# The demo factory gives us an in-memory checkpointer; mark it so the server
+# upgrades it to a durable SQLite one at startup (survives restarts).
+agent._langstage_auto_checkpointer = True
 
 
 def create_default_agent(workspace: Path):

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -84,6 +84,28 @@ def create_fastapi_app(
     @app.on_event("startup")
     async def _start_services() -> None:
         await task_store.setup()
+        # Upgrade an auto-attached in-memory checkpointer to a durable SQLite
+        # one so conversation/interrupt state + the task review gate survive a
+        # restart (and orphaned tasks resume from their last checkpoint). Only
+        # touches checkpointers LangStage attached (the sentinel) — never a
+        # user-supplied one.
+        if getattr(agent, "_langstage_auto_checkpointer", False) is True:
+            try:
+                from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+                ckpt_db = workspace / ".langstage" / "checkpoints.db"
+                ckpt_db.parent.mkdir(parents=True, exist_ok=True)
+                ckpt_cm = AsyncSqliteSaver.from_conn_string(str(ckpt_db))
+                saver = await ckpt_cm.__aenter__()
+                await saver.setup()
+                agent.checkpointer = saver
+                app.state._ckpt_cm = ckpt_cm
+            except Exception:  # noqa: BLE001 - keep the in-memory saver on failure
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Durable checkpointer unavailable; keeping in-memory.",
+                    exc_info=True,
+                )
         await runner.start()
         scheduler.start()
 
@@ -92,6 +114,12 @@ def create_fastapi_app(
         scheduler.shutdown()
         await runner.shutdown()
         await task_store.close()
+        ckpt_cm = getattr(app.state, "_ckpt_cm", None)
+        if ckpt_cm is not None:
+            try:
+                await ckpt_cm.__aexit__(None, None, None)
+            except Exception:  # noqa: BLE001
+                pass
         set_scheduler(None)
         set_runner(None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.10.0"
+version = "0.11.0"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -24,6 +24,9 @@ dependencies = [
     "croniter>=2.0",
     # Durable task store for the async task board (TaskRunner persistence).
     "aiosqlite>=0.19",
+    # Durable agent checkpointer (auto-attached) so conversation/interrupt state
+    # and the task review gate survive restarts.
+    "langgraph-checkpoint-sqlite>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_byo_integration.py
+++ b/tests/test_byo_integration.py
@@ -86,12 +86,16 @@ async def test_server_startup_upgrades_to_sqlite(tmp_path):
     config = AppConfig.resolve(overrides={"workspace_root": tmp_path})
     app = create_fastapi_app(agent=graph, workspace=tmp_path, config=config)
 
-    await app.router.startup()
+    # Run the registered startup/shutdown handlers directly (portable across
+    # Starlette versions — `router.startup()` isn't available everywhere).
+    for handler in app.router.on_startup:
+        await handler()
     try:
         assert isinstance(graph.checkpointer, AsyncSqliteSaver)
         assert (tmp_path / ".langstage" / "checkpoints.db").exists()
     finally:
-        await app.router.shutdown()
+        for handler in app.router.on_shutdown:
+            await handler()
 
 
 def test_langstage_tools_bundle():

--- a/tests/test_byo_integration.py
+++ b/tests/test_byo_integration.py
@@ -30,15 +30,68 @@ def test_checkpointer_auto_attached(tmp_path):
     assert graph.checkpointer is None  # BYO graph with no checkpointer
     app = CoworkApp(agent=graph, workspace=str(tmp_path))
     assert app.agent.checkpointer is not None  # LangStage attached one
+    # marked as ours so the server can upgrade it to a durable SQLite saver
+    assert getattr(app.agent, "_langstage_auto_checkpointer", False) is True
 
 
-def test_user_checkpointer_is_preserved(tmp_path):
+def test_user_checkpointer_is_preserved_and_unmarked(tmp_path):
     from langgraph.checkpoint.memory import InMemorySaver
 
     saver = InMemorySaver()
     graph = _bare_graph(checkpointer=saver)
     app = CoworkApp(agent=graph, workspace=str(tmp_path))
     assert app.agent.checkpointer is saver  # not replaced
+    # not marked → the server will never swap it out
+    assert getattr(app.agent, "_langstage_auto_checkpointer", False) is False
+
+
+async def test_durable_checkpoint_persists_across_restart(tmp_path):
+    """The whole point of the SQLite saver: a thread's state survives a 'restart'
+    (a brand-new saver on the same db file can read the checkpoint)."""
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+    db = str(tmp_path / "ckpt.db")
+    cfg = {"configurable": {"thread_id": "t1"}}
+
+    def inc(state):
+        return {"x": state["x"] + 1}
+
+    builder = StateGraph(_S)
+    builder.add_node("inc", inc)
+    builder.add_edge(START, "inc")
+    builder.add_edge("inc", END)
+
+    async with AsyncSqliteSaver.from_conn_string(db) as s1:
+        await s1.setup()
+        g1 = builder.compile(checkpointer=s1)
+        out = await g1.ainvoke({"x": 0}, cfg)
+        assert out["x"] == 1
+
+    async with AsyncSqliteSaver.from_conn_string(db) as s2:  # "restart"
+        g2 = builder.compile(checkpointer=s2)
+        snap = await g2.aget_state(cfg)
+        assert snap is not None and snap.values.get("x") == 1  # persisted
+
+
+async def test_server_startup_upgrades_to_sqlite(tmp_path):
+    """create_fastapi_app's startup swaps an auto-attached in-memory saver for a
+    durable SQLite one (and shutdown closes it)."""
+    from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+    from langstage.config import AppConfig
+    from langstage.server.main import create_fastapi_app
+
+    graph = _bare_graph()
+    graph._langstage_auto_checkpointer = True  # as CoworkApp would mark it
+    config = AppConfig.resolve(overrides={"workspace_root": tmp_path})
+    app = create_fastapi_app(agent=graph, workspace=tmp_path, config=config)
+
+    await app.router.startup()
+    try:
+        assert isinstance(graph.checkpointer, AsyncSqliteSaver)
+        assert (tmp_path / ".langstage" / "checkpoints.db").exists()
+    finally:
+        await app.router.shutdown()
 
 
 def test_langstage_tools_bundle():


### PR DESCRIPTION
Upgrades the auto-attached checkpointer to a SQLite-backed `AsyncSqliteSaver` at startup, so conversation/interrupt state + the task review gate **survive restarts** and orphaned tasks resume from their last checkpoint. Only LangStage-attached checkpointers are upgraded (sentinel) — user-supplied ones are never touched; falls back to in-memory on failure.

Also picks up parser 0.6.1 (sharper async-delegation tool descriptions).

Tests: durable persistence across restart + startup-upgrade wiring. **Suite 132 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)