### PR TITLE
fix: /api/files path-escape returns 400 not 500 (0.11.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.11.6 — 2026-06-22
+
+### Fixed
+- **`/api/files/*` returned 500 on a path that escapes the workspace.** The
+  workspace boundary held (no traversal — `_resolve_path` raised
+  `ValueError("Path escapes workspace: …")`), but on `read`, `preview`, and
+  `tree` that error propagated uncaught into a generic 500, while the sibling
+  routes (`download`/`mkdir`/`delete`) already mapped it to a clean 400. Those
+  three now return **400** too, matching the rest of the file API. (Found by the
+  dogfood routine.)
+
 ## 0.11.5 — 2026-06-22
 
 ### Fixed

--- a/langstage/server/routes_files.py
+++ b/langstage/server/routes_files.py
@@ -25,6 +25,10 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
             return tree
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail=f"Path not found: {path}")
+        except ValueError as e:
+            # Path escapes the workspace — the boundary holds (no traversal), but
+            # return a clean 400 instead of letting it fall through to a 500.
+            raise HTTPException(status_code=400, detail=str(e))
 
     @r.get("/read")
     async def read_file(
@@ -37,6 +41,9 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"File not found: {path}")
         except IsADirectoryError:
             raise HTTPException(status_code=400, detail=f"Path is a directory: {path}")
+        except ValueError as e:
+            # Path escapes the workspace — boundary holds; return 400, not 500.
+            raise HTTPException(status_code=400, detail=str(e))
 
     @r.get("/preview")
     async def preview_file(
@@ -49,6 +56,9 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
             raise HTTPException(status_code=404, detail=f"File not found: {path}")
         except IsADirectoryError:
             raise HTTPException(status_code=400, detail=f"Path is a directory: {path}")
+        except ValueError as e:
+            # Path escapes the workspace — boundary holds; return 400, not 500.
+            raise HTTPException(status_code=400, detail=str(e))
 
     @r.get("/download")
     async def download_file(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.5"
+version = "0.11.6"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -85,6 +85,21 @@ async def test_files_read_not_found(client):
 
 
 @pytest.mark.asyncio
+async def test_files_read_path_escape_returns_400_not_500(client):
+    # A path that escapes the workspace must be rejected cleanly. The boundary
+    # holds either way (no traversal), but the path-escape ValueError used to
+    # propagate uncaught -> 500 instead of the 400 the sibling cases return.
+    resp = await client.get("/api/files/read?path=/../../../../etc/passwd")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_files_tree_path_escape_returns_400_not_500(client):
+    resp = await client.get("/api/files/tree?path=/../../../..")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_canvas_empty(client):
     resp = await client.get("/api/canvas/items")
     assert resp.status_code == 200


### PR DESCRIPTION
From the daily dogfood routine.

## The bug
`GET /api/files/read?path=/../../../../etc/passwd` returned **500 Internal Server Error**. The workspace boundary held (no traversal — `file_manager._resolve_path` raised `ValueError("Path escapes workspace: …")`), but on `read`, `preview`, and `tree` that error propagated uncaught into a generic 500. The sibling routes (`download`/`mkdir`/`delete`) already caught `ValueError` and returned a clean **400**.

## The fix
`read`, `preview`, and `tree` now catch the path-escape `ValueError` and return **400**, matching the rest of the file API. No behavior change to the boundary — only the error contract.

## Tests
- `test_files_read_path_escape_returns_400_not_500`
- `test_files_tree_path_escape_returns_400_not_500`

(5 file-route tests pass.)
