### PR TITLE
feat: add a real /api/health liveness + readiness endpoint (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.9 — 2026-07-06
+
+### Added
+- **A real health/readiness endpoint: `GET /api/health` (gh #67).** `/health` (and every
+  non-`/api/*` path) returned the SPA `index.html` — HTTP 200 regardless of backend state,
+  and 401 once auth was enabled — so a reverse proxy / k8s / uptime probe had no usable
+  liveness signal. The new endpoint is dedicated JSON under `/api/*` (so it can't collide
+  with the SPA catch-all) and **exempt from Basic Auth** (a probe can't carry credentials):
+  - liveness (default) → `200 {"status": "ok", "version": …}` — the process is up;
+  - readiness (`?ready=1`) → `200` only if the agent object loaded **and** the task store
+    is reachable, else `503 {"status": "degraded", "checks": {…}}` — reflecting real
+    backend state instead of the always-served static shell.
+
 ## 0.13.8 — 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ langstage-agui --agent my_agent.py:graph
 - **Slash commands** — `/save-workflow`, `/create-workflow`, and `/run-workflow` with autocomplete
 - **Print / export** — print conversations via browser Print dialog with optimized CSS
 - **Token usage** — cumulative counter with per-turn breakdown chart
-- **Authentication** — optional HTTP Basic Auth for all endpoints
+- **Authentication** — optional HTTP Basic Auth for all endpoints (except the health probe)
+- **Health checks** — `GET /api/health` (liveness, JSON, auth-exempt) and `?ready=1` (readiness: 200 only if the agent loaded and the task store is reachable, else 503) for reverse proxies, k8s, and uptime monitors
 - **Theming** — light, dark, and system-auto modes
 - **Customization** — title, subtitle, welcome message, agent name, and custom icon
 

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
-from fastapi.responses import FileResponse, Response
+from fastapi.responses import FileResponse, JSONResponse, Response
 
 from langstage_core.adapters import SessionAdapter
 from langstage_core.tasks import TaskRunner, set_runner
@@ -24,6 +24,16 @@ from langstage.scheduler import CronScheduler, set_scheduler
 from langstage.tasks import SqliteTaskStore
 from langstage.workspace.file_manager import FileManager
 from langstage.workspace.canvas_manager import CanvasManager
+
+
+def _app_version() -> str:
+    """The installed ``langstage`` version, for the health payload (gh #67)."""
+    try:
+        from langstage import __version__
+
+        return __version__
+    except Exception:  # noqa: BLE001 - never let the health probe fail on this
+        return "0.0.0+unknown"
 
 
 def create_fastapi_app(
@@ -128,6 +138,37 @@ def create_fastapi_app(
     scheduler = CronScheduler(runner)
     set_scheduler(scheduler)
     app.include_router(create_cron_router(scheduler))
+
+    # Dedicated health/readiness endpoint under /api/* (so it never collides with the
+    # SPA catch-all) and exempt from Basic Auth in the middleware, so a reverse proxy /
+    # k8s / uptime probe always has an endpoint — even with auth on (gh #67).
+    @app.get("/api/health")
+    async def health(ready: int = 0) -> Response:
+        """Liveness (default) or readiness (`?ready=1`).
+
+        Liveness just proves the process is up. Readiness reflects real backend state:
+        200 only if the agent object loaded AND the task store is reachable, else 503 —
+        fixing the false-positive where the always-served SPA shell made ``/health``
+        report healthy regardless of backend state.
+        """
+        payload = {"status": "ok", "version": _app_version()}
+        if not ready:
+            return JSONResponse(payload)
+
+        checks = {"agent": "ok" if agent is not None else "load_failed"}
+        try:
+            # A bounded query (filtered to a sentinel parent → empty) that still
+            # exercises the DB connection, without loading the whole task table.
+            await task_store.list(parent_id="__health_probe__")
+            checks["task_store"] = "ok"
+        except Exception as exc:  # noqa: BLE001 - any failure means not ready
+            checks["task_store"] = f"unreachable: {type(exc).__name__}"
+
+        ok = all(v == "ok" for v in checks.values())
+        return JSONResponse(
+            {"status": "ok" if ok else "degraded", "version": _app_version(), "checks": checks},
+            status_code=200 if ok else 503,
+        )
 
     # Expose for testing
     app.state.session_adapter = adapter

--- a/langstage/server/middleware.py
+++ b/langstage/server/middleware.py
@@ -17,6 +17,10 @@ class BasicAuthMiddleware:
     on the upgrade request.
     """
 
+    # Paths served without auth so an orchestrator / load-balancer liveness probe
+    # (which can't carry credentials) always has an endpoint to hit (gh #67).
+    _AUTH_EXEMPT = frozenset({"/api/health"})
+
     def __init__(self, app: ASGIApp, username: str, password: str) -> None:
         self.app = app
         self._username = username
@@ -24,6 +28,10 @@ class BasicAuthMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if scope.get("path", "") in self._AUTH_EXEMPT:
             await self.app(scope, receive, send)
             return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.8"
+version = "0.13.9"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,69 @@
+"""A real /api/health endpoint (gh #67).
+
+Before this, `/health` (and every non-`/api/*` path) returned the SPA shell — HTTP 200
+regardless of backend state, and 401 once auth was enabled — so an orchestrator / LB /
+uptime probe had no usable liveness signal. `/api/health` is a dedicated JSON endpoint,
+exempt from Basic Auth, with an optional readiness mode that reflects real backend state.
+"""
+from typing import TypedDict
+
+from fastapi.testclient import TestClient
+from langgraph.graph import END, START, StateGraph
+
+from langstage.app import CoworkApp
+
+
+class _S(TypedDict):
+    x: int
+
+
+def _graph():
+    g = StateGraph(_S)
+    g.add_node("n", lambda s: {"x": s.get("x", 0) + 1})
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    return g.compile()
+
+
+def _client(tmp_path, **kwargs):
+    app = CoworkApp(agent=_graph(), workspace=str(tmp_path), **kwargs).create_server()
+    return TestClient(app)
+
+
+def test_health_liveness_is_json_ok(tmp_path):
+    r = _client(tmp_path).get("/api/health")
+    assert r.status_code == 200
+    assert "application/json" in r.headers.get("content-type", "")
+    body = r.json()
+    assert body["status"] == "ok"
+    assert "version" in body  # a real version string, not the SPA shell
+
+
+def test_health_readiness_reports_backend_checks(tmp_path):
+    # With the app wired (agent loaded, task store created), readiness is 200 and
+    # names the checks — reflecting real backend state, not the always-served shell.
+    with _client(tmp_path) as c:  # `with` drives lifespan so the task store is set up
+        r = c.get("/api/health?ready=1")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["agent"] == "ok"
+    assert body["checks"]["task_store"] == "ok"
+
+
+def test_health_is_exempt_from_basic_auth(tmp_path):
+    # With auth ON, every other path 401s without credentials — but a liveness probe
+    # can't carry credentials, so /api/health must still answer (gh #67).
+    c = _client(tmp_path, auth_password="secret123")
+    # a normal API path is protected...
+    assert c.get("/api/config").status_code == 401
+    # ...but health is reachable without credentials.
+    r = c.get("/api/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_health_is_not_the_spa_shell(tmp_path):
+    # The old /health returned index.html (text/html). The new endpoint is JSON.
+    r = _client(tmp_path).get("/api/health")
+    assert "text/html" not in r.headers.get("content-type", "")


### PR DESCRIPTION
Closes #67 (nightly dogfood). LangStage is "the web stage" — a deployable FastAPI service
with `--host`/`--port`/`0.0.0.0` and optional Basic Auth — but it had no real health
endpoint. What looked like one wasn't: `/health`, `/healthz`, `/ready`, … all returned the
SPA `index.html` (HTTP 200 for *any* non-`/api/*` path), so a monitor got **200 even if the
agent failed to load**; and with auth on, **every** path including `/health` returned 401,
leaving an LB/k8s liveness probe (which can't carry credentials) nothing to hit.

**New endpoint** — dedicated JSON under `/api/*` (so it can't collide with the SPA
catch-all), **exempt from Basic Auth** in the middleware:
- `GET /api/health` → `200 {"status": "ok", "version": "…"}` — pure liveness.
- `GET /api/health?ready=1` → readiness: `200` only if the agent object loaded **and** the
  task store is reachable (a bounded probe query), else `503 {"status": "degraded",
  "checks": {"agent": …, "task_store": …}}` — this is where the false-positive is fixed:
  readiness reflects real backend state, not the static shell.

Everything else stays behind auth as before. Tests: liveness JSON, readiness checks, and
that health answers **without** credentials while `/api/config` still 401s. Full suite
165 passed. Ships as **0.13.9**.