### PR TITLE
docs: fix Task-board snippet import (gh #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The **Board** tab turns LangStage into a lightweight agent control room: delegat
 - **Agent self-delegation** — the default agent carries five tools (`start_async_task`, `check_async_task`, `list_async_tasks`, `update_async_task`, `cancel_async_task`) so it can spawn async sub-tasks; spawned tasks are linked to their parent on the board. Add them to a custom agent with:
 
   ```python
-  from langgraph_stream_parser.tasks import TASK_TOOLS
+  from langstage_core.tasks import TASK_TOOLS
   agent = create_deep_agent(tools=[*your_tools, *TASK_TOOLS], ...)
   ```
 


### PR DESCRIPTION
Closes #59.

The README's agent-self-delegation snippet imported `from langgraph_stream_parser.tasks import TASK_TOOLS` — a module retired in the 1.0 rename — so the documented copy-paste `ModuleNotFoundError`s on a clean `pip install langstage`. `TASK_TOOLS` (the five async-task tools the snippet documents) lives in `langstage_core.tasks`. Verified the corrected import resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)