### PR TITLE
fix: render non-streaming agents (core 0.6.4) + honor LANGSTAGE_WORKSPACE_ROOT (0.11.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.11.2 — 2026-06-20
+
+### Fixed
+- **Custom non-streaming agents replied with nothing in chat (gh #-dogfood).** A
+  `CompiledGraph` whose node returns a finished `AIMessage` (rule-based / router /
+  retrieval agents, or any LLM call outside a token-streaming node) rendered an
+  empty assistant turn. Root cause was in the shared core; bumped
+  `langgraph-stream-parser` to `>=0.6.4`, which emits such content as a fallback.
+- **Canonical `LANGSTAGE_WORKSPACE_ROOT` was ignored** when computing the default
+  agent's workspace — `default_agent.py` read only the deprecated
+  `DEEPAGENT_WORKSPACE_ROOT`. It now reads the canonical name first and warns on
+  the legacy one.
+
 ## 0.11.1 — 2026-06-16
 
 ### Fixed

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 import os
+import warnings
 
 from langgraph_stream_parser.demo import create_default_agent as _build_default_agent
 from langgraph_stream_parser.tasks import TASK_TOOLS
@@ -107,8 +108,20 @@ This applies to EVERY user message, regardless of complexity.
 
 The workspace is your sandbox - feel free to create files, organize content, and help users manage their projects."""
 
-# Get workspace root from environment variable or default to current directory
-workspace_root = os.getenv("DEEPAGENT_WORKSPACE_ROOT", os.getcwd())
+# Workspace root: canonical LANGSTAGE_WORKSPACE_ROOT first, then the deprecated
+# DEEPAGENT_WORKSPACE_ROOT (with a warning), else cwd. Reading only the legacy
+# name meant the canonical var was silently ignored (gh #-dogfood).
+workspace_root = os.getenv("LANGSTAGE_WORKSPACE_ROOT")
+if workspace_root is None:
+    _legacy_ws = os.getenv("DEEPAGENT_WORKSPACE_ROOT")
+    if _legacy_ws is not None:
+        warnings.warn(
+            "DEEPAGENT_WORKSPACE_ROOT is deprecated; use LANGSTAGE_WORKSPACE_ROOT.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        workspace_root = _legacy_ws
+workspace_root = workspace_root or os.getcwd()
 
 # Default tools list used by both global and session agents.
 # Canvas tools are injected by CanvasMiddleware — not included here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.1"
+version = "0.11.2"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -12,7 +12,9 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    "langgraph-stream-parser>=0.6,<0.7",
+    # >=0.6.4 carries the dual-mode content fallback so non-token-streaming
+    # agents render in chat instead of replying blank (gh #-dogfood).
+    "langgraph-stream-parser>=0.6.4,<0.7",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -38,7 +40,7 @@ deepagents = [
     "deepagents>=0.3",
 ]
 agui = [
-    "langgraph-stream-parser[agui]>=0.6,<0.7",
+    "langgraph-stream-parser[agui]>=0.6.4,<0.7",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_canonical_workspace.py
+++ b/tests/test_canonical_workspace.py
@@ -1,0 +1,45 @@
+"""Regression: the default agent's workspace honors canonical
+LANGSTAGE_WORKSPACE_ROOT, not only the deprecated DEEPAGENT_WORKSPACE_ROOT
+(dogfood cluster 2).
+
+``default_agent.workspace_root`` is resolved at import time, so each case runs a
+subprocess with the env set first.
+"""
+import os
+import subprocess
+import sys
+
+
+def _workspace_root(env_overrides: dict) -> str:
+    env = dict(os.environ)
+    for k in list(env):
+        if k.endswith("WORKSPACE_ROOT"):
+            del env[k]
+    env.update(env_overrides)
+    out = subprocess.run(
+        [sys.executable, "-c", "import langstage.default_agent as d; print(d.workspace_root)"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert out.returncode == 0, out.stderr
+    return out.stdout.strip()
+
+
+def test_canonical_workspace_root_is_honored(tmp_path):
+    target = str(tmp_path / "canon")
+    assert _workspace_root({"LANGSTAGE_WORKSPACE_ROOT": target}) == target
+
+
+def test_canonical_beats_legacy(tmp_path):
+    canon = str(tmp_path / "canon")
+    legacy = str(tmp_path / "legacy")
+    got = _workspace_root(
+        {"LANGSTAGE_WORKSPACE_ROOT": canon, "DEEPAGENT_WORKSPACE_ROOT": legacy}
+    )
+    assert got == canon
+
+
+def test_legacy_still_works(tmp_path):
+    legacy = str(tmp_path / "legacy")
+    assert _workspace_root({"DEEPAGENT_WORKSPACE_ROOT": legacy}) == legacy


### PR DESCRIPTION
Clusters 1 (propagation) + 2 from the comprehensive dogfood run.

## #1 — custom non-streaming agents replied blank (major)
A `CompiledGraph` whose node returns a finished `AIMessage` (rule-based / router / retrieval agents, or any LLM call outside a token-streaming node) rendered an **empty** assistant turn over chat (SSE) and as an empty task result. Root cause was in the shared core's dual-mode parsing; fixed in `langgraph-stream-parser` 0.6.4. Bumped the pin (base + `[agui]`) to `>=0.6.4,<0.7` to guarantee web users get the fix.

## #2 — canonical workspace env ignored (minor)
`default_agent.py` read only the deprecated `DEEPAGENT_WORKSPACE_ROOT`, so the canonical `LANGSTAGE_WORKSPACE_ROOT` was silently ignored when computing the agent's workspace. Now reads canonical first, warns on the legacy name, else falls back to cwd.

## Tests
`tests/test_canonical_workspace.py` (subprocess, since `workspace_root` resolves at import): canonical honored, canonical beats legacy, legacy still works. **135 passed.**

Out of cluster (noted, not in this PR): README's WebSocket-vs-SSE wording, bare-`langstage run` install hint, `deepagents.toml` in CLI help text, no `--version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)