### PR TITLE
feat: workspace is one source of truth, not a hand-synced mirror (ADR 0005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.4 — 2026-07-03
+
+### Changed
+- **The workspace is now one source of truth, not a hand-synced mirror (ADR 0005).**
+  `CoworkApp.__init__` used to reconcile the #44 split-brain imperatively — resolving
+  the workspace, then assigning `config.WORKSPACE_ROOT` and two env vars so the agent's
+  bash/file/canvas tools agreed with the file browser. It now calls
+  `core.apply_workspace(self.config.workspace_root)` once, and `config.WORKSPACE_ROOT`
+  is a **live view** of `core.workspace_root()` (via module `__getattr__`) — so the
+  file browser and the agent tools read the same value by construction, with no mirror
+  to drift. Behavior is unchanged (the full #44 regression suite passes); the split-brain
+  is now structurally impossible. Requires `langstage-core>=1.0.7`.
+
 ## 0.13.3 — 2026-07-03
 
 ### Added

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -1,7 +1,6 @@
 """CoworkApp — main entry point for the application."""
 
 import logging
-import os
 import webbrowser
 from pathlib import Path
 
@@ -73,23 +72,18 @@ class CoworkApp:
             "show_files": show_files,
         })
 
-        # Ensure workspace directory exists
-        self.config.workspace_root.mkdir(parents=True, exist_ok=True)
-
         # Unify the workspace across the WHOLE app on the RESOLVED value (Python
-        # kwarg / CLI --workspace / langstage.toml / env), not just the env var.
-        # The agent's bash/file/canvas tools read langstage.config.WORKSPACE_ROOT
-        # (and some agents read the env var), so set both from the resolved config
-        # BEFORE the agent + tools are built. Otherwise --workspace/toml/Python
-        # reach the file browser but the agent's tools keep running in the launch
-        # cwd — a split-brain where only the env var (lowest documented priority)
-        # actually reached the agent. (gh #44)
-        from langstage import config as _config
+        # kwarg / CLI --workspace / langstage.toml / env) via the shared source of
+        # truth (ADR 0005), BEFORE the agent + tools are built. apply_workspace
+        # ensures the dir, publishes LANGSTAGE_WORKSPACE_ROOT (+ legacy) for agents
+        # that read the env, and records the active workspace that config.WORKSPACE_ROOT
+        # (the agent's bash/file/canvas tools) and the file browser both read — so
+        # --workspace/toml/Python can't reach the browser while the agent runs in the
+        # launch cwd (the #44 split-brain). No chdir: a server serves one workspace but
+        # must not move the process cwd out from under anything else.
+        from langstage_core import apply_workspace
 
-        _resolved_ws = self.config.workspace_root.resolve()
-        _config.WORKSPACE_ROOT = _resolved_ws
-        os.environ["LANGSTAGE_WORKSPACE_ROOT"] = str(_resolved_ws)
-        os.environ["DEEPAGENT_WORKSPACE_ROOT"] = str(_resolved_ws)
+        apply_workspace(self.config.workspace_root)
 
         self.agent = self._resolve_agent(agent)
         self.stream_parser_config = stream_parser_config or {}

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -8,7 +8,6 @@ resolved through the shared chain — defaults < deepagents.toml < DEEPAGENT_* e
 import os
 import warnings
 from dataclasses import dataclass, fields, replace
-from pathlib import Path
 from typing import ClassVar, Optional
 
 from langstage_core.host import HostConfig
@@ -47,16 +46,26 @@ def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
     return None
 
 
-# Module-level constants used by tools.py (bash cwd + file tools) and
-# default_agent.py. Canonical LANGSTAGE_* first, deprecated DEEPAGENT_* fallback.
-# Reading ONLY the legacy names here while default_agent.py honored the canonical
-# LANGSTAGE_WORKSPACE_ROOT created a split-brain: the file browser used the
-# canonical workspace but the agent's bash/file tools ran in cwd (gh #-dogfood).
-# This is the single source — default_agent.py imports WORKSPACE_ROOT from here.
-_ws = _env_canonical_first("LANGSTAGE_WORKSPACE_ROOT", "DEEPAGENT_WORKSPACE_ROOT")
-WORKSPACE_ROOT = Path(_ws) if _ws else Path(os.getcwd())
+# WORKSPACE_ROOT is read by tools.py (bash cwd + file tools) and default_agent.py.
+# Since ADR 0005 it is a LIVE VIEW of the shared source of truth
+# (core.workspace_root()), not a separate mutable constant: CoworkApp.__init__ calls
+# core.apply_workspace(the resolved workspace), and every reader here — the file
+# browser and the agent's bash/file/canvas tools — sees that one value. There is no
+# mirror to hand-sync and drift, which was the #44 split-brain. Before apply_workspace
+# runs, workspace_root() falls back to canonical LANGSTAGE_WORKSPACE_ROOT / legacy
+# DEEPAGENT_WORKSPACE_ROOT / cwd — the same import-time default as before.
 _vfs = _env_canonical_first("LANGSTAGE_VIRTUAL_FS", "DEEPAGENT_VIRTUAL_FS")
 VIRTUAL_FS = (_vfs or "").lower() in ("1", "true", "yes")
+
+
+def __getattr__(name: str):
+    # PEP 562 module getattr: resolve WORKSPACE_ROOT dynamically to the single
+    # source of truth so it can't diverge from what the agent's tools use.
+    if name == "WORKSPACE_ROOT":
+        from langstage_core import workspace_root
+
+        return workspace_root()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 _SAVE_PROMPT = (
     "Please capture this conversation as a detailed workflow markdown file in "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.3"
+version = "0.13.4"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -17,7 +17,7 @@ dependencies = [
     # via core's [agui] extra) is a HARD dep. fastapi + uvicorn are already base
     # deps above, so [agui] mainly adds ag-ui-langgraph itself.
     # >=1.0.6 for the shared preflight primitive core.verify() used by `check --live`.
-    "langstage-core[agui]>=1.0.6",
+    "langstage-core[agui]>=1.0.7",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -45,7 +45,7 @@ deepagents = [
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage[agui]` scripts/READMEs still resolve.
 agui = [
-    "langstage-core[agui]>=1.0.6",
+    "langstage-core[agui]>=1.0.7",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_canonical_workspace.py
+++ b/tests/test_canonical_workspace.py
@@ -79,6 +79,34 @@ def test_config_tools_agent_agree_on_canonical_workspace(tmp_path):
     assert Path(cfg) == Path(tools) == Path(agent)  # no split-brain
 
 
+def test_config_workspace_root_is_live_view_of_source_of_truth(tmp_path):
+    """ADR 0005: config.WORKSPACE_ROOT is a *live view* of core.workspace_root(),
+    not a separate mutable mirror — so the file browser and the agent tools can't
+    drift apart (the #44 split-brain is structurally impossible). Run in a
+    subprocess so the process-global workspace can't leak.
+    """
+    import os as _os
+
+    ws = tmp_path / "applied"
+    code = (
+        "from langstage_core import apply_workspace, workspace_root;"
+        "import langstage.config as c;"
+        f"apply_workspace(r'{ws}');"
+        # After apply, the module attribute reflects the source of truth with no
+        # separate assignment — reading it again tracks a re-apply.
+        "print('CFG=' + str(c.WORKSPACE_ROOT));"
+        "print('SRC=' + str(workspace_root()))"
+    )
+    env = {k: v for k, v in _os.environ.items() if not k.endswith("WORKSPACE_ROOT")}
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+    assert out.returncode == 0, out.stderr
+    cfg = next(line[4:] for line in out.stdout.splitlines() if line.startswith("CFG="))
+    src = next(line[4:] for line in out.stdout.splitlines() if line.startswith("SRC="))
+    assert cfg == src == str(ws.resolve())
+
+
 def test_cli_workspace_reaches_agent_bash(tmp_path):
     """--workspace / CoworkApp(workspace=) must reach the agent's bash tool, not
     just the file browser. Previously only the env var (lowest documented

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.3"
+version = "0.13.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -959,8 +959,8 @@ requires-dist = [
     { name = "langchain", specifier = ">=1.0" },
     { name = "langgraph", specifier = ">=1.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0" },
-    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.6" },
-    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.6" },
+    { name = "langstage-core", extras = ["agui"], specifier = ">=1.0.7" },
+    { name = "langstage-core", extras = ["agui"], marker = "extra == 'agui'", specifier = ">=1.0.7" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
@@ -974,14 +974,14 @@ provides-extras = ["deepagents", "agui", "dev"]
 
 [[package]]
 name = "langstage-core"
-version = "1.0.6"
+version = "1.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/cb/ad7e6df5b5a8c0058108ff8819f77b3521a898a625aebfb83b186717a4b8/langstage_core-1.0.6.tar.gz", hash = "sha256:23d5ef9671dc2aa6f0fa98128758d18cca89d46ca6c759963b49d0b2449b1c9e", size = 229186, upload-time = "2026-07-03T16:53:07.05Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/7a/e9414ca7fa3857945de02743c7b42bc391dd723c9d36f52d6f552a37fe63/langstage_core-1.0.7.tar.gz", hash = "sha256:b9218b3585aba51630b531fa2c66038e279df9abfad3736bfc6071f708fc27cd", size = 235044, upload-time = "2026-07-03T21:38:11.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/11/85810930bbc62b6e6d51f69aeb3dca88d3df5ec95da07f82d41bf61ca7a3/langstage_core-1.0.6-py3-none-any.whl", hash = "sha256:61072221d64961b03fd93a6af0dc7030bd008bc1cf30fecac74e26d135a9b443", size = 56227, upload-time = "2026-07-03T16:53:06.018Z" },
+    { url = "https://files.pythonhosted.org/packages/41/00/a59d85d92d4bd9ae5d165ede92dbd6793aeae4a883f1cf1fc0398b0e2d09/langstage_core-1.0.7-py3-none-any.whl", hash = "sha256:9aa0b854f7d82da2273ede090786bada0d3587f2adeadf95dc90152d7af59b2b", size = 57344, upload-time = "2026-07-03T21:38:10.819Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fifth and **final** surface migration for ADR 0005 (workspace application in core, `langstage-core` 1.0.7) — and the one I saved for last because it's the #44 split-brain.

### What
`CoworkApp.__init__` used to fix the #44 split-brain *imperatively*: resolve the workspace, then assign `config.WORKSPACE_ROOT` **and** two env vars so the agent's bash/file/canvas tools agreed with the file browser. That hand-sync is exactly the kind of mirror that drifts.

Now:
- `CoworkApp.__init__` calls **`core.apply_workspace(self.config.workspace_root)`** once.
- `config.WORKSPACE_ROOT` is a **live view** of `core.workspace_root()` via a module `__getattr__` (PEP 562) — not a separate mutable constant.

So the file browser and the agent tools read the same value **by construction**. The split-brain isn't fixed by reconciliation anymore — it's structurally impossible.

### Why this is low-risk despite being the scary one
`tools.py` already read `config.WORKSPACE_ROOT` *dynamically* (`from . import config as cfg; cfg.WORKSPACE_ROOT`), and the static import is unused at runtime — so redirecting the attribute to `workspace_root()` makes every reader follow the single source with **no change to tools.py**. Two files change: `config.py` + `app.py`.

### Tests (regression-first)
- The entire existing **#44 regression suite** (`test_canonical_workspace.py`, incl. `test_cli_workspace_reaches_agent_bash` which asserts the agent's `bash('pwd')` runs in the workspace) passes **unchanged**.
- Added `test_config_workspace_root_is_live_view_of_source_of_truth`: after `apply_workspace`, `config.WORKSPACE_ROOT` == `core.workspace_root()` — proving there's no separate mirror.
- **156 passed.** Bumps the core floor to `>=1.0.7`.

Completes the ADR 0005 rollout: core 1.0.7 → cli → vscode → hermes → jupyter → **web**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)