### PR TITLE
fix: readiness checks the agent is runnable, not just non-None (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.13.10 — 2026-07-07
+
+### Fixed
+- **Readiness (`/api/health?ready=1`) now checks the agent is *runnable*, not just
+  non-`None` (gh #69).** The `agent` check was `agent is not None` — vacuous (a failed
+  load aborts startup, so a serving process always has a non-`None` agent) and blind to
+  the common BYO slip of exporting an **uncompiled `StateGraph`**: it loaded, so readiness
+  said `200 ok`, yet every turn died with `'StateGraph' object has no attribute
+  'aget_state'`. A k8s / ALB probe would mark the pod Ready and route traffic to a server
+  that fails every turn. Readiness now gates on runnability (`callable(agent.astream)`) —
+  the same check `langstage check` uses (gh #39) — and returns `503 not_runnable` otherwise.
+
 ## 0.13.9 — 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ langstage-agui --agent my_agent.py:graph
 - **Print / export** — print conversations via browser Print dialog with optimized CSS
 - **Token usage** — cumulative counter with per-turn breakdown chart
 - **Authentication** — optional HTTP Basic Auth for all endpoints (except the health probe)
-- **Health checks** — `GET /api/health` (liveness, JSON, auth-exempt) and `?ready=1` (readiness: 200 only if the agent loaded and the task store is reachable, else 503) for reverse proxies, k8s, and uptime monitors
+- **Health checks** — `GET /api/health` (liveness, JSON, auth-exempt) and `?ready=1` (readiness: 200 only if the agent is a **runnable** graph and the task store is reachable, else 503) for reverse proxies, k8s, and uptime monitors
 - **Theming** — light, dark, and system-auto modes
 - **Customization** — title, subtitle, welcome message, agent name, and custom icon
 

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -155,7 +155,14 @@ def create_fastapi_app(
         if not ready:
             return JSONResponse(payload)
 
-        checks = {"agent": "ok" if agent is not None else "load_failed"}
+        # "loaded" (`is not None`) is vacuous — a failed load aborts startup, so a
+        # serving process always has a non-None agent. And "loaded" ≠ "runnable": an
+        # uncompiled StateGraph (the common BYO slip) loads fine but dies every turn
+        # with no `astream`. Gate readiness on runnability — the exact check
+        # `langstage check` uses (gh #39) — so a probe can't mark an unrunnable server
+        # Ready (gh #69).
+        agent_runnable = callable(getattr(agent, "astream", None))
+        checks = {"agent": "ok" if agent_runnable else "not_runnable"}
         try:
             # A bounded query (filtered to a sentinel parent → empty) that still
             # exercises the DB connection, without loading the whole task table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.9"
+version = "0.13.10"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -67,3 +67,26 @@ def test_health_is_not_the_spa_shell(tmp_path):
     # The old /health returned index.html (text/html). The new endpoint is JSON.
     r = _client(tmp_path).get("/api/health")
     assert "text/html" not in r.headers.get("content-type", "")
+
+
+def _uncompiled_graph():
+    """The common BYO mistake: export the builder, forget `.compile()`. It loads
+    (server starts) but isn't runnable — dies every turn with no `astream` (gh #69)."""
+    g = StateGraph(_S)
+    g.add_node("n", lambda s: {"x": s.get("x", 0) + 1})
+    g.set_entry_point("n")
+    return g  # NOT compiled
+
+
+def test_health_readiness_503_for_unrunnable_agent(tmp_path):
+    # gh #69: an uncompiled StateGraph passed readiness (200 "ok") under the old
+    # `agent is not None` check, yet every turn fails. Readiness must now 503.
+    app = CoworkApp(agent=_uncompiled_graph(), workspace=str(tmp_path)).create_server()
+    with TestClient(app) as c:
+        r = c.get("/api/health?ready=1")
+    assert r.status_code == 503, r.text
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["checks"]["agent"] == "not_runnable"
+    # ...but plain liveness still answers 200 (the process IS up).
+    assert TestClient(app).get("/api/health").status_code == 200


### PR DESCRIPTION
Closes #69 (nightly dogfood — a gap in the `/api/health` readiness shipped yesterday in 0.13.9).

The readiness `agent` check was `agent is not None`, which is doubly wrong:
1. **Vacuous** — a failed agent *load* aborts server startup (traceback, exit 1), so in any
   *serving* process `agent` is always non-`None`; the `load_failed` branch can never fire.
2. **"loaded" ≠ "runnable"** — an **uncompiled `StateGraph`** (the common BYO slip: export
   the builder, forget `.compile()`) loads fine, so readiness returned `200 "ok"`, yet every
   chat turn dies with `'StateGraph' object has no attribute 'aget_state'`. A k8s/ALB probe
   pointed at `?ready=1` marks the pod Ready and routes traffic to a server that fails every
   turn — defeating the probe's purpose for the most common misconfiguration.

**Fix:** gate readiness on runnability — `callable(getattr(agent, "astream", None))`, the
exact check `langstage check` uses (gh #39) — returning `503 {"checks": {"agent":
"not_runnable"}}` for a non-runnable object. Regression test drives an uncompiled StateGraph
→ 503 (liveness still 200). Ships as **0.13.10**.