### PR TITLE
Repoint to langstage-core 1.0; AG-UI as the SessionAdapter's only path (ADR 0003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 0.13.0 — 2026-07-02
+
+### Changed
+- **AG-UI is now the chat/board's only streaming path (ADR 0003).** The
+  `SessionAdapter` streams every turn through `langstage-core`'s in-process AG-UI
+  adapter, emitting the **same** SSE frames the React frontend already consumes —
+  so the UI is unchanged. Removed the `LANGSTAGE_AGUI` opt-in env and the
+  `AppConfig.agui` toggle (they gated a path that no longer exists); the adapter is
+  constructed without `agui=`/`stream_mode=`.
+- **Repointed to `langstage-core` 1.0** (the rename of `langgraph-stream-parser`;
+  ADR 0003). The AG-UI runtime (`ag-ui-langgraph[fastapi]`, via core's `[agui]`
+  extra) moved into **base dependencies** — since AG-UI is the only path, a bare
+  `pip install langstage` must run a turn. (`fastapi` + `uvicorn` were already base
+  deps.) The `[agui]` extra is now a redundant no-op alias.
+
+### Removed
+- The `experimental.agui` TOML key / `LANGSTAGE_AGUI` env / `AppConfig.agui` field.
+  The frontend's content-delta accumulation was already AG-UI-native, so chat
+  rendering is unchanged.
+
 ## 0.11.8 — 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ langstage is the web stage (and namesake) of the **LangStage family**: write you
 | Terminal | [langstage-cli](https://github.com/dkedar7/langstage-cli) | `langstage-cli -a my_agent.py:graph` |
 | VS Code | [langstage-vscode](https://github.com/dkedar7/langstage-vscode) | chat participant + stdio sidecar |
 | Reference agent | [langstage-hermes](https://github.com/dkedar7/langstage-hermes) | `LANGSTAGE_AGENT_SPEC=langstage_hermes.agent:graph` on any stage |
-| Shared core | [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) | typed events + config resolver behind every stage |
+| Shared core | [langstage-core](https://github.com/dkedar7/langstage-core) | typed events + config resolver behind every stage |
 
 ### Serve over AG-UI
 
-This surface's agent — any LangGraph `CompiledGraph` — can also be served over the [AG-UI protocol](https://github.com/dkedar7/langgraph-stream-parser) for use with AG-UI compatible clients:
+This surface's agent — any LangGraph `CompiledGraph` — can also be served over the [AG-UI protocol](https://github.com/dkedar7/langstage-core) for use with AG-UI compatible clients:
 
 ```bash
-pip install "langgraph-stream-parser[agui]"
+pip install "langstage-core[agui]"
 langstage-agui --agent my_agent.py:graph
 ```
 
@@ -156,7 +156,7 @@ langstage check --agent my_agent.py:graph
 
 ## Task board
 
-The **Board** tab turns LangStage into a lightweight agent control room: delegate a task and it runs on a background copy of your agent while you keep chatting. No extra infrastructure — tasks are persisted in a local SQLite file (the board survives a restart) and executed by an in-process worker pool, built on the [`langgraph-stream-parser`](https://github.com/dkedar7/langgraph-stream-parser) task engine.
+The **Board** tab turns LangStage into a lightweight agent control room: delegate a task and it runs on a background copy of your agent while you keep chatting. No extra infrastructure — tasks are persisted in a local SQLite file (the board survives a restart) and executed by an in-process worker pool, built on the [`langstage-core`](https://github.com/dkedar7/langstage-core) task engine.
 
 - **Delegate** from the Board tab (or let the agent delegate to itself — see below). A task moves `queued → ongoing → review → done`; cancel or retry from any card.
 - **Open a task** (click its card) to **live-tail the agent's full event stream** — content and tool calls, rendered like the chat. Approve/reject a task paused for human review, or send it a **follow-up**.
@@ -239,7 +239,7 @@ app = CoworkApp(
 )
 ```
 
-See [langgraph-stream-parser](https://github.com/dkedar7/langgraph-stream-parser) for details.
+See [langstage-core](https://github.com/dkedar7/langstage-core) for details.
 
 ## Architecture
 

--- a/frontend/e2e/stub_agent.py
+++ b/frontend/e2e/stub_agent.py
@@ -5,7 +5,7 @@ Launch the app against it with::
     langstage run --agent <abs path>/stub_agent.py:graph --no-browser
 
 It's a real compiled LangGraph graph with a MemorySaver checkpointer, so it
-streams through the exact same ``langgraph_stream_parser`` path as the
+streams through the exact same ``langstage_core`` path as the
 production agent — including token-by-token ``messages``-mode streaming, which
 the langstage adapter relies on. But the "model" is a local echo that just
 replays the user's last message, so there's no API key and it's fully

--- a/langstage/__init__.py
+++ b/langstage/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from langgraph_stream_parser.tasks import TASK_TOOLS
+from langstage_core.tasks import TASK_TOOLS
 
 from langstage.app import CoworkApp, run_app
 from langstage.scheduler import CRON_TOOLS

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import uvicorn
 
-from langgraph_stream_parser import load_agent_spec
+from langstage_core import load_agent_spec
 from langstage.config import AppConfig
 from langstage.server.main import create_fastapi_app
 

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -7,7 +7,7 @@ from langstage.config import AppConfig
 
 
 # The keyless echo agent shipped with the shared core - see `--demo`.
-DEMO_AGENT_SPEC = "langgraph_stream_parser.demo.stub:graph"
+DEMO_AGENT_SPEC = "langstage_core.demo.stub:graph"
 
 
 @click.group(invoke_without_command=True)
@@ -110,7 +110,7 @@ def _agent_tool_names(agent) -> set[str] | None:
 def check(agent_spec, demo):
     """Preflight a bring-your-own agent: load it and report which LangStage
     features will light up (and which need a convention or tool to unlock)."""
-    from langgraph_stream_parser import load_agent_spec
+    from langstage_core import load_agent_spec
     from langstage.middleware import agent_uses_canvas_middleware
 
     spec = DEMO_AGENT_SPEC if demo else agent_spec

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, fields, replace
 from pathlib import Path
 from typing import ClassVar, Optional
 
-from langgraph_stream_parser.host import HostConfig
+from langstage_core.host import HostConfig
 
 
 def _env_canonical_first(canonical: str, legacy: str) -> Optional[str]:
@@ -102,10 +102,6 @@ class AppConfig(HostConfig):
     # None means auto-resolve (canvas auto-detects middleware; files defaults True).
     show_canvas: Optional[bool] = None
     show_files: Optional[bool] = None
-    # [experimental] Stream chat through the in-process AG-UI adapter instead of
-    # the built-in StreamParser (ADR 0002). Opt-in via LANGSTAGE_AGUI=1. Requires
-    # the agui extra: pip install "langstage[agui]".
-    agui: Optional[bool] = None
 
     _ENV: ClassVar[dict] = {
         "subtitle": ("DEEPAGENT_SUBTITLE", str),
@@ -121,7 +117,6 @@ class AppConfig(HostConfig):
         "custom_css": ("DEEPAGENT_CUSTOM_CSS", str),
         "show_canvas": ("DEEPAGENT_SHOW_CANVAS", _parse_optional_bool),
         "show_files": ("DEEPAGENT_SHOW_FILES", _parse_optional_bool),
-        "agui": ("DEEPAGENT_AGUI", _parse_optional_bool),
     }
     _TOML: ClassVar[dict] = {
         "subtitle": "ui.subtitle",
@@ -137,7 +132,6 @@ class AppConfig(HostConfig):
         "custom_css": "ui.custom_css",
         "show_canvas": "ui.show_canvas",
         "show_files": "ui.show_files",
-        "agui": "experimental.agui",
     }
 
     @classmethod

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -5,8 +5,8 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from langgraph_stream_parser.demo import create_default_agent as _build_default_agent
-from langgraph_stream_parser.tasks import TASK_TOOLS
+from langstage_core.demo import create_default_agent as _build_default_agent
+from langstage_core.tasks import TASK_TOOLS
 
 from langstage.config import WORKSPACE_ROOT as _WORKSPACE_ROOT
 from langstage.middleware import CanvasMiddleware

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -7,8 +7,8 @@ from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, Response
 
-from langgraph_stream_parser.adapters import SessionAdapter
-from langgraph_stream_parser.tasks import TaskRunner, set_runner
+from langstage_core.adapters import SessionAdapter
+from langstage_core.tasks import TaskRunner, set_runner
 
 from langstage.config import AppConfig
 from langstage.server.middleware import add_middleware
@@ -49,14 +49,12 @@ def create_fastapi_app(
     canvas_manager = CanvasManager(workspace)
 
     # One session-scoped streaming adapter owns agent execution + the SSE pipe.
-    # max_result_len is large so the UI can show full tool output, not a preview.
+    # Since core 1.0 (ADR 0003) it streams every turn through the in-process AG-UI
+    # adapter — the only path — emitting the same SSE frames, so the frontend is
+    # unchanged. max_result_len is large so the UI shows full tool output.
     adapter = SessionAdapter(
         graph=agent,
-        stream_mode=["updates", "messages"],
         max_result_len=50_000,
-        # [experimental] Route chat through the in-process AG-UI adapter (ADR 0002)
-        # when LANGSTAGE_AGUI is set; same SSE frames, so the frontend is unchanged.
-        agui=bool(config.agui),
         **(stream_parser_config or {}),
     )
 

--- a/langstage/server/routes_chat.py
+++ b/langstage/server/routes_chat.py
@@ -1,6 +1,6 @@
 """SSE streaming + REST endpoints for chat.
 
-Backed by ``langgraph_stream_parser.adapters.SessionAdapter`` — the per-session
+Backed by ``langstage_core.adapters.SessionAdapter`` — the per-session
 queue, cancellation, and SSE plumbing that used to live in cowork's own
 ``stream/`` package now come from the shared runtime.
 """
@@ -13,7 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from langgraph_stream_parser.adapters import SessionAdapter
+from langstage_core.adapters import SessionAdapter
 
 from langstage.workspace.file_manager import FileManager
 

--- a/langstage/server/routes_session.py
+++ b/langstage/server/routes_session.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from langgraph_stream_parser.adapters import SessionAdapter
+from langstage_core.adapters import SessionAdapter
 
 from langstage.server.routes_chat import context_parts
 

--- a/langstage/server/routes_tasks.py
+++ b/langstage/server/routes_tasks.py
@@ -11,8 +11,8 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from langgraph_stream_parser.tasks import TaskRunner
-from langgraph_stream_parser.tasks.store import TaskStore
+from langstage_core.tasks import TaskRunner
+from langstage_core.tasks.store import TaskStore
 
 
 class TaskCreate(BaseModel):

--- a/langstage/tasks/__init__.py
+++ b/langstage/tasks/__init__.py
@@ -2,7 +2,7 @@
 
 The task-delegation *engine* (TaskRunner, the TaskStore protocol, the
 Task/TaskState machine) lives in the shared core,
-``langgraph_stream_parser.tasks``. This package provides only langstage-web's
+``langstage_core.tasks``. This package provides only langstage-web's
 concrete store — durable across restarts so the task board survives a bounce.
 """
 from .sqlite_store import SqliteTaskStore

--- a/langstage/tasks/sqlite_store.py
+++ b/langstage/tasks/sqlite_store.py
@@ -1,4 +1,4 @@
-"""SQLite-backed :class:`~langgraph_stream_parser.tasks.TaskStore`.
+"""SQLite-backed :class:`~langstage_core.tasks.TaskStore`.
 
 Durable across restarts (the task board survives a bounce). Single-process by
 design: an :class:`asyncio.Lock` serializes the claim so two workers never grab
@@ -16,9 +16,9 @@ from typing import Any, Optional
 
 import aiosqlite
 
-from langgraph_stream_parser.tasks import Task
-from langgraph_stream_parser.tasks.state import ONGOING, QUEUED
-from langgraph_stream_parser.tasks.store import now_iso
+from langstage_core.tasks import Task
+from langstage_core.tasks.state import ONGOING, QUEUED
+from langstage_core.tasks.store import now_iso
 
 _COLUMNS = [
     "task_id", "parent_id", "title", "prompt", "agent_spec", "state",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.12.3"
+version = "0.13.0"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -12,9 +12,11 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115",
     "uvicorn[standard]>=0.30",
-    # >=0.6.4 carries the dual-mode content fallback so non-token-streaming
-    # agents render in chat instead of replying blank (gh #-dogfood).
-    "langgraph-stream-parser>=0.6.16,<0.7",
+    # Since core 1.0 (ADR 0003) the SessionAdapter streams every turn ONLY through
+    # the in-process AG-UI adapter, so the AG-UI runtime (ag-ui-langgraph[fastapi],
+    # via core's [agui] extra) is a HARD dep. fastapi + uvicorn are already base
+    # deps above, so [agui] mainly adds ag-ui-langgraph itself.
+    "langstage-core[agui]>=1.0",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -39,16 +41,18 @@ dependencies = [
 deepagents = [
     "deepagents>=0.3",
 ]
+# Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
+# existing `pip install langstage[agui]` scripts/READMEs still resolve.
 agui = [
-    "langgraph-stream-parser[agui]>=0.6.16,<0.7",
+    "langstage-core[agui]>=1.0",
 ]
 dev = [
     "pytest>=8",
     "pytest-asyncio>=0.24",
     "httpx>=0.27",
     "ruff>=0.5",
-    # The experimental AG-UI chat path (ADR 0002); pulled into dev so CI exercises
-    # tests/test_agui.py instead of skipping it.
+    # AG-UI runtime for the SessionAdapter's only streaming path (base deps pull
+    # this via core's [agui] extra; pinned here too so the test env is explicit).
     "ag-ui-langgraph>=0.0.41",
 ]
 

--- a/tests/test_agui.py
+++ b/tests/test_agui.py
@@ -1,46 +1,26 @@
-"""Experimental AG-UI chat path for the web app (ADR 0002).
+"""AG-UI chat path for the web app — the SessionAdapter's only streaming path
+since core 1.0 (ADR 0003).
 
-The config toggle (LANGSTAGE_AGUI) flips SessionAdapter into its in-process AG-UI
-mode, which emits the same SSE frames — so the frontend is unchanged. The frame
-mapping + outcome tracking live in the core (langgraph-stream-parser); here we
-verify the web's toggle wiring and one end-to-end stream.
+The adapter streams every turn through the in-process AG-UI adapter, emitting the
+same SSE frames the frontend already consumes. The frame mapping + outcome
+tracking live in the core (langstage-core); here we verify one end-to-end stream.
 """
 
 import pytest
 
-from langstage.config import AppConfig
-
-
-def test_agui_toggle_defaults_off():
-    assert AppConfig().agui is None
-    assert bool(AppConfig().agui) is False  # coerced off when unset (as main.py does)
-
-
-def test_agui_toggle_from_env(monkeypatch):
-    monkeypatch.setenv("LANGSTAGE_AGUI", "1")
-    assert AppConfig.from_env().agui is True
-
-
-def test_agui_toggle_legacy_env(monkeypatch):
-    monkeypatch.delenv("LANGSTAGE_AGUI", raising=False)
-    monkeypatch.setenv("DEEPAGENT_AGUI", "true")
-    assert AppConfig.from_env().agui is True
-
-
-# ── end-to-end (requires the agui extra) ─────────────────────────────
-
+# The AG-UI runtime is a base dependency (core's [agui] extra); importorskip is a
+# safety net so a stripped env degrades gracefully rather than erroring at collect.
 pytest.importorskip("ag_ui_langgraph")
 
 
 @pytest.mark.asyncio
-async def test_session_adapter_agui_streams_via_web_dep():
-    from langgraph_stream_parser import load_agent_spec
-    from langgraph_stream_parser.adapters import SessionAdapter
+async def test_session_adapter_streams_agui_frames():
+    from langstage_core import load_agent_spec
+    from langstage_core.adapters import SessionAdapter
 
     adapter = SessionAdapter(
-        graph=load_agent_spec("langgraph_stream_parser.demo.stub:graph"),
+        graph=load_agent_spec("langstage_core.demo.stub:graph"),
         max_result_len=50_000,
-        agui=True,
     )
     session = adapter.submit_message("s1", "hello web agui")
     await session.current_task

--- a/tests/test_routes_tasks.py
+++ b/tests/test_routes_tasks.py
@@ -1,6 +1,6 @@
 """Contract tests for the /api/tasks REST router.
 
-Wires a real TaskRunner + SqliteTaskStore + SessionAdapter (fake agent) behind
+Wires a real TaskRunner + SqliteTaskStore + SessionAdapter (stub agent) behind
 the router and drives it over HTTP. (httpx ASGITransport doesn't fire lifespan,
 so the store/runner are set up explicitly here rather than via app startup.)
 """
@@ -10,13 +10,12 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from langgraph_stream_parser.adapters import SessionAdapter
-from langgraph_stream_parser.tasks import TaskRunner
-from langgraph_stream_parser.tasks.state import DONE
+from langstage_core import load_agent_spec
+from langstage_core.adapters import SessionAdapter
+from langstage_core.tasks import TaskRunner
+from langstage_core.tasks.state import DONE
 from langstage.server.routes_tasks import create_tasks_router
 from langstage.tasks import SqliteTaskStore
-
-from .test_streaming import FakeStreamingAgent
 
 
 async def _wait(store, task_id, target, timeout=4.0):
@@ -35,7 +34,7 @@ async def _wait(store, task_id, target, timeout=4.0):
 async def ctx(tmp_path):
     store = SqliteTaskStore(tmp_path / "tasks.db")
     await store.setup()
-    adapter = SessionAdapter(graph=FakeStreamingAgent(chunks=["all ", "done"]))
+    adapter = SessionAdapter(graph=load_agent_spec("langstage_core.demo.stub:graph"))
     runner = TaskRunner(adapter, store, concurrency=2, poll_interval=0.05)
     await runner.start()
     app = FastAPI()

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -5,8 +5,8 @@ to SQLite, so the claim atomicity + durability are proven here independently.
 """
 import asyncio
 
-from langgraph_stream_parser.tasks.state import DONE, ONGOING, QUEUED
-from langgraph_stream_parser.tasks.store import now_iso
+from langstage_core.tasks.state import DONE, ONGOING, QUEUED
+from langstage_core.tasks.store import now_iso
 from langstage.tasks import SqliteTaskStore
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,39 +1,43 @@
 """Integration tests for the streaming pipe via the shared SessionAdapter.
 
-The streaming machinery moved to ``langgraph_stream_parser.adapters.SessionAdapter``
-(tested in the parser's own suite). These tests guard the cowork-level wiring:
-that a conformant agent's events reach the session queue, that the cwd/context
-injection survives, and that the langgraph-stream-parser API contract cowork
-depends on (``prepare_agent_input`` / ``create_resume_input``) hasn't drifted —
-the class of bug that shipped in 0.3.6.
+The streaming machinery lives in ``langstage_core.adapters.SessionAdapter`` — which
+since core 1.0 (ADR 0003) streams every turn through the in-process AG-UI adapter,
+so these use real compiled graphs (the demo stub + a boom graph), not a fake. These
+guard the cowork-level wiring: that a real agent's events reach the session queue,
+that the cwd/context injection survives to the agent, and that the core API contract
+cowork depends on (``prepare_agent_input`` / ``create_resume_input``) hasn't drifted.
 """
 
 import inspect
 
-from langchain_core.messages import AIMessageChunk
-from langgraph_stream_parser.adapters import SessionAdapter
+import pytest
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from langstage_core import load_agent_spec
+from langstage_core.adapters import SessionAdapter
 
 from langstage.server.routes_chat import context_parts
 
-
-class FakeStreamingAgent:
-    """Minimal CompiledStateGraph-ish stand-in for dual stream_mode."""
-
-    def __init__(self, chunks: list[str] | None = None):
-        self._chunks = chunks if chunks is not None else ["Hello", " world"]
-        self.calls: list[dict] = []
-
-    async def astream(self, input_data, config=None, stream_mode=None):
-        self.calls.append({"input": input_data, "config": config, "stream_mode": stream_mode})
-        for text in self._chunks:
-            yield ("messages", (AIMessageChunk(content=text), {"langgraph_node": "model"}))
-        yield ("updates", {"model": {"messages": [AIMessageChunk(content="")]}})
+# The AG-UI runtime is a base dependency (core's [agui] extra); safety net so a
+# stripped env degrades gracefully rather than erroring at collection time.
+pytest.importorskip("ag_ui_langgraph")
 
 
-class FailingAgent:
-    async def astream(self, input_data, config=None, stream_mode=None):
-        yield ("messages", (AIMessageChunk(content="partial"), {"langgraph_node": "model"}))
+def _stub():
+    """The keyless demo echo agent — echoes the user's last message."""
+    return load_agent_spec("langstage_core.demo.stub:graph")
+
+
+def _boom_graph():
+    """A compiled graph whose only node raises, to exercise error surfacing."""
+    def boom(state):
         raise RuntimeError("synthetic model failure")
+
+    b = StateGraph(MessagesState)
+    b.add_node("boom", boom)
+    b.add_edge(START, "boom")
+    b.add_edge("boom", END)
+    return b.compile()
 
 
 def _drain(queue):
@@ -47,7 +51,7 @@ def _drain(queue):
 
 
 async def test_stream_delivers_content_and_complete():
-    adapter = SessionAdapter(graph=FakeStreamingAgent(chunks=["Hi", " there"]))
+    adapter = SessionAdapter(graph=_stub())
     session = adapter.submit_message("s1", "say hi")
     await session.current_task
 
@@ -58,36 +62,30 @@ async def test_stream_delivers_content_and_complete():
 
 
 async def test_message_and_cwd_reach_the_agent():
-    """The user message + cwd context must survive prepare_agent_input."""
-    agent = FakeStreamingAgent()
-    adapter = SessionAdapter(graph=agent)
+    """The user message + cwd context must survive prepare_agent_input to the agent.
 
+    The stub echoes the human message it receives, so both the message and the
+    injected cwd context appear in the streamed content.
+    """
+    adapter = SessionAdapter(graph=_stub())
     session = adapter.submit_message(
         "s-ctx", "the magic phrase",
         context_parts=context_parts(cwd="/tmp/test-workspace"),
     )
     await session.current_task
 
-    serialized = str(agent.calls[0]["input"])
-    assert "the magic phrase" in serialized
-    assert "/tmp/test-workspace" in serialized
-
-
-async def test_thread_id_forwarded_to_config():
-    agent = FakeStreamingAgent()
-    adapter = SessionAdapter(graph=agent)
-    session = adapter.submit_message("s-thread", "hi")
-    await session.current_task
-
-    cfg = agent.calls[0]["config"]
-    assert cfg["configurable"]["thread_id"] == "s-thread"
+    content = "".join(
+        e.get("content", "") for e in _drain(session.event_queue) if e.get("type") == "content"
+    )
+    assert "the magic phrase" in content
+    assert "/tmp/test-workspace" in content
 
 
 # --- Error path --------------------------------------------------------------
 
 
 async def test_stream_surfaces_errors_as_events():
-    adapter = SessionAdapter(graph=FailingAgent())
+    adapter = SessionAdapter(graph=_boom_graph())
     session = adapter.submit_message("s-err", "hi")
     await session.current_task
 
@@ -98,7 +96,7 @@ async def test_stream_surfaces_errors_as_events():
     assert "synthetic model failure" in err.get("error", "")
 
 
-# --- Library API contract (guards against langgraph-stream-parser drift) ------
+# --- Library API contract (guards against core drift) ------------------------
 
 
 def test_context_parts_includes_time_and_cwd():
@@ -110,7 +108,7 @@ def test_context_parts_includes_time_and_cwd():
 
 
 def test_prepare_agent_input_contract():
-    from langgraph_stream_parser import prepare_agent_input
+    from langstage_core import prepare_agent_input
 
     sig = inspect.signature(prepare_agent_input)
     assert "message" in sig.parameters
@@ -119,7 +117,7 @@ def test_prepare_agent_input_contract():
 
 
 def test_create_resume_input_contract():
-    from langgraph_stream_parser import create_resume_input
+    from langstage_core import create_resume_input
 
     sig = inspect.signature(create_resume_input)
     assert "decisions" in sig.parameters

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,58 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "ag-ui-a2ui-toolkit"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/ce/85f3960a83d962e5690bc0f27a3baf3bf1602edc2b0603085928c964ea14/ag_ui_a2ui_toolkit-0.0.4.tar.gz", hash = "sha256:172e2724e53df8173685a3fb896a6e5175eea06e1dc166c715db110ba4beba76", size = 18960, upload-time = "2026-06-17T13:34:28.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/7a/acf85b01cd996bd011b71e181fd9f3daff5396fc3b7d78ba9445bfc08ecf/ag_ui_a2ui_toolkit-0.0.4-py3-none-any.whl", hash = "sha256:236fc511e1ec2399bcda0c14a109b3fb0a0c3e3988c18ef1918745b1c1535e30", size = 21315, upload-time = "2026-06-17T13:34:29.505Z" },
+]
+
+[[package]]
+name = "ag-ui-langgraph"
+version = "0.0.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ag-ui-a2ui-toolkit" },
+    { name = "ag-ui-protocol" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/d5/648338b5ff8f90c488217297a8656b6c133a251a39af2d62bada142b7819/ag_ui_langgraph-0.0.42.tar.gz", hash = "sha256:5384647b9b7b098189530c59b26741581dd009c8dfda907fbfaa9bafa8d21249", size = 330419, upload-time = "2026-06-19T15:07:01.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/c0/32fea8de7ac50a90ea150f999318f4d121cd22d58e446c8fdb420fc2a11e/ag_ui_langgraph-0.0.42-py3-none-any.whl", hash = "sha256:4fd19f0da6d0e16d727ec89e99b692916cbba2b0302f96aba2497043cbfec5db", size = 37969, upload-time = "2026-06-19T15:07:00.517Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
+[[package]]
+name = "ag-ui-protocol"
+version = "0.1.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/10/4ad299267a7d04b89935aa99eef62979758fcf95aee9f8bb5d70c35b1be1/ag_ui_protocol-0.1.19.tar.gz", hash = "sha256:43c27f60d41712dcad0e9e0a203cbdf1c8e248b22417374c5c68321c448af4ea", size = 10720, upload-time = "2026-06-02T17:26:15.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/0a/bcad8116eb058e4b4a305e3fc37ebd7efc879deeb86b854f1c5b8b6e97dd/ag_ui_protocol-0.1.19-py3-none-any.whl", hash = "sha256:898843b1410d378824da0c6a776486288b9c5828689d0bf563118868e37f390f", size = 13490, upload-time = "2026-06-02T17:26:16.313Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -725,10 +777,11 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.14"
+version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
+    { name = "langchain-protocol" },
     { name = "langsmith" },
     { name = "packaging" },
     { name = "pydantic" },
@@ -737,9 +790,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/ff/c5e3da8eca8a18719b300ef6c29e28208ee4e9da7f9749022b96292b6541/langchain_core-1.2.14.tar.gz", hash = "sha256:09549d838a2672781da3a9502f3b9c300863284b77b27e2a6dac4e6e650acfed", size = 833399, upload-time = "2026-02-19T14:22:33.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/e3/bea6d0080acf183332f24dcd74c208aee5857cf8f783c3fb0bd86027d8fb/langchain_core-1.4.8.tar.gz", hash = "sha256:5bf1f8411077c904182ad8f975943d36adcbf579c4e017b3a118b719229ebf9a", size = 957974, upload-time = "2026-06-18T19:39:23.636Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/41/fe6ae9065b866b1397adbfc98db5e1648e8dcd78126b8e1266fcbe2d6395/langchain_core-1.2.14-py3-none-any.whl", hash = "sha256:b349ca28c057ac1f9b5280ea091bddb057db24d0f1c3c89bbb590713e1715838", size = 501411, upload-time = "2026-02-19T14:22:32.013Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d6/bdf6f0481cc57ef300d6b1eb48cf1400c0409be715d6eb3cabadd1142a09/langchain_core-1.4.8-py3-none-any.whl", hash = "sha256:d84c28b05e3ba8d4271d0827aad5b592ccdaaf986e76768c23503f0a2045e8aa", size = 557416, upload-time = "2026-06-18T19:39:21.902Z" },
 ]
 
 [[package]]
@@ -755,6 +808,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ff/27/f3c8f47b7c194c42a7ea38e5b91b412c4bd45f97e702a96edad659312437/langchain_google_genai-3.2.0.tar.gz", hash = "sha256:1fa620ea9c655a37537e95438857c423e1a3599b5a665b8dd87064c76ee95b72", size = 242146, upload-time = "2025-11-24T14:33:11.205Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/9d/c79a367e3379cf6b7d0cc43d558a411a5097d55291f2ce2f573420adb523/langchain_google_genai-3.2.0-py3-none-any.whl", hash = "sha256:689fc159d4623a184678e24771f6d52373e983a8fc8d342e44352aaf28e9445d", size = 57604, upload-time = "2025-11-24T14:33:10.112Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
 ]
 
 [[package]]
@@ -776,15 +841,29 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.0"
+version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ea/83917c2369acf8a10a894d4247655fd063c07924ba5bc4e83c85d2eaeded/langgraph_checkpoint_sqlite-3.1.0.tar.gz", hash = "sha256:f926916ebc1b985d802cc9c820026036e84db9d910d62c97b57e4ba64f67d5ae", size = 147902, upload-time = "2026-05-12T03:34:52.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/07/b342811a16327900af2747c752ea19676172fcddf9b592cc384031076623/langgraph_checkpoint_sqlite-3.1.0-py3-none-any.whl", hash = "sha256:cc9b40df0076feae8a9ad42ae713621b148b00ac23adc09dc1dc66090a46e5ad", size = 38587, upload-time = "2026-05-12T03:34:51.231Z" },
 ]
 
 [[package]]
@@ -814,15 +893,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langgraph-stream-parser"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/4b/15303c3e2512d23a81bab3d2216378c2479ce8dd99187b46110496f39f2d/langgraph_stream_parser-0.3.0.tar.gz", hash = "sha256:8803523804ff4042f942252eb24770cbd1a50aa25d1cfff753ea4ab4be9b9d6e", size = 211787, upload-time = "2026-06-12T05:17:40.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/5e/a6897b99c68cac5a28be998367378d27f1a979763ac0f82d6de9f6d3ea54/langgraph_stream_parser-0.3.0-py3-none-any.whl", hash = "sha256:42726e92db0621c3e7234e1c4e380c145625a1ba36165a84c1bbd0fc4d0bd46f", size = 74728, upload-time = "2026-06-12T05:17:39.235Z" },
-]
-
-[[package]]
 name = "langsmith"
 version = "0.7.5"
 source = { registry = "https://pypi.org/simple" }
@@ -844,14 +914,17 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.7.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "click" },
     { name = "croniter" },
     { name = "fastapi" },
+    { name = "langchain" },
     { name = "langgraph" },
-    { name = "langgraph-stream-parser" },
+    { name = "langgraph-checkpoint-sqlite" },
+    { name = "langstage-core", extra = ["agui"] },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
@@ -860,10 +933,14 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agui = [
+    { name = "langstage-core", extra = ["agui"] },
+]
 deepagents = [
     { name = "deepagents" },
 ]
 dev = [
+    { name = "ag-ui-langgraph" },
     { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -872,13 +949,18 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ag-ui-langgraph", marker = "extra == 'dev'", specifier = ">=0.0.41" },
+    { name = "aiosqlite", specifier = ">=0.19" },
     { name = "click", specifier = ">=8.0" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.3" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
+    { name = "langchain", specifier = ">=1.0" },
     { name = "langgraph", specifier = ">=1.0" },
-    { name = "langgraph-stream-parser", specifier = ">=0.3,<0.4" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -888,7 +970,25 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
     { name = "watchfiles", specifier = ">=1.0" },
 ]
-provides-extras = ["deepagents", "dev"]
+provides-extras = ["deepagents", "agui", "dev"]
+
+[[package]]
+name = "langstage-core"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/4b/768fbd9a47bb66150279c87f5ce5c9aac52f510f5ee0560cb2116fe46586/langstage_core-1.0.0.tar.gz", hash = "sha256:d713aaf0a93c7c5997a839f04358a1cab35ba8c50b70d10deb84e1e9695678ca", size = 222828, upload-time = "2026-07-02T13:41:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/49/2da5eafc600119cc4d34950068f860a80502f84e57fac63bdfc537156da6/langstage_core-1.0.0-py3-none-any.whl", hash = "sha256:8b41c9600074667ef3612fa9c92d94c6d0a2bc89c14504838bf111ab94859ff7", size = 55774, upload-time = "2026-07-02T13:41:48.866Z" },
+]
+
+[package.optional-dependencies]
+agui = [
+    { name = "ag-ui-langgraph", extra = ["fastapi"] },
+    { name = "uvicorn" },
+]
 
 [[package]]
 name = "orjson"
@@ -1396,6 +1496,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fifth and final C2 surface repoint (after langstage-cli 0.6.0, langstage-hermes 0.4.0, langstage-vscode 0.5.0, langstage-jupyter 0.6.0).

## What
- **AG-UI is the chat/board's only streaming path.** The shared `SessionAdapter` (core 1.0) streams every turn through the in-process AG-UI adapter, emitting the **same** SSE frames the React frontend already consumes — the UI is unchanged (the frontend was already content-delta-native: buffered `content` events with rAF batching). Removed the `AppConfig.agui` toggle, the `LANGSTAGE_AGUI` env, and the `experimental.agui` TOML key; the adapter is built without `agui=`/`stream_mode=`.
- **Repointed to `langstage-core` 1.0** (the rename of `langgraph-stream-parser`). The AG-UI runtime (`ag-ui-langgraph[fastapi]`, via core's `[agui]` extra) moved into **base dependencies** so a bare `pip install langstage` runs a turn out of the box (`fastapi` + `uvicorn` were already base deps); the `[agui]` extra is now a redundant alias.

## Tests / build
- Dropped the removed-toggle tests; rewired the adapter tests (`test_streaming`, `test_routes_tasks`) from the fake `astream` agent to **real compiled graphs** (demo stub + a boom graph), since the AG-UI adapter drives a real graph. **148 passed** locally.
- Frontend rebuilt (`npm run build` → `langstage/static`).

Bump `0.12.3 → 0.13.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)