### PR TITLE
fix: don't use a graph's default "LangGraph" name as the app title + refresh header (dogfood)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.7 — 2026-07-04
+
+### Fixed
+- **A bare graph's default name "LangGraph" no longer becomes the app title (dogfood
+  F3).** A compiled `StateGraph` gets `.name == "LangGraph"` by default, which the app
+  used as its header title/agent name for a BYO agent — a confusing brand. Generic
+  names (`LangGraph`, `agent`, `graph`) are now ignored, so the `LangStage` default is
+  kept; a real agent `.name` still becomes the title.
+
+### Docs
+- Refreshed the README header to a `langstage` SVG banner (was a `cover.png` labelled
+  "Cowork Dash", the old name).
+
 ## 0.13.6 — 2026-07-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > Renamed from **cowork-dash** (the old package name now just installs this one, and the `cowork-dash` command still works).
 
 <p align="center">
-  <img src="assets/cover.png" alt="Cowork Dash" style="border: 1px solid #d0d7de; border-radius: 6px;" />
+  <img src="assets/header.svg" alt="langstage — the web stage for your LangGraph agent" width="100%" />
 </p>
 
 **Stack**: Python (FastAPI, chat over Server-Sent Events) backend, React (TypeScript + Vite) frontend.

--- a/assets/header.svg
+++ b/assets/header.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="340" viewBox="0 0 1280 340" role="img" aria-label="langstage — the web stage for your LangGraph agent: chat, files, and a canvas">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0B1221"/>
+      <stop offset="1" stop-color="#0E1B2E"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#7C5CFF"/>
+      <stop offset="1" stop-color="#34D6C8"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.82" cy="0.15" r="0.6">
+      <stop offset="0" stop-color="#7C5CFF" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#7C5CFF" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="340" rx="20" fill="url(#bg)"/>
+  <rect width="1280" height="340" rx="20" fill="url(#glow)"/>
+  <rect x="1" y="1" width="1278" height="338" rx="19" fill="none" stroke="#21314A" stroke-width="1.5"/>
+
+  <!-- ===== left: identity ===== -->
+  <g transform="translate(72,66)">
+    <rect width="118" height="34" rx="17" fill="#1A1535" stroke="url(#accent)" stroke-width="1.5"/>
+    <circle cx="22" cy="17" r="5" fill="url(#accent)"/>
+    <text x="38" y="23" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="15" fill="#C9BEFF">web stage</text>
+  </g>
+
+  <text x="70" y="178" font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="62" font-weight="700" fill="#F2F6FC" letter-spacing="-1">lang<tspan fill="url(#accent)">stage</tspan></text>
+
+  <text x="72" y="224" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#9DB2C8">The web stage for your LangGraph agent &#8212;</text>
+  <text x="72" y="254" font-family="'Segoe UI',Helvetica,Arial,sans-serif" font-size="22" fill="#9DB2C8">streaming chat, a file browser, and a canvas.</text>
+
+  <g font-family="'SF Mono','JetBrains Mono','Consolas',monospace" font-size="13" fill="#7C7FA6">
+    <text x="72" y="300">chat</text>
+    <text x="124" y="300" fill="#45487A">&#8226;</text>
+    <text x="144" y="300">files</text>
+    <text x="196" y="300" fill="#45487A">&#8226;</text>
+    <text x="216" y="300">canvas</text>
+    <text x="288" y="300" fill="#45487A">&#8226;</text>
+    <text x="308" y="300">task board</text>
+    <text x="404" y="300" fill="#45487A">&#8226;</text>
+    <text x="424" y="300">schedules</text>
+  </g>
+
+  <!-- ===== right: browser mock (chat + side panel) ===== -->
+  <g transform="translate(788,70)">
+    <rect width="424" height="200" rx="12" fill="#0E1526" stroke="#26314C" stroke-width="1.5"/>
+    <!-- title bar -->
+    <rect width="424" height="30" rx="12" fill="#141C30"/>
+    <rect y="18" width="424" height="12" fill="#141C30"/>
+    <circle cx="20" cy="15" r="4" fill="#E06C75"/>
+    <circle cx="36" cy="15" r="4" fill="#E5C07B"/>
+    <circle cx="52" cy="15" r="4" fill="#98C379"/>
+    <text x="404" y="19" text-anchor="end" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#5C6C86">Connected</text>
+    <!-- chat column -->
+    <g transform="translate(16,46)">
+      <rect x="60" width="140" height="20" rx="8" fill="#1A2338"/>
+      <rect y="34" width="10" height="10" rx="5" fill="url(#accent)"/>
+      <rect x="18" y="36" width="180" height="8" rx="4" fill="#2A3B57"/>
+      <rect x="18" y="50" width="150" height="8" rx="4" fill="#2A3B57"/>
+      <rect x="18" y="70" width="110" height="22" rx="6" fill="#0C2A22" stroke="#34D6C8" stroke-width="1"/>
+      <circle cx="30" cy="81" r="3.5" fill="#34D6C8"/>
+      <text x="42" y="85" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#7FE3D6">write_file</text>
+    </g>
+    <!-- side panel: files -->
+    <line x1="256" y1="30" x2="256" y2="200" stroke="#26314C" stroke-width="1"/>
+    <g transform="translate(272,48)" font-family="'SF Mono','Consolas',monospace" font-size="10" fill="#8FA3C0">
+      <text x="0" y="6" fill="#5C6C86">FILES</text>
+      <rect x="0" y="16" width="10" height="9" rx="2" fill="#2F9BFF" opacity="0.6"/>
+      <text x="16" y="24">notes.md</text>
+      <rect x="0" y="34" width="10" height="9" rx="2" fill="#2F9BFF" opacity="0.6"/>
+      <text x="16" y="42">report.csv</text>
+      <rect x="0" y="52" width="10" height="9" rx="2" fill="#7C5CFF" opacity="0.6"/>
+      <text x="16" y="60">.canvas/</text>
+    </g>
+  </g>
+</svg>

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -97,8 +97,13 @@ class CoworkApp:
         if self.config.show_files is None:
             self.config.show_files = True
 
-        # Default title and agent_name from the agent object's .name if not explicitly set
+        # Default title and agent_name from the agent object's .name if not explicitly
+        # set — but a bare CompiledStateGraph's default .name is "LangGraph" (and
+        # "agent"/"graph" are just as generic), which reads as a confusing app title for
+        # a BYO agent. Treat those as "no meaningful name" and keep the LangStage default.
         inferred_name = getattr(self.agent, "name", None)
+        if inferred_name in ("LangGraph", "agent", "graph"):
+            inferred_name = None
         if inferred_name:
             if self.config.title == "LangStage":
                 self.config.title = inferred_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.6"
+version = "0.13.7"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_title_inference.py
+++ b/tests/test_title_inference.py
@@ -1,0 +1,34 @@
+"""The app title/agent-name inferred from the agent's .name (dogfood F3).
+
+A bare CompiledStateGraph's default .name is "LangGraph" — a confusing app title for
+a BYO agent — so it must NOT become the title; a real name still does.
+"""
+
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from langstage import CoworkApp
+
+
+def _graph(name=None):
+    b = StateGraph(MessagesState)
+    b.add_node("n", lambda s: {"messages": []})
+    b.add_edge(START, "n")
+    b.add_edge("n", END)
+    g = b.compile()
+    if name:
+        g.name = name
+    return g
+
+
+def test_generic_graph_name_is_not_used_as_title(tmp_path):
+    g = _graph()
+    assert g.name == "LangGraph"  # the default a bare compile gives
+    app = CoworkApp(agent=g, workspace=str(tmp_path))
+    assert app.config.title == "LangStage"  # kept the default, not "LangGraph"
+    assert app.config.agent_name == "Agent"
+
+
+def test_real_graph_name_becomes_title(tmp_path):
+    app = CoworkApp(agent=_graph("Research Assistant"), workspace=str(tmp_path))
+    assert app.config.title == "Research Assistant"
+    assert app.config.agent_name == "Research Assistant"


### PR DESCRIPTION
Two dogfood cosmetics.

**F3:** a compiled `StateGraph` gets `.name == "LangGraph"` by default, which the app used as its header title for a BYO agent — reads as a confusing brand. Generic names (`LangGraph`, `agent`, `graph`) are now ignored (the `LangStage` default is kept); a real `.name` still becomes the title. `tests/test_title_inference.py` covers both.

**Header:** refreshed the README to a `langstage` SVG banner (was `cover.png` labelled "Cowork Dash").

163 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)