### PR TITLE
Don't crash langstage run on a clean install; fix remediation package (gh #46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.1 — 2026-07-02
+
+### Fixed
+- **`langstage run` crashed on a clean `pip install langstage` (gh #46).** The
+  built-in default agent was built at module-import time, so on an install without
+  the `deepagents` extra it dumped a traceback — and the remediation named the wrong
+  package (`langstage-core[demo]` instead of `langstage[deepagents]`). The import is
+  now defensive (falls back to `agent = None`), and `create_default_agent` raises a
+  clean, correctly-packaged error that `langstage run` shows as a one-line message
+  (`pip install "langstage[deepagents]"`, or use `--demo`, or pass `--agent`) instead
+  of a traceback.
+
 ## 0.13.0 — 2026-07-02
 
 ### Changed

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -55,27 +55,34 @@ def run(agent_spec, demo, workspace, port, host, debug, title, subtitle, welcome
         if agent_spec:
             raise click.UsageError("--demo and --agent are mutually exclusive.")
         agent_spec = DEMO_AGENT_SPEC
-    app = CoworkApp(
-        agent_spec=agent_spec,
-        workspace=workspace,
-        port=port,
-        host=host,
-        debug=debug if debug else None,
-        title=title,
-        subtitle=subtitle,
-        welcome_message=welcome_message,
-        theme=theme,
-        agent_name=agent_name,
-        icon_url=icon_url,
-        auth_username=auth_username,
-        auth_password=auth_password,
-        save_workflow_prompt=save_workflow_prompt,
-        run_workflow_prompt=run_workflow_prompt,
-        create_workflow_prompt=create_workflow_prompt,
-        custom_css=custom_css,
-        show_canvas=show_canvas,
-        show_files=show_files,
-    )
+    try:
+        app = CoworkApp(
+            agent_spec=agent_spec,
+            workspace=workspace,
+            port=port,
+            host=host,
+            debug=debug if debug else None,
+            title=title,
+            subtitle=subtitle,
+            welcome_message=welcome_message,
+            theme=theme,
+            agent_name=agent_name,
+            icon_url=icon_url,
+            auth_username=auth_username,
+            auth_password=auth_password,
+            save_workflow_prompt=save_workflow_prompt,
+            run_workflow_prompt=run_workflow_prompt,
+            create_workflow_prompt=create_workflow_prompt,
+            custom_css=custom_css,
+            show_canvas=show_canvas,
+            show_files=show_files,
+        )
+    except RuntimeError as e:
+        # Building the built-in default agent needs the `deepagents` extra + an LLM
+        # key; on a clean `pip install langstage` it isn't there. Surface the clean,
+        # correctly-packaged message (from default_agent.create_default_agent) as a
+        # one-line CLI error instead of a traceback. (gh #46)
+        raise click.ClickException(str(e)) from e
     app.run(open_browser=not no_browser)
 
 

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -164,7 +164,16 @@ def _make_default_agent(ws_root: str):
 # Module-level default (built from the config/env workspace) for any import-time
 # consumers. CoworkApp rebuilds rooted at the RESOLVED workspace via
 # create_default_agent(), so --workspace/toml/Python reach the agent too. (gh #44)
-agent = _make_default_agent(workspace_root)
+#
+# Built defensively: a clean `pip install langstage` has no `deepagents` extra, and
+# the default agent needs it — so an unguarded build here crashed `langstage run`
+# (and every importer, incl. `--version`/`--help`) at import time with a traceback
+# that named the wrong package. Fall back to None; the runtime path
+# (create_default_agent) surfaces a clean, correctly-packaged error. (gh #46)
+try:
+    agent = _make_default_agent(workspace_root)
+except Exception:  # noqa: BLE001 — missing deepagents / API key must not brick the import
+    agent = None
 
 
 def create_default_agent(workspace: Path):
@@ -175,4 +184,16 @@ def create_default_agent(workspace: Path):
     default. Requires deepagents installed and an LLM API key
     (e.g. ANTHROPIC_API_KEY). (gh #44)
     """
-    return _make_default_agent(str(workspace))
+    try:
+        return _make_default_agent(str(workspace))
+    except RuntimeError as e:
+        # The shared core's factory raises when the `deepagents` extra is missing,
+        # but its message names `langstage-core[demo]` — wrong for a `langstage`
+        # user. Re-message with the package they actually installed. (gh #46)
+        if "deepagents" in str(e).lower():
+            raise RuntimeError(
+                "The built-in default agent needs the 'deepagents' extra: "
+                'pip install "langstage[deepagents]". Or run with --demo for the '
+                "keyless echo agent, or point --agent at your own graph."
+            ) from e
+        raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.0"
+version = "0.13.1"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_default_agent_graceful.py
+++ b/tests/test_default_agent_graceful.py
@@ -1,0 +1,42 @@
+"""gh #46: `langstage run` must not crash on a clean `pip install langstage`.
+
+The default agent needs the `deepagents` extra; building it at import time crashed
+every entrypoint, and the remediation named the wrong package (`langstage-core[demo]`
+instead of `langstage[deepagents]`). These run WITHOUT deepagents installed — they
+mock the factory failure, so no `importorskip`.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def test_create_default_agent_remessages_missing_deepagents(monkeypatch):
+    # The shared core's factory raises naming `langstage-core[demo]`; the web must
+    # re-message with the package a `langstage` user actually installs.
+    import langstage.default_agent as da
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError(
+            "create_default_agent requires the 'deepagents' extra. "
+            "Install it with: pip install langstage-core[demo]"
+        )
+
+    monkeypatch.setattr(da, "_build_default_agent", _boom)
+    with pytest.raises(RuntimeError, match=r"langstage\[deepagents\]") as exc:
+        da.create_default_agent(Path("."))
+    # ASCII-only (must encode on a cp1252 Windows console).
+    str(exc.value).encode("cp1252")
+
+
+def test_non_deepagents_runtime_error_is_not_swallowed(monkeypatch):
+    # A RuntimeError unrelated to the missing extra must propagate unchanged, not be
+    # re-messaged as a deepagents problem.
+    import langstage.default_agent as da
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("some other failure")
+
+    monkeypatch.setattr(da, "_build_default_agent", _boom)
+    with pytest.raises(RuntimeError, match="some other failure"):
+        da.create_default_agent(Path("."))


### PR DESCRIPTION
Closes #46.

The built-in default agent was built at **module-import time** (`default_agent.py:167`), so a clean `pip install langstage` (no `deepagents` extra) crashed every entrypoint with a traceback — and the "install the extra" message named `langstage-core[demo]`, wrong for a `langstage` user.

- The import-time build is now **guarded** (falls back to `agent = None`), so importing the module / `--version` / `--help` never crash.
- `create_default_agent` **re-messages** the core's missing-`deepagents` `RuntimeError` with the right package (`pip install "langstage[deepagents]"`, ASCII-only), and passes unrelated `RuntimeError`s through unchanged.
- `langstage run` catches it and shows a **one-line `ClickException`** instead of a traceback.

**Verified clean-room** (no `deepagents`): `import langstage.default_agent` succeeds (`agent is None`), and `langstage run` exits 1 with the clean message. Regression tests added.

Bump `0.13.0 → 0.13.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)