### PR TITLE
check: fail preflight for non-runnable agents (#39)

### DIFF
--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -126,6 +126,25 @@ def check(agent_spec, demo):
     except Exception as e:  # noqa: BLE001 - report load failure cleanly
         click.echo(f"{click.style('[fail]', fg='red')} failed to load: {e}")
         raise SystemExit(1)
+
+    # Loading the object is not enough — the server drives the agent via
+    # astream(), so a non-runnable object (an uncompiled StateGraph, a dict, an
+    # int) starts fine and then dies mid-stream with "'X' object has no attribute
+    # 'astream'". Preflight exists to catch exactly that, so gate the all-clear
+    # on runnability instead of reporting `[ ok ] loads` for any object. (gh #39)
+    fail = click.style("[fail]", fg="red")
+    if not callable(getattr(agent, "astream", None)):
+        if callable(getattr(agent, "compile", None)):
+            # The single most common BYO mistake: exported the builder, not the
+            # compiled graph (forgot `.compile()`).
+            click.echo(f"{fail} not runnable: this is an uncompiled "
+                       f"{type(agent).__name__} - call .compile() and export the result")
+        else:
+            click.echo(f"{fail} not runnable: loaded a {type(agent).__name__}, which is not "
+                       "a LangGraph graph (no astream()). Export a compiled graph "
+                       "(module:attr or path/to/file.py:attr).")
+        raise SystemExit(1)
+
     click.echo(f"{ok} loads")
     name = getattr(agent, "name", None)
     if name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.11.8"
+version = "0.11.9"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,3 +61,42 @@ def test_agent_short_flag(monkeypatch):
     result = CliRunner().invoke(cli_mod.main, ["run", "-a", "my.py:g", "--no-browser"])
     assert result.exit_code == 0, result.output
     assert FakeApp.captured["agent_spec"] == "my.py:g"
+
+
+def _write(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text(body)
+    return p
+
+
+def test_check_fails_on_uncompiled_stategraph(tmp_path):
+    """Preflight must catch the #1 BYO mistake — exporting the builder, not the
+    compiled graph — instead of a confident `[ ok ] loads` + exit 0. (gh #39)"""
+    agent = _write(tmp_path, "uncompiled.py",
+                   "from langgraph.graph import StateGraph, MessagesState\n"
+                   "b = StateGraph(MessagesState)\n"
+                   "b.add_node('respond', lambda s: {'messages': []})\n"
+                   "b.set_entry_point('respond')\n"
+                   "graph = b  # forgot .compile()\n")
+    result = CliRunner().invoke(cli_mod.main, ["check", "--agent", f"{agent}:graph"])
+    assert result.exit_code == 1, result.output
+    assert "not runnable" in result.output
+    assert "uncompiled" in result.output
+    assert "[ ok ] loads" not in result.output
+
+
+def test_check_fails_on_non_graph_object(tmp_path):
+    """A dict / int / str is not a runnable graph; preflight must fail, not pass."""
+    for body in ("graph = 42\n", "graph = {'x': 1}\n", "graph = 'my_agent'\n"):
+        agent = _write(tmp_path, "obj.py", body)
+        result = CliRunner().invoke(cli_mod.main, ["check", "--agent", f"{agent}:graph"])
+        assert result.exit_code == 1, result.output
+        assert "not runnable" in result.output
+        assert "[ ok ] loads" not in result.output
+
+
+def test_check_passes_for_demo_agent():
+    """A real compiled graph still preflights green."""
+    result = CliRunner().invoke(cli_mod.main, ["check", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "[ ok ] loads" in result.output


### PR DESCRIPTION
## Problem

`langstage check` is the preflight doctor, and its first check is `[ ok ] loads`. But it printed `[ ok ] loads` and a full green report (exit 0) for **any** object — an uncompiled `StateGraph` (the #1 BYO mistake: forgot `.compile()`), a `dict`, a `str`, an `int`. The server then started, accepted `POST /api/chat` with 200, and only failed mid-stream with `AttributeError: 'StateGraph' object has no attribute 'astream'`. The tool whose job is to catch "your agent won't run" gave a confident all-clear for exactly that failure.

Fixes #39.

## Fix

Gate the all-clear on **runnability**: the server drives the agent via `astream()`, so if the loaded object has no callable `astream()`, preflight fails (exit 1) with a clear message — and specifically names the uncompiled-`StateGraph` case, telling the user to call `.compile()`. A real compiled graph preflights green exactly as before.

## Tests

`tests/test_cli.py`: uncompiled StateGraph and non-graph objects (dict/int/str) now exit 1 with "not runnable" and no `[ ok ] loads`; the demo agent still passes. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
