### PR TITLE
feat: langstage check --live runs a real turn (ADR 0004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.3 — 2026-07-03
+
+### Added
+- **`langstage check --live`: run one real turn as a true readiness gate (ADR 0004).**
+  The static `check` proves the agent is a runnable graph (gh #39) but not that it
+  can actually complete a turn — a bad key, a tool that fails at runtime, or a
+  broken state schema all pass static and die at first chat. `--live` runs one real
+  turn through the shared `langstage-core` preflight (`core.verify()`) and fails the
+  check (exit 1) if it errors. Default `check` is unchanged — still fast, static,
+  and keyless — so nothing breaks; `--live` is opt-in for when you have a working
+  model and want the real gate. Requires `langstage-core>=1.0.6`.
+
 ## 0.13.2 — 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ langstage check --agent my_agent.py:graph
 [warn] async task tools not found - add `from langstage import LANGSTAGE_TOOLS` ...
 ```
 
+The static checks are fast and need no API key. Add **`--live`** to also run one real
+turn and fail (exit 1) if the agent errors — a true CI readiness gate that catches a
+bad key or a tool that fails at runtime, which the static checks can't:
+
+```bash
+langstage check --agent my_agent.py:graph --live
+```
+
 ## Task board
 
 The **Board** tab turns LangStage into a lightweight agent control room: delegate a task and it runs on a background copy of your agent while you keep chatting. No extra infrastructure — tasks are persisted in a local SQLite file (the board survives a restart) and executed by an in-process worker pool, built on the [`langstage-core`](https://github.com/dkedar7/langstage-core) task engine.

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -114,9 +114,18 @@ def _agent_tool_names(agent) -> set[str] | None:
 @main.command()
 @click.option("--agent", "-a", "agent_spec", default=None, help="Agent spec to check (e.g., my_agent.py:agent)")
 @click.option("--demo", is_flag=True, default=False, help="Check the built-in demo agent instead")
-def check(agent_spec, demo):
+@click.option("--live", is_flag=True, default=False,
+              help="Also run ONE real turn through the agent (needs a working "
+                   "model/key) and fail if it errors — a true readiness gate, "
+                   "beyond the static checks. Uses the shared langstage-core preflight.")
+def check(agent_spec, demo, live):
     """Preflight a bring-your-own agent: load it and report which LangStage
-    features will light up (and which need a convention or tool to unlock)."""
+    features will light up (and which need a convention or tool to unlock).
+
+    The static checks are fast and need no API key. Add ``--live`` to also run one
+    real turn and fail if the agent errors — the same readiness a first chat would
+    prove, so a runnable-but-broken agent (bad key, tool that fails at runtime)
+    doesn't pass here and die at chat time."""
     from langstage_core import load_agent_spec
     from langstage.middleware import agent_uses_canvas_middleware
 
@@ -185,6 +194,22 @@ def check(agent_spec, demo):
                   else "not found - add `from langstage import LANGSTAGE_TOOLS` to your agent's tools"))
     click.echo(f"{ok if has_cron else warn} schedule tools "
                + ("present - agent can create schedules" if has_cron else "not found (LANGSTAGE_TOOLS adds these too)"))
+
+    # --live: the static checks above prove the agent is a runnable graph, not that
+    # it can actually complete a turn (a bad key / a tool that fails at runtime / a
+    # broken state schema all pass static and die at first chat). Run one real turn
+    # through the shared langstage-core preflight and fail the check if it errors —
+    # so a green `check --live` is a true readiness gate. (ADR 0004)
+    if live:
+        from langstage_core.agui import verify as _core_verify
+
+        click.echo("")
+        result = _core_verify(agent)
+        if result.ok:
+            click.echo(f"{ok} live turn: {result.reason}")
+        else:
+            click.echo(f"{fail} live turn failed: {result.reason}")
+            raise SystemExit(1)
 
     click.echo("\nAlways available from the UI regardless of the agent: chat, "
                "tool-call view, file browser, the task board (delegate), and schedules.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.2"
+version = "0.13.3"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -16,7 +16,8 @@ dependencies = [
     # the in-process AG-UI adapter, so the AG-UI runtime (ag-ui-langgraph[fastapi],
     # via core's [agui] extra) is a HARD dep. fastapi + uvicorn are already base
     # deps above, so [agui] mainly adds ag-ui-langgraph itself.
-    "langstage-core[agui]>=1.0",
+    # >=1.0.6 for the shared preflight primitive core.verify() used by `check --live`.
+    "langstage-core[agui]>=1.0.6",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -44,7 +45,7 @@ deepagents = [
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage[agui]` scripts/READMEs still resolve.
 agui = [
-    "langstage-core[agui]>=1.0",
+    "langstage-core[agui]>=1.0.6",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,3 +100,36 @@ def test_check_passes_for_demo_agent():
     result = CliRunner().invoke(cli_mod.main, ["check", "--demo"])
     assert result.exit_code == 0, result.output
     assert "[ ok ] loads" in result.output
+
+
+def test_check_static_default_runs_no_live_turn():
+    """Default `check` stays static/fast/keyless — no live turn (backward-compat)."""
+    result = CliRunner().invoke(cli_mod.main, ["check", "--demo"])
+    assert result.exit_code == 0, result.output
+    assert "live turn" not in result.output
+
+
+def test_check_live_passes_for_demo_agent():
+    """`--live` runs one real turn through core.verify; the keyless stub completes
+    it, so the check is green and reports the live verdict. (ADR 0004)"""
+    result = CliRunner().invoke(cli_mod.main, ["check", "--demo", "--live"])
+    assert result.exit_code == 0, result.output
+    assert "[ ok ] live turn" in result.output
+
+
+def test_check_live_fails_on_runnable_but_broken_agent(tmp_path):
+    """The gap #39 left open: a runnable graph that errors at turn time passes the
+    static checks but must FAIL `--live` (exit 1) — the readiness a first chat proves."""
+    agent = _write(tmp_path, "broken.py",
+                   "from langgraph.graph import StateGraph, START, END, MessagesState\n"
+                   "def boom(s):\n"
+                   "    raise RuntimeError('tool exploded')\n"
+                   "b = StateGraph(MessagesState)\n"
+                   "b.add_node('boom', boom)\n"
+                   "b.add_edge(START, 'boom')\n"
+                   "b.add_edge('boom', END)\n"
+                   "graph = b.compile()\n")
+    result = CliRunner().invoke(cli_mod.main, ["check", "--agent", f"{agent}:graph", "--live"])
+    assert result.exit_code == 1, result.output
+    assert "[ ok ] loads" in result.output  # static gates passed...
+    assert "live turn failed" in result.output  # ...but the real turn caught it

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.0"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -959,8 +959,8 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.0" },
     { name = "langgraph", specifier = ">=1.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0" },
-    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.6" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -974,14 +974,14 @@ provides-extras = ["deepagents", "agui", "dev"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.0"
+version = "1.0.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/4b/768fbd9a47bb66150279c87f5ce5c9aac52f510f5ee0560cb2116fe46586/langstage_core-1.0.0.tar.gz", hash = "sha256:d713aaf0a93c7c5997a839f04358a1cab35ba8c50b70d10deb84e1e9695678ca", size = 222828, upload-time = "2026-07-02T13:41:50.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/cb/ad7e6df5b5a8c0058108ff8819f77b3521a898a625aebfb83b186717a4b8/langstage_core-1.0.6.tar.gz", hash = "sha256:23d5ef9671dc2aa6f0fa98128758d18cca89d46ca6c759963b49d0b2449b1c9e", size = 229186, upload-time = "2026-07-03T16:53:07.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/49/2da5eafc600119cc4d34950068f860a80502f84e57fac63bdfc537156da6/langstage_core-1.0.0-py3-none-any.whl", hash = "sha256:8b41c9600074667ef3612fa9c92d94c6d0a2bc89c14504838bf111ab94859ff7", size = 55774, upload-time = "2026-07-02T13:41:48.866Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/11/85810930bbc62b6e6d51f69aeb3dca88d3df5ec95da07f82d41bf61ca7a3/langstage_core-1.0.6-py3-none-any.whl", hash = "sha256:61072221d64961b03fd93a6af0dc7030bd008bc1cf30fecac74e26d135a9b443", size = 56227, upload-time = "2026-07-03T16:53:06.018Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Second surface adoption of the ADR 0004 shared preflight (`langstage-core` `verify()`, 1.0.6) — after cli `--verify`.

### What
`langstage check --live` runs **one real turn** through `core.verify()` after the static checks, and fails the check (**exit 1**) if the agent errors. Default `check` is **unchanged** — still fast, static, and keyless.

### Why (completes #39)
`check`'s static gate proves the agent is a *runnable graph* (#39) but not that it can *complete a turn* — a bad key, a tool that fails at runtime, or a broken state schema all pass static and die at first chat. `--live` is the real readiness gate for when you have a working model:

```bash
langstage check --agent my_agent.py:graph --live   # exit 0 clean, 1 if it errors
```

### Design choice
Made `--live` **opt-in** rather than changing `check`'s default, because a live turn needs a working key and is slower — making it default would break every keyless `check` in CI. Backward-compatible.

### Tests
`tests/test_cli.py`: default `check` runs no live turn (backward-compat), `--live --demo` passes green, and a **runnable-but-broken** agent (node raises) passes the static gates but **fails `--live`** (exit 1, "live turn failed"). 155 passed. Bumps the core floor to `>=1.0.6`.

Backlog item 38 — remaining: jupyter health, hermes `doctor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)