### PR TITLE
fix: auth_username default admin lives in config so --show-config agrees (0.11.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.11.7 — 2026-06-26
+
+### Fixed
+- **`--show-config` reported `auth_username` as empty when the effective default
+  is `admin`.** The `admin` default lived only in the auth middleware
+  (`auth_username or "admin"`), not the config layer that `--show-config`
+  renders — so a user enabling auth and consulting the documented config
+  inspector to find their login username saw a blank, while the server enforced
+  `admin`. The default now lives in `config.py` (`auth_username: str = "admin"`),
+  so `--show-config`, `--help`, the README table, and the runtime all agree.
+  (Auth stays inert unless a password is set, so this has no security effect.)
+  (Found by the dogfood routine, gh #35.)
+
 ## 0.11.6 — 2026-06-22
 
 ### Fixed

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -86,7 +86,11 @@ class AppConfig(HostConfig):
     theme: str = "auto"  # "light" | "dark" | "auto"
     agent_name: str = "Agent"
     icon_url: str = ""
-    auth_username: str = ""
+    # Default "admin" lives here (the resolved-config layer) so --show-config,
+    # --help, the README, and the runtime all agree on the effective username.
+    # Auth is inert unless auth_password is set, so this has no security effect.
+    # (gh #35)
+    auth_username: str = "admin"
     auth_password: str = ""
     save_workflow_prompt: str = _SAVE_PROMPT
     run_workflow_prompt: str = _RUN_PROMPT

--- a/langstage/server/middleware.py
+++ b/langstage/server/middleware.py
@@ -61,7 +61,7 @@ class BasicAuthMiddleware:
 def add_middleware(
     app: FastAPI,
     debug: bool = False,
-    auth_username: str = "",
+    auth_username: str = "admin",
     auth_password: str = "",
 ) -> None:
     """Add middleware stack. CORS is always added; basic auth is conditional."""
@@ -81,7 +81,8 @@ def add_middleware(
         allow_headers=["*"],
     )
 
-    # Basic auth (only when a password is configured)
+    # Basic auth (only when a password is configured). The "admin" default now
+    # lives in the config layer, so use the resolved value directly — what
+    # --show-config displays is exactly what the server enforces. (gh #35)
     if auth_password:
-        username = auth_username or "admin"
-        app.add_middleware(BasicAuthMiddleware, username=username, password=auth_password)
+        app.add_middleware(BasicAuthMiddleware, username=auth_username or "admin", password=auth_password)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.6"
+version = "0.11.7"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,19 @@ def test_show_config_prints_resolved_config():
     assert "DEEPAGENT_AGENT_SPEC" in result.output
 
 
+def test_show_config_auth_username_default_is_admin():
+    # gh #35: the effective default (and what the server enforces) is "admin";
+    # --show-config must not show it as blank.
+    from langstage.config import AppConfig
+
+    assert AppConfig().auth_username == "admin"
+    result = CliRunner().invoke(cli_mod.main, ["--show-config"])
+    assert result.exit_code == 0
+    import re
+
+    assert re.search(r"auth_username\s*=\s*admin", result.output), result.output
+
+
 def test_bare_invocation_prints_help():
     result = CliRunner().invoke(cli_mod.main, [])
     assert result.exit_code == 0


### PR DESCRIPTION
From the daily dogfood routine (Fixes #35). The admin default lived only in the auth middleware, not the config layer --show-config renders -- so a user enabling auth and consulting the documented config inspector for their login username saw a blank while the server enforced admin. The default now lives in config.py, so --show-config, --help, the README table, and the runtime all agree. Auth stays inert unless a password is set, so no security effect. Test: AppConfig().auth_username == admin and --show-config shows it. 141 tests pass.