### PR TITLE
fix: operate the agent from the workspace cwd so BYO files land there (ADR 0006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.6 — 2026-07-04
+
+### Fixed
+- **A bring-your-own agent's files now land in the workspace, visible in the file
+  browser (ADR 0006, dogfood F7).** An agent that writes `Path("out.txt").write_text(…)`
+  (a raw cwd-relative path) used to write to the server's *launch* directory — invisible
+  in the file browser (rooted at the workspace) — so the agent could say "saved to the
+  workspace" while the browser showed it empty. `run()` now `chdir`s to the resolved
+  workspace after the agent spec is resolved and the server is wired (both use the
+  absolute path, so they're unaffected), matching the cli. Embedding `CoworkApp`
+  programmatically has no cwd side effect (the chdir is in `run()`, not `__init__`).
+
 ## 0.13.5 — 2026-07-04
 
 ### Fixed

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -1,6 +1,7 @@
 """CoworkApp — main entry point for the application."""
 
 import logging
+import os
 import webbrowser
 from pathlib import Path
 
@@ -157,9 +158,26 @@ class CoworkApp:
         from langstage.default_agent import create_default_agent
         return create_default_agent(self.config.workspace_root)
 
+    def _enter_workspace(self) -> None:
+        """Make the resolved workspace the process cwd (ADR 0006).
+
+        So a bring-your-own agent's raw relative file ops
+        (``Path("out.txt").write_text(...)``) land in the workspace — where the file
+        browser shows them — instead of the server's launch cwd. Called from ``run()``
+        *after* the agent spec is resolved and ``create_server()`` has wired the file
+        browser at the **absolute** workspace, so neither is affected. The bundled
+        agent (rooted via an absolute ``FilesystemBackend``) is unaffected either way.
+        Done in ``run()`` (not ``__init__``) so embedding ``CoworkApp`` has no cwd side
+        effect. Safe under the one-workspace-per-process model (ADR 0005).
+        """
+        from langstage_core import workspace_root
+
+        os.chdir(workspace_root())
+
     def run(self, open_browser: bool = True) -> None:
         """Start the FastAPI server with uvicorn. Blocks."""
         app = self.create_server()
+        self._enter_workspace()
 
         if open_browser:
             url = f"http://{self.config.host}:{self.config.port}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.5"
+version = "0.13.6"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_canonical_workspace.py
+++ b/tests/test_canonical_workspace.py
@@ -146,3 +146,32 @@ def test_cli_workspace_reaches_agent_bash(tmp_path):
     # not the launch cwd.
     assert os.path.basename(ws.rstrip("/\\")) == "project", ws
     assert os.path.basename(bashpwd.rstrip("/")) == "project", bashpwd
+
+
+def test_run_enters_workspace_cwd(tmp_path):
+    """ADR 0006: run() chdirs to the resolved workspace so a bring-your-own agent's
+    raw relative file writes land in the workspace (visible in the file browser), not
+    the server's launch cwd. Construction itself must NOT chdir (embedding side effect)."""
+    from langgraph.graph import END, START, MessagesState, StateGraph
+    from langstage import CoworkApp
+
+    def _n(s):
+        return {"messages": []}
+
+    b = StateGraph(MessagesState)
+    b.add_node("n", _n)
+    b.add_edge(START, "n")
+    b.add_edge("n", END)
+
+    ws = tmp_path / "ws"
+    origin = os.getcwd()
+    try:
+        app = CoworkApp(agent=b.compile(), workspace=str(ws))
+        # Constructing does not move cwd...
+        assert os.getcwd() == origin
+        # ...run()'s enter-workspace step does.
+        app._enter_workspace()
+        from pathlib import Path
+        assert Path(os.getcwd()).resolve() == ws.resolve()
+    finally:
+        os.chdir(origin)


### PR DESCRIPTION
Closes the headline dogfood finding (F7). See **ADR 0006** in langstage-core.

### The bug (fresh-user dogfood)
A BYO agent that writes `Path("notes.md").write_text(...)` — a raw cwd-relative path — wrote to the server's **launch dir**, not the workspace. The file browser (rooted at the workspace) showed **"Workspace is empty"** while the agent replied "saved to the workspace." Core can't re-root an arbitrary BYO tool (ADR 0005 boundary); the only mechanism that redirects a raw relative write is the **process cwd** — which cli already sets, but the server didn't.

### Fix
`run()` `chdir`s to the resolved workspace, **after** the agent spec is resolved and `create_server()` has wired the file browser (both use the absolute workspace, so neither is affected). Now a BYO agent's relative writes land in the workspace and appear in the browser — matching cli.

- Placed in `run()`, not `__init__`, so **embedding** `CoworkApp` has no cwd side effect.
- The bundled agent (absolute `FilesystemBackend` root) is unaffected either way.
- Safe under the one-workspace-per-process model (ADR 0005).

### Tests
`test_run_enters_workspace_cwd`: constructing does **not** move cwd; `_enter_workspace()` does (to the workspace). 161 passed, ruff clean.

Jupyter is the documented exception (JupyterLab owns the process cwd) — see ADR 0006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)