### PR TITLE
Fix path traversal in the workspace file API (#41)

### DIFF
--- a/langstage/workspace/file_manager.py
+++ b/langstage/workspace/file_manager.py
@@ -304,7 +304,12 @@ class FileManager:
         else:
             resolved = self.workspace
 
-        # Ensure path is within workspace (prevent directory traversal)
-        if not str(resolved).startswith(str(self.workspace)):
+        # Confine to the workspace by path containment, NOT a string prefix. A bare
+        # startswith() match has no path-separator boundary, so a *sibling* directory
+        # that shares the workspace's name as a prefix (ws-secret, ws.bak, ws2, ...)
+        # slips through and becomes readable/writable/deletable via ../-relative
+        # paths. is_relative_to() is true only for the workspace itself or a real
+        # descendant. (gh #41)
+        if not resolved.is_relative_to(self.workspace):
             raise ValueError(f"Path escapes workspace: {path}")
         return resolved

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.12.0"
+version = "0.12.1"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -56,3 +56,27 @@ def test_csv_language(workspace):
     fm = FileManager(workspace)
     content = fm.read_file("/data.csv")
     assert content["language"] == "csv"
+
+
+def test_sibling_prefix_dir_cannot_escape_workspace(tmp_path):
+    """A sibling dir sharing the workspace's name prefix must NOT be reachable.
+
+    The old guard used a plain str startswith() with no separator boundary, so
+    `ws-secret` passed the check for workspace `ws` and a ../-relative path could
+    read/write/delete outside the workspace. (gh #41 — path traversal)
+    """
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    sibling = tmp_path / "ws_secret"
+    sibling.mkdir()
+    (sibling / "passwd.txt").write_text("SECRET outside the workspace")
+    (ws / "inside.txt").write_text("ok")
+
+    fm = FileManager(ws)
+    # Legitimate in-workspace access still works.
+    assert fm._resolve_path("inside.txt").name == "inside.txt"
+    assert fm._resolve_path("/").resolve() == ws.resolve()
+    # Every traversal into the prefix-sharing sibling is rejected.
+    for escape in ("../ws_secret/passwd.txt", "../ws_secret", "/../ws_secret/passwd.txt"):
+        with pytest.raises(ValueError, match="escapes workspace"):
+            fm._resolve_path(escape)


### PR DESCRIPTION
## Problem (security — path traversal)

The `/api/files/*` workspace endpoints confined paths with a plain string prefix match in `FileManager._resolve_path`:

```python
if not str(resolved).startswith(str(self.workspace)):
    raise ValueError(...)
```

That has **no path-separator boundary**, so any *sibling* directory whose name shares the workspace dir's name as a prefix — `ws-secret`, `ws.bak`, `ws2`, `workspace_secret`, … — passes the check. A `../`-relative path then reads, writes, creates, or **deletes** files outside the workspace, across every file route (read/tree/download/preview/upload/mkdir/delete) since they all funnel through `_resolve_path`. Auth is off by default, so a default `langstage run` exposes this to any local client and to the agent's own host file tools.

```
$ curl -s 'http://localhost:8097/api/files/read?path=../workspace_secret/passwd.txt'
{"content":"secret OUTSIDE the workspace\n", ...}   # HTTP 200 — escaped
```

Fixes #41.

## Fix

Confine by **path containment**, not a string prefix: `resolved.is_relative_to(self.workspace)` is true only for the workspace itself or a real descendant. (`is_relative_to` is 3.9+; the package is ≥3.11.)

## Tests

`tests/test_file_manager.py`: a `ws` / `ws_secret` pair — legit in-workspace access still works; every `../ws_secret` traversal is now rejected with "escapes workspace". Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
