### PR TITLE
docs: add troubleshooting entry for the pre-0.12.2 workspace split-brain

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,26 @@ app = CoworkApp(
 
 See [langstage-core](https://github.com/dkedar7/langstage-core) for details.
 
+## Troubleshooting
+
+### Files the agent creates don't show up in the file browser
+
+If the agent's `bash`/file tools appear to write somewhere other than the
+workspace shown in the UI's file browser, you're likely on
+`langstage < 0.12.2`. Before that version, `--workspace`,
+`langstage.toml`'s `[workspace] root`, and the Python `workspace=` kwarg
+only configured the file browser — the agent's own tools kept running in
+whatever directory the server was launched from, so files the agent wrote
+would silently land outside the workspace and never appear in the browser.
+
+**Fix:** `pip install --upgrade langstage` (0.12.2+ threads the resolved
+workspace into the agent's tools too, not just the file browser).
+
+**Verify it's working:** ask the agent to run `pwd` and confirm the
+reported path matches your configured workspace. If you're not ready to
+upgrade, `LANGSTAGE_WORKSPACE_ROOT` reached the agent's tools correctly
+even on the affected versions, so setting it directly is a safe fallback.
+
 ## Architecture
 
 ```


### PR DESCRIPTION
Adds a Troubleshooting section covering issue #44 (fixed in #45,
released in 0.12.2): before that version, --workspace/langstage.toml/
Python workspace= only configured the file browser, not the agent's
own bash/file tools, so agent-created files silently landed outside
the workspace and never appeared in the UI.

Verified: confirmed via PyPI release timestamps the fix shipped in
0.12.2 (2 min after #45 merged), then reproduced the issue's own repro
steps against the current release (0.13.3) to confirm it's actually
fixed — file lands in the configured workspace, not the launch dir.