### PR TITLE
fix: declare langchain dep + minimal-install CI guard (0.11.1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,28 @@ jobs:
       - name: Run tests
         run: pytest -q
 
+  minimal-install:
+    # Guards against UNDECLARED dependencies. The other jobs install
+    # `.[deepagents]`, which pulls `langchain` transitively and so masks any
+    # dependency that's used-but-not-declared. This job installs with NO extras
+    # — exactly what `pip install langstage` gives a real user — and exercises
+    # the import + CLI hot paths. It is the test that would have caught the
+    # missing `langchain` declaration (found in prod by the daily cloud routine).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install with NO extras (declared deps only)
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+      - name: Import + CLI smoke on a minimal install
+        run: |
+          python -c "import langstage; from langstage import CoworkApp, LANGSTAGE_TOOLS; from langstage.middleware import agent_uses_canvas_middleware; print('imports ok')"
+          langstage check --demo
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.11.1 — 2026-06-16
+
+### Fixed
+- **Declare `langchain` as a dependency.** `langstage.middleware` (canvas) imports
+  `langchain.agents.middleware` and is loaded on hot paths (`app`, the `check` CLI
+  command, the default agent), but `langchain` wasn't declared — it only arrived
+  transitively via the `[deepagents]` extra. A clean `pip install langstage` therefore
+  failed with `ModuleNotFoundError: No module named 'langchain'` on `langstage check`
+  / `langstage run`. Now a hard dependency. (Found in production by the daily QA routine.)
+
+### CI
+- Added a **minimal-install** job: installs with no extras (`pip install .`) and runs
+  an import + CLI smoke — the lane that matches a real `pip install langstage`. The
+  other jobs install `[deepagents]`, which masked the missing `langchain` by pulling
+  it transitively. This guards against undeclared dependencies going forward.
+
 ## 0.11.0 — 2026-06-15
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.0"
+version = "0.11.1"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -16,6 +16,10 @@ dependencies = [
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
+    # CanvasMiddleware subclasses langchain.agents.middleware on import, and
+    # langstage.middleware is imported on hot paths (app, cli `check`, default
+    # agent) — so langchain is a HARD dep, not incidental via [deepagents].
+    "langchain>=1.0",
     "watchfiles>=1.0",
     "click>=8.0",
     "python-dotenv>=1.0",


### PR DESCRIPTION
**Bug (found in prod by the daily QA routine, issue #28):** `langstage.middleware` imports `langchain.agents.middleware` and loads on hot paths (`app`, the `check` CLI, default agent), but `langchain` wasn't declared — it only came transitively via `[deepagents]`. Clean `pip install langstage` → `ModuleNotFoundError: langchain` on `langstage check`/`run`.

**Why CI missed it:** every job installs `.[deepagents(,dev)]`, which pulls langchain transitively and masks the missing declaration. No env ever did a minimal install.

**Fix:** declare `langchain>=1.0` (hard dep). **Guard:** new `minimal-install` CI job installs with NO extras + import/CLI smoke — matches a real user install and would have caught this.

Verified in a clean venv (no extras): `import langstage.middleware` + `langstage check --demo` succeed. Suite 132 passed. Lesson recorded to the brain (`test-environment-parity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)