### PR TITLE
Make /api/files/upload path the full destination, symmetric with the other file routes (gh #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.13 — 2026-07-10
+
+### Changed
+- **`/api/files/upload` now treats `path` as the full destination path, symmetric with every
+  other files route (gh #75).** `upload` alone interpreted `path` as a *parent directory* and
+  appended the multipart filename, while `read`/`preview`/`download`/`delete`/`mkdir` treat
+  `path` as the full target. So a `path`-symmetric client doing `POST upload?path=P` then
+  `GET read?path=P` didn't get its file back — the upload silently landed at
+  `P/<multipart-filename>` (creating a stray directory `P`), returned `200`, and the read of
+  `P` then failed. Now `upload?path=P` stores the file **at** `P` and round-trips. The
+  directory-drop mode is still available **explicitly** — end `path` with `/`, or point it at
+  an existing directory, and the multipart filename is appended (this is what the file-browser
+  UI uses, so it's unchanged). The OpenAPI `description` and the README REST section document
+  the contract.
+
 ## 0.13.12 — 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -351,7 +351,10 @@ the canonical reference for a programmatic client instead of reverse-engineering
 All three honor auth: with `--auth-password` set they return `401` without credentials
 (like every route except `/api/health`). A couple of shapes worth knowing (and that `/docs`
 spells out): `POST /api/files/upload` takes `path` as a **query** parameter (not a form
-field); `/api/stream` is the SSE event stream keyed by `session_id`.
+field), and `path` is the **full destination path** — `upload?path=P` stores the file at
+`P`, so it round-trips with `read`/`download`/`delete?path=P` (end `path` with `/`, or point
+it at an existing directory, to drop the upload inside under its own filename instead);
+`/api/stream` is the SSE event stream keyed by `session_id`.
 
 ## Development
 

--- a/langstage/server/routes_files.py
+++ b/langstage/server/routes_files.py
@@ -75,12 +75,32 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
 
     @r.post("/upload")
     async def upload_file(
-        path: str = Query(..., description="Destination dir relative to workspace"),
+        path: str = Query(
+            ...,
+            description=(
+                "Destination path relative to workspace. By DEFAULT this is the full target "
+                "path — `upload?path=P` stores the file AT `P`, so `read?path=P` round-trips, "
+                "symmetric with read/preview/download/delete/mkdir. To drop the upload INTO a "
+                "directory under its own multipart filename, end `path` with '/' or point it "
+                "at an existing directory."
+            ),
+        ),
         file: UploadFile = File(...),
     ):
-        """Upload a file to the workspace."""
+        """Upload a file to the workspace.
+
+        `path` is the full destination path by default, so it round-trips with the other
+        files routes (`upload?path=reports/q3.md` → `read?path=reports/q3.md`). Previously
+        `path` was always treated as a *parent directory* and the multipart filename was
+        appended, which silently misplaced a `path`-symmetric client's file at
+        `P/<filename>` and broke the round-trip (gh #75). The directory-drop mode is still
+        available explicitly: a trailing '/' or an existing-directory `path` appends the
+        multipart filename (this is what the file-browser UI uses — it uploads into the
+        directory being viewed).
+        """
         try:
-            dest = path.rstrip("/") + "/" + file.filename
+            drop_into_dir = path.endswith("/") or file_manager.get_absolute_path(path).is_dir()
+            dest = (path.rstrip("/") + "/" + file.filename) if drop_into_dir else path
             content = await file.read()
             result = file_manager.save_upload(dest, content)
             return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.12"
+version = "0.13.13"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -199,3 +199,60 @@ async def test_auth_default_username(workspace, mock_agent):
         # wrong username should fail
         resp = await c.get("/api/config", auth=("user", "secret"))
         assert resp.status_code == 401
+
+
+# ── /api/files/upload path semantics (gh #75) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_upload_path_is_the_full_destination_and_round_trips(client):
+    # gh #75: upload?path=P must store the file AT P (symmetric with read/download/delete),
+    # so a `path`-symmetric client's upload->read round-trips. Previously `path` was treated
+    # as a parent dir and the file landed at P/<filename>, silently creating a directory P.
+    up = await client.post(
+        "/api/files/upload?path=reports/q3.md",
+        files={"file": ("rt.txt", b"roundtrip", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    assert up.json()["path"] == "reports/q3.md"  # stored AS the file, not reports/q3.md/rt.txt
+
+    got = await client.get("/api/files/read?path=reports/q3.md")
+    assert got.status_code == 200, got.text
+    assert got.json()["content"] == "roundtrip"
+
+
+@pytest.mark.asyncio
+async def test_upload_into_an_existing_directory_appends_filename(client):
+    # Backward-compat: the file-browser UI uploads into the directory being viewed (an
+    # existing dir, no trailing slash). That must still drop the file INTO it.
+    up = await client.post(
+        "/api/files/upload?path=subdir",  # subdir exists in the workspace fixture
+        files={"file": ("note.txt", b"hi", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    assert up.json()["path"] == "subdir/note.txt"
+
+    got = await client.get("/api/files/read?path=subdir/note.txt")
+    assert got.status_code == 200 and got.json()["content"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_upload_trailing_slash_forces_directory_drop(client):
+    # A trailing '/' explicitly means "drop into this directory under the multipart
+    # filename", even when the directory doesn't exist yet.
+    up = await client.post(
+        "/api/files/upload?path=fresh/",
+        files={"file": ("a.txt", b"abc", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    assert up.json()["path"] == "fresh/a.txt"
+
+
+@pytest.mark.asyncio
+async def test_upload_path_escape_returns_400(client):
+    # The workspace boundary still holds for uploads.
+    up = await client.post(
+        "/api/files/upload?path=../escapee.txt",
+        files={"file": ("x.txt", b"x", "text/plain")},
+    )
+    assert up.status_code == 400

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.12"
+version = "0.13.13"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## What

`/api/files/*` uses a single `path` query param across all endpoints, but **`upload` gave it different semantics**:

| Endpoint | Meaning of `path` |
|---|---|
| `read` / `preview` / `download` / `delete` / `mkdir` | the full target path |
| **`upload`** (before) | the **parent directory**; the multipart filename was appended |

So a client that uses `path` uniformly and does the natural symmetric thing — `POST upload?path=P` then `GET read?path=P` — didn't get its file back:

```console
$ curl -sX POST "…/api/files/upload?path=reports/q3.md" -F "file=@rt.txt"
{"path":"reports/q3.md/rt.txt", …}     # 200 — stored UNDER reports/q3.md/, not AS it
$ curl -s "…/api/files/read?path=reports/q3.md"
{"detail":"Path is a directory: reports/q3.md"}   # 400 — a stray dir was created
```

The `200` + a plausible `path` in the response made the misfiling invisible until a later read/download 400'd.

## Fix

`path` is now the **full destination path** by default (symmetric with the rest of the API), so `upload?path=P` stores the file at `P` and round-trips.

The directory-drop mode is preserved **explicitly**: a trailing `/` **or** a `path` that names an existing directory appends the multipart filename. That existing-directory case is exactly what the **file-browser UI** does — it uploads into the directory being viewed — so the shipped frontend keeps working with no change or rebuild.

```console
# symmetric client (fixed):
upload?path=reports/q3.md   -> stored AT reports/q3.md   -> read?path=reports/q3.md ✓
# directory drop (UI / explicit):
upload?path=subdir          -> subdir/<filename>   (subdir exists)
upload?path=fresh/          -> fresh/<filename>    (trailing slash)
```

The OpenAPI `description` and the README REST section document the contract.

## Tests

`tests/test_app.py`: the upload→read round-trip; directory-drop into an existing dir (the UI path); trailing-slash drop; and the workspace-traversal `400`.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)