### PR TITLE
feat: experimental --agui chat path (ADR 0002, web — final surface)

### DIFF
--- a/langstage/config.py
+++ b/langstage/config.py
@@ -9,7 +9,7 @@ import os
 import warnings
 from dataclasses import dataclass, fields, replace
 from pathlib import Path
-from typing import Any, ClassVar, Optional
+from typing import ClassVar, Optional
 
 from langgraph_stream_parser.host import HostConfig
 
@@ -102,6 +102,10 @@ class AppConfig(HostConfig):
     # None means auto-resolve (canvas auto-detects middleware; files defaults True).
     show_canvas: Optional[bool] = None
     show_files: Optional[bool] = None
+    # [experimental] Stream chat through the in-process AG-UI adapter instead of
+    # the built-in StreamParser (ADR 0002). Opt-in via LANGSTAGE_AGUI=1. Requires
+    # the agui extra: pip install "langstage[agui]".
+    agui: Optional[bool] = None
 
     _ENV: ClassVar[dict] = {
         "subtitle": ("DEEPAGENT_SUBTITLE", str),
@@ -117,6 +121,7 @@ class AppConfig(HostConfig):
         "custom_css": ("DEEPAGENT_CUSTOM_CSS", str),
         "show_canvas": ("DEEPAGENT_SHOW_CANVAS", _parse_optional_bool),
         "show_files": ("DEEPAGENT_SHOW_FILES", _parse_optional_bool),
+        "agui": ("DEEPAGENT_AGUI", _parse_optional_bool),
     }
     _TOML: ClassVar[dict] = {
         "subtitle": "ui.subtitle",
@@ -132,6 +137,7 @@ class AppConfig(HostConfig):
         "custom_css": "ui.custom_css",
         "show_canvas": "ui.show_canvas",
         "show_files": "ui.show_files",
+        "agui": "experimental.agui",
     }
 
     @classmethod

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -54,6 +54,9 @@ def create_fastapi_app(
         graph=agent,
         stream_mode=["updates", "messages"],
         max_result_len=50_000,
+        # [experimental] Route chat through the in-process AG-UI adapter (ADR 0002)
+        # when LANGSTAGE_AGUI is set; same SSE frames, so the frontend is unchanged.
+        agui=bool(config.agui),
         **(stream_parser_config or {}),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.12.2"
+version = "0.12.3"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -14,7 +14,7 @@ dependencies = [
     "uvicorn[standard]>=0.30",
     # >=0.6.4 carries the dual-mode content fallback so non-token-streaming
     # agents render in chat instead of replying blank (gh #-dogfood).
-    "langgraph-stream-parser>=0.6.7,<0.7",
+    "langgraph-stream-parser>=0.6.16,<0.7",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -40,13 +40,16 @@ deepagents = [
     "deepagents>=0.3",
 ]
 agui = [
-    "langgraph-stream-parser[agui]>=0.6.7,<0.7",
+    "langgraph-stream-parser[agui]>=0.6.16,<0.7",
 ]
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
     "httpx>=0.27",
     "ruff>=0.5",
+    # The experimental AG-UI chat path (ADR 0002); pulled into dev so CI exercises
+    # tests/test_agui.py instead of skipping it.
+    "ag-ui-langgraph>=0.0.41",
 ]
 
 [project.scripts]

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -1,0 +1,52 @@
+"""Experimental AG-UI chat path for the web app (ADR 0002).
+
+The config toggle (LANGSTAGE_AGUI) flips SessionAdapter into its in-process AG-UI
+mode, which emits the same SSE frames — so the frontend is unchanged. The frame
+mapping + outcome tracking live in the core (langgraph-stream-parser); here we
+verify the web's toggle wiring and one end-to-end stream.
+"""
+
+import pytest
+
+from langstage.config import AppConfig
+
+
+def test_agui_toggle_defaults_off():
+    assert AppConfig().agui is None
+    assert bool(AppConfig().agui) is False  # coerced off when unset (as main.py does)
+
+
+def test_agui_toggle_from_env(monkeypatch):
+    monkeypatch.setenv("LANGSTAGE_AGUI", "1")
+    assert AppConfig.from_env().agui is True
+
+
+def test_agui_toggle_legacy_env(monkeypatch):
+    monkeypatch.delenv("LANGSTAGE_AGUI", raising=False)
+    monkeypatch.setenv("DEEPAGENT_AGUI", "true")
+    assert AppConfig.from_env().agui is True
+
+
+# ── end-to-end (requires the agui extra) ─────────────────────────────
+
+pytest.importorskip("ag_ui_langgraph")
+
+
+@pytest.mark.asyncio
+async def test_session_adapter_agui_streams_via_web_dep():
+    from langgraph_stream_parser import load_agent_spec
+    from langgraph_stream_parser.adapters import SessionAdapter
+
+    adapter = SessionAdapter(
+        graph=load_agent_spec("langgraph_stream_parser.demo.stub:graph"),
+        max_result_len=50_000,
+        agui=True,
+    )
+    session = adapter.submit_message("s1", "hello web agui")
+    await session.current_task
+    frames = []
+    while not session.event_queue.empty():
+        frames.append(session.event_queue.get_nowait())
+    assert frames[-1]["type"] == "complete"
+    assert session.outcome == "complete"
+    assert "hello web agui" in "".join(f["content"] for f in frames if f["type"] == "content")


### PR DESCRIPTION
**Fourth and final** surface of the AG-UI migration (after cli, jupyter, vscode). Opt-in via `LANGSTAGE_AGUI=1`.

The chat stream runs through the core's in-process AG-UI adapter (`SessionAdapter(agui=True)`, new in langgraph-stream-parser 0.6.16) instead of the built-in `StreamParser`. It emits the **same `event_to_dict` SSE frames** and the **same terminal `session.outcome`**, so the React frontend **and** the task board (which reads `session.outcome`) are unchanged.

## Changes
- `AppConfig` gains an `agui` toggle (`LANGSTAGE_AGUI` / legacy `DEEPAGENT_AGUI` / `[experimental].agui`).
- `server/main.py` passes `agui=bool(config.agui)` to `SessionAdapter`.
- Core floor bumped to `>=0.6.16` (base + `[agui]` extra).

## Tests
`tests/test_agui.py`: toggle default-off + coercion, env (canonical + legacy), and an end-to-end `SessionAdapter` agui stream. Full suite **152 passed**. Default path untouched; requires the `[agui]` extra. Python-only — the built React frontend is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)