### PR TITLE
fix: replace deprecated @app.on_event with FastAPI lifespan

### DIFF
--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -1,6 +1,7 @@
 """FastAPI application factory."""
 
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
@@ -34,7 +35,53 @@ def create_fastapi_app(
     custom_css_content: str | None = None,
 ) -> FastAPI:
     """Create a FastAPI app with SSE streaming, REST, and static file serving."""
-    app = FastAPI(title=config.title, version="2.0.0")
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        await task_store.setup()
+        # Upgrade an auto-attached in-memory checkpointer to a durable SQLite
+        # one so conversation/interrupt state + the task review gate survive a
+        # restart (and orphaned tasks resume from their last checkpoint). Only
+        # touches checkpointers LangStage attached (the sentinel) — never a
+        # user-supplied one.
+        if getattr(agent, "_langstage_auto_checkpointer", False) is True:
+            try:
+                from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+
+                ckpt_db = workspace / ".langstage" / "checkpoints.db"
+                ckpt_db.parent.mkdir(parents=True, exist_ok=True)
+                ckpt_cm = AsyncSqliteSaver.from_conn_string(str(ckpt_db))
+                saver = await ckpt_cm.__aenter__()
+                await saver.setup()
+                agent.checkpointer = saver
+                app.state._ckpt_cm = ckpt_cm
+            except Exception:  # noqa: BLE001 - keep the in-memory saver on failure
+                import logging
+                logging.getLogger(__name__).warning(
+                    "Durable checkpointer unavailable; keeping in-memory.",
+                    exc_info=True,
+                )
+        await runner.start()
+        scheduler.start()
+
+        try:
+            yield
+        finally:
+            # Mirrors the old @app.on_event("shutdown") semantics: these run
+            # unconditionally on shutdown, not just on a clean exit.
+            scheduler.shutdown()
+            await runner.shutdown()
+            await task_store.close()
+            ckpt_cm = getattr(app.state, "_ckpt_cm", None)
+            if ckpt_cm is not None:
+                try:
+                    await ckpt_cm.__aexit__(None, None, None)
+                except Exception:  # noqa: BLE001
+                    pass
+            set_scheduler(None)
+            set_runner(None)
+
+    app = FastAPI(title=config.title, version="2.0.0", lifespan=lifespan)
 
     # Middleware
     add_middleware(
@@ -81,48 +128,6 @@ def create_fastapi_app(
     scheduler = CronScheduler(runner)
     set_scheduler(scheduler)
     app.include_router(create_cron_router(scheduler))
-
-    @app.on_event("startup")
-    async def _start_services() -> None:
-        await task_store.setup()
-        # Upgrade an auto-attached in-memory checkpointer to a durable SQLite
-        # one so conversation/interrupt state + the task review gate survive a
-        # restart (and orphaned tasks resume from their last checkpoint). Only
-        # touches checkpointers LangStage attached (the sentinel) — never a
-        # user-supplied one.
-        if getattr(agent, "_langstage_auto_checkpointer", False) is True:
-            try:
-                from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
-
-                ckpt_db = workspace / ".langstage" / "checkpoints.db"
-                ckpt_db.parent.mkdir(parents=True, exist_ok=True)
-                ckpt_cm = AsyncSqliteSaver.from_conn_string(str(ckpt_db))
-                saver = await ckpt_cm.__aenter__()
-                await saver.setup()
-                agent.checkpointer = saver
-                app.state._ckpt_cm = ckpt_cm
-            except Exception:  # noqa: BLE001 - keep the in-memory saver on failure
-                import logging
-                logging.getLogger(__name__).warning(
-                    "Durable checkpointer unavailable; keeping in-memory.",
-                    exc_info=True,
-                )
-        await runner.start()
-        scheduler.start()
-
-    @app.on_event("shutdown")
-    async def _stop_services() -> None:
-        scheduler.shutdown()
-        await runner.shutdown()
-        await task_store.close()
-        ckpt_cm = getattr(app.state, "_ckpt_cm", None)
-        if ckpt_cm is not None:
-            try:
-                await ckpt_cm.__aexit__(None, None, None)
-            except Exception:  # noqa: BLE001
-                pass
-        set_scheduler(None)
-        set_runner(None)
 
     # Expose for testing
     app.state.session_adapter = adapter

--- a/tests/test_byo_integration.py
+++ b/tests/test_byo_integration.py
@@ -86,16 +86,11 @@ async def test_server_startup_upgrades_to_sqlite(tmp_path):
     config = AppConfig.resolve(overrides={"workspace_root": tmp_path})
     app = create_fastapi_app(agent=graph, workspace=tmp_path, config=config)
 
-    # Run the registered startup/shutdown handlers directly (portable across
-    # Starlette versions — `router.startup()` isn't available everywhere).
-    for handler in app.router.on_startup:
-        await handler()
-    try:
+    # Drive the lifespan context manager directly: startup runs up to the
+    # `yield`, shutdown runs on exit (even if the body raises).
+    async with app.router.lifespan_context(app):
         assert isinstance(graph.checkpointer, AsyncSqliteSaver)
         assert (tmp_path / ".langstage" / "checkpoints.db").exists()
-    finally:
-        for handler in app.router.on_shutdown:
-            await handler()
 
 
 def test_langstage_tools_bundle():


### PR DESCRIPTION
@app.on_event("startup"/"shutdown") emits a FastAPI DeprecationWarning
(use lifespan event handlers instead). Replaced both with a single
@asynccontextmanager lifespan function passed to FastAPI(lifespan=...).
All original logic (checkpointer upgrade, task runner/scheduler
start/stop) is unchanged.

Wrapped the post-yield shutdown code in try/finally to preserve the
old on_event("shutdown") semantics: those handlers always ran
unconditionally on shutdown, which a bare yield doesn't guarantee if
an exception occurs during the app's runtime.

Updated test_server_startup_upgrades_to_sqlite, which manually
iterated app.router.on_startup/on_shutdown (now empty under
lifespan=) — switched to driving app.router.lifespan_context(app)
directly.

Verified: zero on_event warnings anywhere in test output, full suite
159 passed/1 skipped, and a live smoke test (real demo server via the
actual ASGI lifespan protocol) starts and stops cleanly.