### PR TITLE
Thread the resolved workspace into the agent's tools (#44)

### DIFF
--- a/langstage/app.py
+++ b/langstage/app.py
@@ -1,6 +1,7 @@
 """CoworkApp — main entry point for the application."""
 
 import logging
+import os
 import webbrowser
 from pathlib import Path
 
@@ -74,6 +75,21 @@ class CoworkApp:
 
         # Ensure workspace directory exists
         self.config.workspace_root.mkdir(parents=True, exist_ok=True)
+
+        # Unify the workspace across the WHOLE app on the RESOLVED value (Python
+        # kwarg / CLI --workspace / langstage.toml / env), not just the env var.
+        # The agent's bash/file/canvas tools read langstage.config.WORKSPACE_ROOT
+        # (and some agents read the env var), so set both from the resolved config
+        # BEFORE the agent + tools are built. Otherwise --workspace/toml/Python
+        # reach the file browser but the agent's tools keep running in the launch
+        # cwd — a split-brain where only the env var (lowest documented priority)
+        # actually reached the agent. (gh #44)
+        from langstage import config as _config
+
+        _resolved_ws = self.config.workspace_root.resolve()
+        _config.WORKSPACE_ROOT = _resolved_ws
+        os.environ["LANGSTAGE_WORKSPACE_ROOT"] = str(_resolved_ws)
+        os.environ["DEEPAGENT_WORKSPACE_ROOT"] = str(_resolved_ws)
 
         self.agent = self._resolve_agent(agent)
         self.stream_parser_config = stream_parser_config or {}

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -139,29 +139,40 @@ AGENT_MIDDLEWARE = [CanvasMiddleware()]
 # Global agent for physical filesystem mode (writes to disk via the shared
 # demo factory's FilesystemBackend + InMemorySaver boilerplate). Cowork supplies
 # the prompt, notebook/display tools, canvas middleware, and bash interrupt.
-agent = _build_default_agent(
-    workspace=workspace_root,
-    model=None,  # let deepagents pick its default model (prior behavior)
-    name="LangStage",
-    system_prompt=SYSTEM_PROMPT,
-    tools=AGENT_TOOLS,
-    middleware=AGENT_MIDDLEWARE,
-    interrupt_on=dict(bash=True),
-    virtual_mode=True,
-)
-# Preserve the middleware list for runtime introspection. deepagents fuses
-# middleware into the compiled graph, so we stash the originals so that
-# agent_uses_canvas_middleware() can still detect them.
-agent.middleware = AGENT_MIDDLEWARE
-# The demo factory gives us an in-memory checkpointer; mark it so the server
-# upgrades it to a durable SQLite one at startup (survives restarts).
-agent._langstage_auto_checkpointer = True
+def _make_default_agent(ws_root: str):
+    """Build the LangStage default deepagent rooted at ``ws_root``."""
+    a = _build_default_agent(
+        workspace=ws_root,
+        model=None,  # let deepagents pick its default model (prior behavior)
+        name="LangStage",
+        system_prompt=SYSTEM_PROMPT,
+        tools=AGENT_TOOLS,
+        middleware=AGENT_MIDDLEWARE,
+        interrupt_on=dict(bash=True),
+        virtual_mode=True,
+    )
+    # Preserve the middleware list for runtime introspection. deepagents fuses
+    # middleware into the compiled graph, so we stash the originals so that
+    # agent_uses_canvas_middleware() can still detect them.
+    a.middleware = AGENT_MIDDLEWARE
+    # The demo factory gives us an in-memory checkpointer; mark it so the server
+    # upgrades it to a durable SQLite one at startup (survives restarts).
+    a._langstage_auto_checkpointer = True
+    return a
+
+
+# Module-level default (built from the config/env workspace) for any import-time
+# consumers. CoworkApp rebuilds rooted at the RESOLVED workspace via
+# create_default_agent(), so --workspace/toml/Python reach the agent too. (gh #44)
+agent = _make_default_agent(workspace_root)
 
 
 def create_default_agent(workspace: Path):
-    """Create a default deepagent with filesystem access.
+    """Create a default deepagent with filesystem access, rooted at ``workspace``.
 
-    Requires deepagents to be installed and an LLM API key
-    (e.g. ANTHROPIC_API_KEY) to be set.
+    Builds a fresh agent for the given workspace, so the agent's tools run in the
+    same resolved workspace the file browser uses — not the import-time env/cwd
+    default. Requires deepagents installed and an LLM API key
+    (e.g. ANTHROPIC_API_KEY). (gh #44)
     """
-    return agent
+    return _make_default_agent(str(workspace))

--- a/langstage/tools.py
+++ b/langstage/tools.py
@@ -1590,10 +1590,15 @@ def bash(command: str, timeout: int = 60) -> Dict[str, Any]:
         return _bash_sandboxed(command, timeout)
 
     try:
+        # Read the workspace dynamically from config (not the import-bound copy),
+        # so CoworkApp's resolved --workspace/toml/Python value is honored — not
+        # just whatever the env was at import time. (gh #44)
+        from . import config as cfg
+
         result = subprocess.run(
             command,
             shell=True,
-            cwd=str(WORKSPACE_ROOT),
+            cwd=str(cfg.WORKSPACE_ROOT),
             capture_output=True,
             text=True,
             timeout=timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.12.1"
+version = "0.12.2"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_canonical_workspace.py
+++ b/tests/test_canonical_workspace.py
@@ -77,3 +77,44 @@ def test_config_tools_agent_agree_on_canonical_workspace(tmp_path):
     assert Path(tools) == Path(target), f"bash cwd ignored canonical: {tools}"
     assert Path(agent) == Path(target)
     assert Path(cfg) == Path(tools) == Path(agent)  # no split-brain
+
+
+def test_cli_workspace_reaches_agent_bash(tmp_path):
+    """--workspace / CoworkApp(workspace=) must reach the agent's bash tool, not
+    just the file browser. Previously only the env var (lowest documented
+    priority) reached the agent; CLI/TOML/Python were dropped. (gh #44)
+
+    Run in a subprocess so the global config.WORKSPACE_ROOT mutation can't leak.
+    """
+    launch = tmp_path / "launch"
+    project = launch / "project"
+    project.mkdir(parents=True)
+    agent = launch / "bashpwd.py"
+    agent.write_text(
+        "from langgraph.graph import StateGraph, MessagesState, START, END\n"
+        "from langchain_core.messages import AIMessage\n"
+        "from langstage.tools import bash\n"
+        "def respond(s):\n"
+        "    return {'messages': [AIMessage(content=bash('pwd')['stdout'].strip())]}\n"
+        "b = StateGraph(MessagesState); b.add_node('respond', respond)\n"
+        "b.add_edge(START, 'respond'); b.add_edge('respond', END)\n"
+        "graph = b.compile()\n"
+    )
+    code = (
+        f"from langstage import CoworkApp; "
+        f"CoworkApp(agent_spec=r'{agent}:graph', workspace='./project', port=8190); "
+        "import langstage.config as cfg; from langstage.tools import bash; "
+        "print('WS=' + str(cfg.WORKSPACE_ROOT)); "
+        "print('BASH=' + bash('pwd')['stdout'].strip())"
+    )
+    env = {k: v for k, v in os.environ.items() if not k.endswith("WORKSPACE_ROOT")}
+    out = subprocess.run(
+        [sys.executable, "-c", code], cwd=str(launch), env=env, capture_output=True, text=True
+    )
+    assert out.returncode == 0, out.stderr
+    ws = next(line[3:] for line in out.stdout.splitlines() if line.startswith("WS="))
+    bashpwd = next(line[5:] for line in out.stdout.splitlines() if line.startswith("BASH="))
+    # Both the tools' workspace and the agent's bash cwd resolve to ./project,
+    # not the launch cwd.
+    assert os.path.basename(ws.rstrip("/\\")) == "project", ws
+    assert os.path.basename(bashpwd.rstrip("/")) == "project", bashpwd


### PR DESCRIPTION
## Problem

LangStage has one documented **Workspace** setting (`--workspace` / `LANGSTAGE_WORKSPACE_ROOT` / `langstage.toml [workspace] root` / `CoworkApp(workspace=)`), priority `Python > CLI > env > defaults`. But only the **env var** reached the agent's `bash`/file/canvas tools — `--workspace`, the TOML key, and the Python kwarg were honored by the **file browser** yet **silently dropped** for the agent, which kept running in the launch cwd.

```
$ langstage run --agent bashpwd.py:graph --workspace ./project ...
file browser root: project          # ✅ honored
agent bash ran in: /.../repro        # ❌ launch cwd, not ./project — files land outside the workspace
```

So an agent you intended to confine to `./project` actually operated relative to wherever you launched the server, and its files were invisible in the browser. The lowest-priority source (env) was the *only* one that reached the agent — inverting the documented order, and re-opening the very split-brain the code comments claim was fixed.

Fixes #44.

## Root cause

`config.WORKSPACE_ROOT` is an env-only module constant read at import; `bash` used it directly (import-bound), and `create_default_agent()` discarded the workspace it was handed and returned a module-global agent built from that env/cwd constant — while `app.py` wired the *resolved* workspace only into the `FileManager`.

## Fix

- `CoworkApp.__init__` sets `config.WORKSPACE_ROOT` (and the env vars) from the resolved config **before** the agent + tools are built — unifying the whole app on the resolved workspace.
- `bash` reads `config.WORKSPACE_ROOT` **dynamically** (not the import-bound copy).
- `create_default_agent(workspace)` builds a fresh agent rooted at the passed workspace instead of returning the env/cwd module global.

## Tests

`tests/test_canonical_workspace.py`: with `CoworkApp(workspace="./project")` from a different launch cwd, both `config.WORKSPACE_ROOT` and the agent's `bash` cwd resolve to `./project` (subprocess-isolated). Full suite: 148 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
