### PR TITLE
fix: report the real workspace as [Working directory], not virtual / (dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.13.5 — 2026-07-04
+
+### Fixed
+- **The `[Working directory: …]` context the chat prepends to each message now
+  reports the real filesystem workspace, not the frontend's virtual path (dogfood).**
+  It used the file browser's current folder verbatim, so an agent at the browser root
+  was told `[Working directory: /]` — misleading, and actively wrong for a
+  bring-your-own agent that resolves paths against it. It now reports
+  `core.workspace_root()` with the browsed subfolder applied (e.g. `<workspace>/notes`),
+  so the agent hears where it actually operates.
+
 ## 0.13.4 — 2026-07-03
 
 ### Changed

--- a/langstage/server/routes_chat.py
+++ b/langstage/server/routes_chat.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
+from langstage_core import workspace_root
 from langstage_core.adapters import SessionAdapter
 
 from langstage.workspace.file_manager import FileManager
@@ -36,15 +37,24 @@ class CancelRequest(BaseModel):
 
 
 def context_parts(cwd: str | None = None) -> list[str]:
-    """Context lines prepended to each user message (current time + cwd).
+    """Context lines prepended to each user message (current time + working dir).
 
     Forwarded to ``SessionAdapter.submit_message(context_parts=...)``, which
     feeds them through ``prepare_agent_input``.
+
+    ``cwd`` is the file browser's current folder as a *virtual* path (``/`` = the
+    workspace root). We report the **real filesystem** working directory the agent
+    operates in — the resolved workspace (``core.workspace_root()``) with that
+    virtual subfolder applied — not the raw virtual path. Reporting the raw ``/``
+    told the agent its working directory was the filesystem root (misleading, and
+    actively wrong for a bring-your-own agent that resolves paths against it).
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     parts = [f"[Current time: {now}]"]
-    if cwd:
-        parts.append(f"[Working directory: {cwd}]")
+    root = workspace_root()
+    sub = (cwd or "").strip("/\\")
+    working_dir = (root / sub) if sub else root
+    parts.append(f"[Working directory: {working_dir}]")
     return parts
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.4"
+version = "0.13.5"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -61,16 +61,18 @@ async def test_stream_delivers_content_and_complete():
     assert "error" not in types
 
 
-async def test_message_and_cwd_reach_the_agent():
-    """The user message + cwd context must survive prepare_agent_input to the agent.
+async def test_message_and_cwd_reach_the_agent(monkeypatch, tmp_path):
+    """The user message + the resolved working directory must reach the agent.
 
     The stub echoes the human message it receives, so both the message and the
-    injected cwd context appear in the streamed content.
+    injected working-directory context appear in the streamed content.
     """
+    monkeypatch.setattr("langstage_core.host.workspace._ACTIVE", None)
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(tmp_path))
     adapter = SessionAdapter(graph=_stub())
     session = adapter.submit_message(
         "s-ctx", "the magic phrase",
-        context_parts=context_parts(cwd="/tmp/test-workspace"),
+        context_parts=context_parts(cwd="/reports"),
     )
     await session.current_task
 
@@ -78,7 +80,9 @@ async def test_message_and_cwd_reach_the_agent():
         e.get("content", "") for e in _drain(session.event_queue) if e.get("type") == "content"
     )
     assert "the magic phrase" in content
-    assert "/tmp/test-workspace" in content
+    # The REAL working directory (workspace + the browsed subfolder) reached the
+    # agent — not the raw virtual "/reports". (gh dogfood-F4)
+    assert str(tmp_path / "reports") in content
 
 
 # --- Error path --------------------------------------------------------------
@@ -99,12 +103,22 @@ async def test_stream_surfaces_errors_as_events():
 # --- Library API contract (guards against core drift) ------------------------
 
 
-def test_context_parts_includes_time_and_cwd():
-    parts = context_parts(cwd="/work")
-    assert any("Current time" in p for p in parts)
-    assert any("/work" in p for p in parts)
-    # Without cwd, only the time line is present.
-    assert len(context_parts()) == 1
+def test_context_parts_reports_real_workspace_not_virtual_root(monkeypatch, tmp_path):
+    # gh dogfood-F4: the "Working directory" must be the REAL filesystem workspace,
+    # not the frontend's virtual path. A "/" cwd (file-browser root) must report the
+    # workspace root, NOT filesystem root — the old bug told a BYO agent its cwd was "/".
+    monkeypatch.setattr("langstage_core.host.workspace._ACTIVE", None)
+    monkeypatch.setenv("LANGSTAGE_WORKSPACE_ROOT", str(tmp_path))
+
+    root_parts = context_parts(cwd="/")
+    assert any("Current time" in p for p in root_parts)
+    wd = next(p for p in root_parts if "Working directory" in p)
+    assert str(tmp_path) in wd
+    assert "[Working directory: /]" not in wd  # the F4 symptom must be gone
+
+    # A browsed subfolder resolves under the workspace, not as a bare virtual path.
+    sub = next(p for p in context_parts(cwd="/notes") if "Working directory" in p)
+    assert str(tmp_path / "notes") in sub
 
 
 def test_prepare_agent_input_contract():


### PR DESCRIPTION
Found by a fresh-user dogfood (a bring-your-own note-taking agent).

The chat prepends `[Working directory: {cwd}]` to each message, where `cwd` is the **file browser's current folder** — a *virtual* path (`/` = workspace root). So at the browser root the agent was told `[Working directory: /]`, i.e. filesystem root. Misleading, and actively wrong for a BYO agent that resolves paths against its "working directory."

`context_parts` now reports `core.workspace_root()` (the real filesystem workspace) with the browsed subfolder applied — e.g. `<workspace>` at the root, `<workspace>/notes` when browsing `/notes`.

`tests/test_streaming.py`: a `/` cwd now reports the workspace root (not `/`); a `/notes` cwd resolves under the workspace; the resolved dir reaches the agent. 160 passed.

Note: this fixes the *misleading preamble*. The deeper cross-surface question (a BYO agent's raw relative writes land in the launch cwd on servers, vs the workspace on cli) is a separate design decision — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)