### PR TITLE
feat: advertise the built-in OpenAPI/Swagger docs + report the real version (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.13.11 — 2026-07-08
+
+### Added
+- **The built-in OpenAPI/Swagger docs are now advertised as the canonical REST reference
+  (gh #71).** Because the backend is FastAPI, a complete, always-in-sync schema is already
+  served at `/openapi.json`, `/docs` (Swagger UI), and `/redoc` — but it was mentioned
+  nowhere, so a client author had to reverse-engineer request shapes. A new README **REST
+  API** section points at all three, and `langstage run` prints the docs URL on startup.
+
+### Fixed
+- **The OpenAPI schema now reports the real package version (gh #71).** The FastAPI app was
+  constructed with a hardcoded `version="2.0.0"`; it now uses the installed `langstage`
+  version, with a titled/described schema, so `/openapi.json` and `/docs` are accurate.
+
 ## 0.13.10 — 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -323,6 +323,23 @@ Browser  <--SSE / REST-->  FastAPI  <--astream_events-->  LangGraph Agent
 
 The frontend is pre-built and bundled into the Python package as static files. No Node.js required at runtime.
 
+## REST API
+
+Because the backend is FastAPI, LangStage serves a **complete, always-in-sync OpenAPI
+schema** for the whole REST surface (chat, files, canvas, cron, tasks, health) — use it as
+the canonical reference for a programmatic client instead of reverse-engineering shapes:
+
+| Route | What |
+|---|---|
+| `/docs` | Interactive **Swagger UI** — try every endpoint, see exact request/response schemas |
+| `/redoc` | **ReDoc** — a clean, readable reference of the same schema |
+| `/openapi.json` | The raw OpenAPI document — feed it to a client generator (`openapi-generator`, etc.) |
+
+All three honor auth: with `--auth-password` set they return `401` without credentials
+(like every route except `/api/health`). A couple of shapes worth knowing (and that `/docs`
+spells out): `POST /api/files/upload` takes `path` as a **query** parameter (not a form
+field); `/api/stream` is the SSE event stream keyed by `session_id`.
+
 ## Development
 
 ```bash

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -184,8 +184,12 @@ class CoworkApp:
         app = self.create_server()
         self._enter_workspace()
 
+        url = f"http://{self.config.host}:{self.config.port}"
+        # Point power users at the built-in, always-in-sync REST API docs — the
+        # FastAPI OpenAPI schema is served but was undocumented/undiscoverable (gh #71).
+        print(f"LangStage: {url}  |  REST API docs: {url}/docs")
+
         if open_browser:
-            url = f"http://{self.config.host}:{self.config.port}"
             # Open browser after a short delay (server needs to start first)
             import threading
             threading.Timer(1.5, webbrowser.open, args=[url]).start()

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -91,7 +91,18 @@ def create_fastapi_app(
             set_scheduler(None)
             set_runner(None)
 
-    app = FastAPI(title=config.title, version="2.0.0", lifespan=lifespan)
+    # Real package version (not a hardcoded "2.0.0") so the built-in OpenAPI schema
+    # (/openapi.json, /docs, /redoc) reports the version users actually run (gh #71).
+    app = FastAPI(
+        title=f"{config.title} REST API",
+        version=_app_version(),
+        description=(
+            "The LangStage web-stage REST API — chat (SSE), files, canvas, cron, and the "
+            "task board. Interactive docs at /docs and /redoc; schema at /openapi.json. "
+            "All endpoints require Basic Auth when --auth-password is set, except /api/health."
+        ),
+        lifespan=lifespan,
+    )
 
     # Middleware
     add_middleware(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.10"
+version = "0.13.11"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,58 @@
+"""The built-in OpenAPI/Swagger docs are served + correct (gh #71).
+
+FastAPI serves a complete, always-in-sync schema at /openapi.json, /docs, and /redoc.
+It was undocumented; these tests pin that it's reachable, reports the real package version
+(not a hardcoded "2.0.0"), and honors auth (401 under --auth-password, while /api/health
+stays exempt).
+"""
+from typing import TypedDict
+
+from fastapi.testclient import TestClient
+from langgraph.graph import END, START, StateGraph
+
+from langstage import __version__
+from langstage.app import CoworkApp
+
+
+class _S(TypedDict):
+    x: int
+
+
+def _graph():
+    g = StateGraph(_S)
+    g.add_node("n", lambda s: {"x": s.get("x", 0) + 1})
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    return g.compile()
+
+
+def _client(tmp_path, **kwargs):
+    return TestClient(CoworkApp(agent=_graph(), workspace=str(tmp_path), **kwargs).create_server())
+
+
+def test_openapi_and_docs_are_served(tmp_path):
+    c = _client(tmp_path)
+    assert c.get("/docs").status_code == 200
+    assert c.get("/redoc").status_code == 200
+    doc = c.get("/openapi.json")
+    assert doc.status_code == 200
+    assert "application/json" in doc.headers.get("content-type", "")
+
+
+def test_openapi_reports_the_real_version_and_enumerates_the_api(tmp_path):
+    doc = _client(tmp_path).get("/openapi.json").json()
+    # the real package version, not the old hardcoded "2.0.0"
+    assert doc["info"]["version"] == __version__
+    assert doc["info"]["version"] != "2.0.0"
+    # the schema actually enumerates the REST surface
+    paths = set(doc["paths"])
+    assert {"/api/chat", "/api/health", "/api/tasks"} <= paths
+
+
+def test_docs_honor_auth_but_health_stays_exempt(tmp_path):
+    c = _client(tmp_path, auth_password="secret123")
+    # the docs are behind auth like every other route...
+    assert c.get("/docs").status_code == 401
+    assert c.get("/openapi.json").status_code == 401
+    # ...except the liveness probe.
+    assert c.get("/api/health").status_code == 200


### PR DESCRIPTION
Closes #71 (nightly dogfood). A low-effort, high-leverage DX win — the artifact already
exists and is correct; it just needed advertising.

Because the backend is FastAPI, a **complete, always-in-sync, auth-aware OpenAPI schema** is
already served at `/openapi.json`, `/docs` (Swagger UI), and `/redoc` — but it's mentioned
nowhere in the README or `--help`, so a client author reverse-engineers request shapes by
trial and error (e.g. `POST /api/files/upload` takes `path` as a **query** param, which a
`422` doesn't explain — but `/docs` does).

**Changes:**
- **README** — a new **REST API** section pointing at `/docs`, `/redoc`, `/openapi.json`,
  noting they honor auth (401 under `--auth-password`, except `/api/health`) and calling out
  the upload query-param shape.
- **`langstage run`** — prints `REST API docs: <url>/docs` on startup so it's discoverable.
- **Accuracy** — the FastAPI app was built with a hardcoded `version="2.0.0"`; it now reports
  the real installed `langstage` version, with a titled/described schema.

Tests: `/docs`, `/redoc`, `/openapi.json` are served; the schema reports the real version and
enumerates the surface; docs honor auth while `/api/health` stays exempt. Full suite 169
passed. Ships as **0.13.11**.