### PR TITLE
fix: README documents the real SSE chat transport, not a non-existent /ws/chat (0.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.3 — 2026-06-21
+
+### Fixed
+- **README advertised a `/ws/chat` WebSocket transport that doesn't exist** — the
+  Architecture diagram and Features bullet promised WebSocket; connecting to
+  `/ws/chat` returns **403** (no such route). The real chat transport is
+  Server-Sent Events: `GET /api/stream?session_id=…` + `POST /api/chat`. Corrected
+  the diagram, the Features bullet, and the Stack line. (gh #-dogfood)
+- Bumped the `langgraph-stream-parser` floor to `>=0.6.6` (base + `[agui]`) so
+  dict-form-message agents (`{"role":"assistant","content":…}`) render in chat.
+
 ## 0.11.2 — 2026-06-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="assets/cover.png" alt="Cowork Dash" style="border: 1px solid #d0d7de; border-radius: 6px;" />
 </p>
 
-**Stack**: Python (FastAPI + WebSocket) backend, React (TypeScript + Vite) frontend.
+**Stack**: Python (FastAPI, chat over Server-Sent Events) backend, React (TypeScript + Vite) frontend.
 
 ## Every stage for your LangGraph agent
 
@@ -36,7 +36,7 @@ langstage-agui --agent my_agent.py:graph
 
 ## Features
 
-- **Chat** with real-time token streaming via WebSocket
+- **Chat** with real-time token streaming over Server-Sent Events (`GET /api/stream` + `POST /api/chat`)
 - **Tool call visualization** — inline display of arguments, results, duration, and status
 - **Rich inline content** — HTML, Plotly charts, images, DataFrames, PDFs, and JSON rendered directly in the chat
 - **Canvas panel** — persistent report surface for charts, tables, diagrams, images, and narrative markdown. Opt-in via `CanvasMiddleware`; auto-detected by the UI.
@@ -240,13 +240,16 @@ See [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser
 ## Architecture
 
 ```
-Browser  <--WebSocket-->  FastAPI  <--astream_events-->  LangGraph Agent
-            /ws/chat         |
-                        REST APIs:
-                          /api/config
-                          /api/files/tree
-                          /api/files/{path}
-                          /api/canvas/items
+Browser  <--SSE / REST-->  FastAPI  <--astream_events-->  LangGraph Agent
+                              |
+   chat (Server-Sent Events):  GET /api/stream?session_id=...   (event stream)
+                               POST /api/chat {session_id, content}
+   other REST APIs:            /api/config
+                               /api/files/tree
+                               /api/files/{path}
+                               /api/canvas/items
+                               /api/cron        (schedules)
+                               /api/tasks       (async task board)
 ```
 
 The frontend is pre-built and bundled into the Python package as static files. No Node.js required at runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.2"
+version = "0.11.3"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -14,7 +14,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     # >=0.6.4 carries the dual-mode content fallback so non-token-streaming
     # agents render in chat instead of replying blank (gh #-dogfood).
-    "langgraph-stream-parser>=0.6.4,<0.7",
+    "langgraph-stream-parser>=0.6.6,<0.7",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -40,7 +40,7 @@ deepagents = [
     "deepagents>=0.3",
 ]
 agui = [
-    "langgraph-stream-parser[agui]>=0.6.4,<0.7",
+    "langgraph-stream-parser[agui]>=0.6.6,<0.7",
 ]
 dev = [
     "pytest>=8",


### PR DESCRIPTION
Major (docs) from the dogfood re-run.

The README's **Architecture diagram**, **Features bullet**, and **Stack line** all advertise a WebSocket chat transport at `/ws/chat`. No such route exists — connecting returns **403 Forbidden**, and a package-wide grep for `.websocket(` / `ws/chat` finds nothing. The real chat transport is **Server-Sent Events**: `GET /api/stream?session_id=…` + `POST /api/chat` (`routes_chat.py`, prefix `/api`). A power user wiring a custom client to the documented `/ws/chat` is dead in the water.

Corrected all three doc spots to describe SSE (and added the `/api/cron` + `/api/tasks` routes to the diagram while there).

Also bumped the `langgraph-stream-parser` floor to `>=0.6.6,<0.7` (base + `[agui]`) so dict-form-message agents (`{"role":"assistant","content":…}`) render in chat. **135 tests pass** against core 0.6.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)