### PR TITLE
fix: cron next_run computed synchronously on create (0.11.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.11.8 — 2026-06-27
+
+### Fixed
+- **`POST /api/cron` (and the `schedule_run` agent tool) returned `next_run:
+  null` on a running server.** `add_job` computed `next_run` synchronously only
+  when the scheduler hadn't started yet; on a live server it deferred to the run
+  loop, which hadn't fired when the create response / tool message was
+  serialized — so the two places a user looks right after creating a schedule
+  showed no next fire time (a follow-up `GET` already had it, and the agent
+  always said "Next run: pending"). `next_run` is now computed synchronously in
+  `add_job` regardless of started state; the run loop keeps refreshing it.
+  (Found by the dogfood routine, gh #37.)
+
 ## 0.11.7 — 2026-06-26
 
 ### Fixed

--- a/langstage/scheduler.py
+++ b/langstage/scheduler.py
@@ -105,10 +105,14 @@ class CronScheduler:
             created_by=created_by,
         )
         self._jobs[job.id] = job
+        # Compute next_run synchronously so the POST create response and the
+        # schedule_run tool's confirmation message carry it immediately. On a
+        # started scheduler _start_job's run loop keeps refreshing it; without
+        # this, a live server deferred next_run to the loop and returned null on
+        # create (only a follow-up GET showed it). (gh #37)
+        job.next_run = self._compute_next(job.cron)
         if self._started:
             self._start_job(job)
-        else:
-            job.next_run = self._compute_next(job.cron)
         return job
 
     def remove_job(self, job_id: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.7"
+version = "0.11.8"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -97,6 +97,31 @@ async def test_run_now():
     assert len(runner.enqueued) == 1
 
 
+async def test_next_run_populated_on_create_for_started_scheduler():
+    # gh #37: on a live (started) server, add_job used to defer next_run to the
+    # run loop, so the POST create response (and schedule_run) returned null.
+    s = CronScheduler(FakeRunner())
+    s.start()  # _started=True; creates run-loop tasks (needs the running loop)
+    try:
+        job = s.add_job(name="daily3", cron="0 9 * * 1-5", prompt="morning")
+        assert job.next_run, "next_run must be set synchronously on create"
+    finally:
+        s.shutdown()
+
+
+async def test_schedule_run_tool_reports_next_run_on_started_scheduler():
+    s = CronScheduler(FakeRunner())
+    s.start()
+    set_scheduler(s)
+    try:
+        out = schedule_run.invoke({"name": "nightly", "cron": "0 9 * * 1-5", "prompt": "p"})
+        assert "Next run: pending" not in out
+        assert "Next run:" in out
+    finally:
+        set_scheduler(None)
+        s.shutdown()
+
+
 # ── agent tools ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
From the daily dogfood routine (Fixes #37). add_job computed next_run synchronously only when the scheduler had not started; on a live server it deferred to the run loop, which had not fired when the POST /api/cron create response (and the schedule_run tool message) were serialized -- so both returned next_run=null / 'Next run: pending,' even though a follow-up GET already had it. next_run is now computed synchronously in add_job regardless of started state; the run loop keeps refreshing it. Tests: a started scheduler's add_job has next_run on create; schedule_run no longer says 'pending' on a started scheduler. 11 scheduler tests pass.