### PR TITLE
Detect CanvasMiddleware on a BYO agent via a marker node (gh #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.2 — 2026-07-02
+
+### Fixed
+- **Canvas auto-detection never fired for a bring-your-own agent (gh #48).**
+  `CanvasMiddleware` does its work in `wrap_model_call`, which langchain/deepagents
+  fuse into the model node — leaving no `.middleware` attribute or graph node — so an
+  agent that attached `CanvasMiddleware()` via `create_deep_agent(middleware=[...])`
+  was undetectable: the Canvas tab never auto-appeared and `langstage check` reported
+  "no CanvasMiddleware". `CanvasMiddleware` now defines a no-op `before_agent` hook, so
+  langchain compiles a named `CanvasMiddleware.before_agent` graph node, and
+  `agent_uses_canvas_middleware` detects it by node name (covering `CanvasMiddleware`
+  and any subclass) in addition to the stashed-attribute path the bundled default uses.
+
 ## 0.13.1 — 2026-07-02
 
 ### Fixed

--- a/langstage/middleware/canvas.py
+++ b/langstage/middleware/canvas.py
@@ -39,6 +39,24 @@ def agent_uses_canvas_middleware(agent: Any) -> bool:
                     return True
         except TypeError:
             continue
+
+    # A bring-your-own agent that attached CanvasMiddleware via
+    # create_deep_agent(middleware=[...]) exposes no middleware list — langchain
+    # fuses it. But CanvasMiddleware's before_agent hook makes langchain compile a
+    # named `CanvasMiddleware.before_agent` graph node, so detect it by node name
+    # (covers CanvasMiddleware and any subclass). (gh #48)
+    canvas_names = {CanvasMiddleware.__name__}
+    pending = [CanvasMiddleware]
+    while pending:
+        for sub in pending.pop().__subclasses__():
+            if sub.__name__ not in canvas_names:
+                canvas_names.add(sub.__name__)
+                pending.append(sub)
+    nodes = getattr(agent, "nodes", None)
+    if isinstance(nodes, dict):
+        for name in nodes:
+            if str(name).split(".", 1)[0] in canvas_names:
+                return True
     return False
 
 from langchain.agents.middleware.types import (
@@ -157,3 +175,16 @@ class CanvasMiddleware(AgentMiddleware):
             return await handler(request)
         self._apply(request)
         return await handler(request)
+
+    def before_agent(self, state: Any, runtime: Any = None) -> None:
+        """No-op detection marker (gh #48).
+
+        The middleware's real work is in ``wrap_model_call``, which fuses into the
+        model node and leaves no trace on the compiled graph — so a bring-your-own
+        agent that attaches ``CanvasMiddleware()`` via
+        ``create_deep_agent(middleware=[...])`` was undetectable, and the Canvas tab
+        never auto-appeared. A ``before_agent`` hook makes langchain compile a named
+        ``CanvasMiddleware.before_agent`` graph node, which ``agent_uses_canvas_middleware``
+        finds. Returns ``None`` (no state change) — it runs once per invocation.
+        """
+        return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.1"
+version = "0.13.2"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_tab_visibility.py
+++ b/tests/test_tab_visibility.py
@@ -127,6 +127,25 @@ def test_detect_no_canvas_middleware_when_other_middleware_present():
     assert agent_uses_canvas_middleware(_FakeAgentWithOtherMiddleware()) is False
 
 
+class _FakeCompiledWithCanvasNode:
+    # A BYO deep agent exposes no middleware list — langchain fuses the middleware —
+    # but CanvasMiddleware's before_agent hook compiles to a named node. (gh #48)
+    nodes = {"__start__": None, "model": None, "tools": None, "CanvasMiddleware.before_agent": None}
+
+
+class _FakeCompiledWithoutCanvasNode:
+    nodes = {"__start__": None, "model": None, "TodoListMiddleware.after_model": None}
+
+
+def test_detect_canvas_middleware_via_node_name():
+    # gh #48: detection must work for a BYO agent that only exposes graph nodes.
+    assert agent_uses_canvas_middleware(_FakeCompiledWithCanvasNode()) is True
+
+
+def test_no_false_positive_from_other_middleware_nodes():
+    assert agent_uses_canvas_middleware(_FakeCompiledWithoutCanvasNode()) is False
+
+
 def test_detect_handles_none_agent():
     # Should not crash on unexpected input
     assert agent_uses_canvas_middleware(None) is False


### PR DESCRIPTION
Closes #48.

`CanvasMiddleware` does its work in `wrap_model_call`, which langchain/deepagents **fuse into the model node** — so a bring-your-own agent that attached `CanvasMiddleware()` via `create_deep_agent(middleware=[...])` exposed **no `.middleware` list and no graph node**, and `agent_uses_canvas_middleware` returned False: the Canvas tab never auto-appeared and `langstage check` reported "no CanvasMiddleware" even when attached per the README.

Fix: `CanvasMiddleware` now defines a **no-op `before_agent` hook**, which langchain compiles into a named `CanvasMiddleware.before_agent` graph node (verified — middleware hooks become `ClassName.hook` nodes). `agent_uses_canvas_middleware` now scans node names (`CanvasMiddleware` + any subclass), in addition to the stashed-`.middleware` path the bundled default agent already uses.

**Verified** against a real BYO deep agent: detection is now `True` (was `False`), and stays `False` for a plain agent (no false positive). Regression tests added; 152 pass.

Bump `0.13.1 → 0.13.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)