### PR TITLE
fix: config.py honors canonical LANGSTAGE_WORKSPACE_ROOT — kill the bash-cwd split-brain (0.11.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.11.5 — 2026-06-22
+
+### Fixed
+- **Workspace split-brain: the agent's `bash`/file tools ignored
+  `LANGSTAGE_WORKSPACE_ROOT`.** 0.11.2 fixed `default_agent.py` to honor the
+  canonical var, but `config.py`'s module-level `WORKSPACE_ROOT` / `VIRTUAL_FS`
+  still read **only** the legacy `DEEPAGENT_*` names — and `tools.py` uses
+  `config.WORKSPACE_ROOT` as the `bash` cwd. So with only `LANGSTAGE_WORKSPACE_ROOT`
+  set, the file browser used the canonical workspace while `bash`/file tools ran in
+  cwd (the 0.11.2 entry over-claimed the fix). `config.py` is now canonical-first
+  (legacy fallback + warning) for both vars, and is the **single source** —
+  `default_agent.py` imports `config.WORKSPACE_ROOT` instead of resolving its own
+  copy, so the agent and tools can never disagree again. (gh #-dogfood)
+
 ## 0.11.4 — 2026-06-21
 
 ### Fixed

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -6,11 +6,29 @@ resolved through the shared chain — defaults < deepagents.toml < DEEPAGENT_* e
 < overrides (Python/CLI args). cowork gains `deepagents.toml` support this way.
 """
 import os
+import warnings
 from dataclasses import dataclass, fields, replace
 from pathlib import Path
 from typing import Any, ClassVar, Optional
 
 from langgraph_stream_parser.host import HostConfig
+
+
+def _env_canonical_first(canonical: str, legacy: str) -> Optional[str]:
+    """Read an env var by its canonical ``LANGSTAGE_*`` name, falling back to the
+    deprecated ``DEEPAGENT_*`` name (with a warning). Canonical wins."""
+    value = os.getenv(canonical)
+    if value is not None:
+        return value
+    legacy_value = os.getenv(legacy)
+    if legacy_value is not None:
+        warnings.warn(
+            f"{legacy} is deprecated; use {canonical}.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return legacy_value
+    return None
 
 
 def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
@@ -29,10 +47,16 @@ def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
     return None
 
 
-# Module-level constants used by tools.py and default_agent.py (independent of
-# AppConfig — read directly from the environment at import).
-WORKSPACE_ROOT = Path(os.getenv("DEEPAGENT_WORKSPACE_ROOT", os.getcwd()))
-VIRTUAL_FS = os.getenv("DEEPAGENT_VIRTUAL_FS", "").lower() in ("1", "true", "yes")
+# Module-level constants used by tools.py (bash cwd + file tools) and
+# default_agent.py. Canonical LANGSTAGE_* first, deprecated DEEPAGENT_* fallback.
+# Reading ONLY the legacy names here while default_agent.py honored the canonical
+# LANGSTAGE_WORKSPACE_ROOT created a split-brain: the file browser used the
+# canonical workspace but the agent's bash/file tools ran in cwd (gh #-dogfood).
+# This is the single source — default_agent.py imports WORKSPACE_ROOT from here.
+_ws = _env_canonical_first("LANGSTAGE_WORKSPACE_ROOT", "DEEPAGENT_WORKSPACE_ROOT")
+WORKSPACE_ROOT = Path(_ws) if _ws else Path(os.getcwd())
+_vfs = _env_canonical_first("LANGSTAGE_VIRTUAL_FS", "DEEPAGENT_VIRTUAL_FS")
+VIRTUAL_FS = (_vfs or "").lower() in ("1", "true", "yes")
 
 _SAVE_PROMPT = (
     "Please capture this conversation as a detailed workflow markdown file in "

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -5,12 +5,10 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-import os
-import warnings
-
 from langgraph_stream_parser.demo import create_default_agent as _build_default_agent
 from langgraph_stream_parser.tasks import TASK_TOOLS
 
+from langstage.config import WORKSPACE_ROOT as _WORKSPACE_ROOT
 from langstage.middleware import CanvasMiddleware
 from langstage.scheduler import CRON_TOOLS
 from langstage.tools import (
@@ -108,20 +106,13 @@ This applies to EVERY user message, regardless of complexity.
 
 The workspace is your sandbox - feel free to create files, organize content, and help users manage their projects."""
 
-# Workspace root: canonical LANGSTAGE_WORKSPACE_ROOT first, then the deprecated
-# DEEPAGENT_WORKSPACE_ROOT (with a warning), else cwd. Reading only the legacy
-# name meant the canonical var was silently ignored (gh #-dogfood).
-workspace_root = os.getenv("LANGSTAGE_WORKSPACE_ROOT")
-if workspace_root is None:
-    _legacy_ws = os.getenv("DEEPAGENT_WORKSPACE_ROOT")
-    if _legacy_ws is not None:
-        warnings.warn(
-            "DEEPAGENT_WORKSPACE_ROOT is deprecated; use LANGSTAGE_WORKSPACE_ROOT.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        workspace_root = _legacy_ws
-workspace_root = workspace_root or os.getcwd()
+# Workspace root comes from langstage.config — the SINGLE source (canonical
+# LANGSTAGE_WORKSPACE_ROOT first, deprecated DEEPAGENT_WORKSPACE_ROOT fallback,
+# else cwd). The bash/file tools read the same config.WORKSPACE_ROOT, so the agent
+# and the tools can never disagree about the workspace (gh #-dogfood). Previously
+# this file resolved it independently and the two drifted — a split-brain where
+# the file browser used the canonical workspace but bash ran in cwd.
+workspace_root = str(_WORKSPACE_ROOT)
 
 # Default tools list used by both global and session agents.
 # Canvas tools are injected by CanvasMiddleware — not included here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.4"
+version = "0.11.5"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_canonical_workspace.py
+++ b/tests/test_canonical_workspace.py
@@ -43,3 +43,37 @@ def test_canonical_beats_legacy(tmp_path):
 def test_legacy_still_works(tmp_path):
     legacy = str(tmp_path / "legacy")
     assert _workspace_root({"DEEPAGENT_WORKSPACE_ROOT": legacy}) == legacy
+
+
+def _config_and_tools_and_agent_roots(env_overrides: dict) -> tuple[str, str, str]:
+    """Return (config.WORKSPACE_ROOT, tools.WORKSPACE_ROOT, agent.workspace_root)
+    — all resolved at import, so run a subprocess with the env set first."""
+    env = dict(os.environ)
+    for k in list(env):
+        if k.endswith("WORKSPACE_ROOT"):
+            del env[k]
+    env.update(env_overrides)
+    code = (
+        "import langstage.config as c, langstage.tools as t, langstage.default_agent as d;"
+        "print(c.WORKSPACE_ROOT); print(t.WORKSPACE_ROOT); print(d.workspace_root)"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert out.returncode == 0, out.stderr
+    cfg, tools, agent = out.stdout.strip().splitlines()[-3:]
+    return cfg, tools, agent
+
+
+def test_config_tools_agent_agree_on_canonical_workspace(tmp_path):
+    """No split-brain: config.WORKSPACE_ROOT (the bash cwd via tools) and the
+    agent's workspace must both honor canonical LANGSTAGE_WORKSPACE_ROOT and
+    agree — config.py used to read only the legacy name (gh #-dogfood)."""
+    from pathlib import Path
+
+    target = str(tmp_path / "canon")
+    cfg, tools, agent = _config_and_tools_and_agent_roots(
+        {"LANGSTAGE_WORKSPACE_ROOT": target}
+    )
+    assert Path(cfg) == Path(target), f"config.WORKSPACE_ROOT ignored canonical: {cfg}"
+    assert Path(tools) == Path(target), f"bash cwd ignored canonical: {tools}"
+    assert Path(agent) == Path(target)
+    assert Path(cfg) == Path(tools) == Path(agent)  # no split-brain


### PR DESCRIPTION
**Major regression caught by the nightly routine.**

0.11.2 fixed `default_agent.py` to honor canonical `LANGSTAGE_WORKSPACE_ROOT` — but `config.py`'s module-level `WORKSPACE_ROOT` / `VIRTUAL_FS` still read **only** the legacy `DEEPAGENT_*` names (`config.py:34-35`), and `tools.py` uses `config.WORKSPACE_ROOT` as the `bash` cwd (`tools.py:1596`). So with only `LANGSTAGE_WORKSPACE_ROOT` set:
- file browser → canonical workspace ✓
- agent `bash`/file tools → **cwd** ✗  → **split-brain**

…and the 0.11.2 CHANGELOG claimed this exact bug was fixed.

## Fix
- `config.py` `WORKSPACE_ROOT` / `VIRTUAL_FS` are now **canonical-first** (legacy fallback + `DeprecationWarning`).
- `config.py` is the **single source**: `default_agent.py` now imports `config.WORKSPACE_ROOT` instead of resolving its own copy. The duplicated resolution is exactly what let this regress — now they can't drift.

## Verified
With only `LANGSTAGE_WORKSPACE_ROOT` set, `config.WORKSPACE_ROOT`, `tools.WORKSPACE_ROOT` (bash cwd), and the agent's `workspace_root` all resolve to the canonical path and agree. New regression test `test_config_tools_agent_agree_on_canonical_workspace`. **138 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)