### PR TITLE
fix: scheduled runs no longer overlap their own in-flight run (gh #78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.14 — 2026-07-11
+
+### Fixed
+- **Scheduled runs no longer overlap their own in-flight run — unattended schedules that hit a
+  human-in-the-loop review gate stop piling up stuck tasks (gh #78).** A cron fire enqueues onto
+  the same task board as a manual delegation, so if the scheduled agent tripped a review gate its
+  task parked at `review_needed` waiting for a human who — for an *unattended* schedule — never
+  came, and **every subsequent fire added another stuck task**. This wasn't an edge case: the
+  built-in default agent gates `bash` (`interrupt_on=dict(bash=True)`), so scheduling it silently
+  stalled at review whenever it used bash. The scheduler now applies cron-style **overlap
+  protection**: an automatic fire is **skipped** while the schedule's previous run is still
+  unresolved (`queued` / `ongoing` / `review_needed`), and the schedule row surfaces it
+  (`last_status = "skipped: previous run still review_needed"`). `GET /api/cron` now also returns
+  `last_task_id` and `last_run_state` per schedule so a client can flag a run awaiting review.
+  Manual **Run now** (`POST /api/cron/{id}/run`) is an explicit action and still fires regardless.
+
 ## 0.13.13 — 2026-07-10
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The **Board** tab turns LangStage into a lightweight agent control room: delegat
   ```
 
 - **Scheduled runs** (the Schedules tab) enqueue onto the same board.
+- **A schedule never overlaps its own run.** If the previous fire's task is still queued, running, or **awaiting human review**, the next *automatic* fire is skipped (the schedule row shows `skipped: previous run still …`) instead of piling up duplicate tasks. This matters when the scheduled agent has a human-in-the-loop gate — e.g. the default agent gates `bash` — because such a run parks at **review** on the board for you to approve, and the schedule waits for you rather than stacking stuck reviews. Manual **Run now** bypasses this. `GET /api/cron` surfaces each schedule's `last_task_id` + `last_run_state` so a client can flag one awaiting review.
 
 Task REST API: `GET /api/tasks`, `POST /api/tasks` (delegate), `GET /api/tasks/{id}/events`, and `POST /api/tasks/{id}/{cancel,retry,resume,message}`. Concurrency is bounded by `LANGSTAGE_TASK_CONCURRENCY` (default 3).
 

--- a/langstage/scheduler.py
+++ b/langstage/scheduler.py
@@ -31,6 +31,18 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     croniter = None  # type: ignore
 
+# Task states a scheduled run can still be "in flight" in. A schedule must not
+# re-fire while its previous run is unresolved (gh #78) — otherwise unattended
+# fires pile up as stuck tasks, most painfully ``review_needed``, which waits for
+# a human that an unattended schedule never gets. Imported from the task engine
+# so the set stays in lockstep with the runner's state machine.
+try:
+    from langstage_core.tasks import ONGOING, QUEUED, REVIEW_NEEDED
+
+    _UNRESOLVED_TASK_STATES = frozenset({QUEUED, ONGOING, REVIEW_NEEDED})
+except Exception:  # pragma: no cover - defensive; core is always present in practice
+    _UNRESOLVED_TASK_STATES = frozenset({"queued", "ongoing", "review_needed"})
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -58,8 +70,9 @@ class CronJob:
     enabled: bool = True
     next_run: Optional[str] = None
     last_run: Optional[str] = None
-    last_status: Optional[str] = None   # "ok" | "running" | "error: ..."
+    last_status: Optional[str] = None   # "queued" | "skipped: ..." | "error: ..."
     run_count: int = 0
+    last_task_id: Optional[str] = None  # id of the last task enqueued onto the board (gh #78)
 
     @property
     def session_id(self) -> str:
@@ -85,6 +98,17 @@ class CronScheduler:
     # ── queries ──────────────────────────────────────────────────────
     def list_jobs(self) -> list[dict[str, Any]]:
         return [j.to_dict() for j in self._jobs.values()]
+
+    async def list_jobs_with_state(self) -> list[dict[str, Any]]:
+        """Like :meth:`list_jobs`, but each job is enriched with
+        ``last_run_state`` — the current board state of its most recent run
+        (``queued`` / ``ongoing`` / ``review_needed`` / ``done`` / …), or
+        ``None`` if it hasn't run yet. Lets a client surface e.g. a schedule
+        whose last run is stuck awaiting review (gh #78)."""
+        jobs = self.list_jobs()
+        for d in jobs:
+            d["last_run_state"] = await self._task_state(d.get("last_task_id"))
+        return jobs
 
     def get(self, job_id: str) -> Optional[CronJob]:
         return self._jobs.get(job_id)
@@ -128,7 +152,8 @@ class CronScheduler:
         job = self._jobs.get(job_id)
         if job is None:
             return False
-        await self._fire(job)
+        # Manual run-now is an explicit user action → bypass overlap protection.
+        await self._fire(job, force=True)
         return True
 
     # ── lifecycle ────────────────────────────────────────────────────
@@ -176,15 +201,32 @@ class CronScheduler:
             logger.exception("cron job %s loop crashed", job.id)
             job.last_status = "error: loop crashed"
 
-    async def _fire(self, job: CronJob) -> None:
+    async def _fire(self, job: CronJob, *, force: bool = False) -> None:
         # Producer: enqueue a task onto the durable runner and return. The
         # runner executes it on the board (queued → ongoing → done), so the
         # scheduler no longer runs the agent or drains queues itself.
+        #
+        # Overlap protection (gh #78): an *automatic* fire is SKIPPED while the
+        # schedule's previous run is still unresolved (queued/ongoing/awaiting
+        # review). Without this, a schedule whose agent trips a human-in-the-loop
+        # review gate silently piles up stuck ``review_needed`` tasks that never
+        # complete — and the built-in default agent gates ``bash``, so that is the
+        # common case, not an edge. Manual run-now passes ``force=True``.
+        if not force and job.last_task_id is not None:
+            prev_state = await self._task_state(job.last_task_id)
+            if prev_state in _UNRESOLVED_TASK_STATES:
+                job.last_status = f"skipped: previous run still {prev_state}"
+                logger.info(
+                    "cron job %s skipped fire: previous run %s still %s",
+                    job.id, job.last_task_id, prev_state,
+                )
+                return
         try:
-            await self._runner.enqueue(
+            task_id = await self._runner.enqueue(
                 title=job.name,
                 prompt=job.prompt,
             )
+            job.last_task_id = task_id
             job.last_status = "queued"
         except asyncio.CancelledError:
             raise
@@ -194,6 +236,20 @@ class CronScheduler:
         finally:
             job.last_run = _now_iso()
             job.run_count += 1
+
+    async def _task_state(self, task_id: Optional[str]) -> Optional[str]:
+        """Current board state of ``task_id`` via the runner's store. Returns
+        None if there's no id, no store, or the task is gone."""
+        if not task_id:
+            return None
+        store = getattr(self._runner, "store", None)
+        if store is None:
+            return None
+        try:
+            task = await store.get(task_id)
+        except Exception:  # pragma: no cover - defensive
+            return None
+        return task.get("state") if task else None
 
 
 # ── process-global singleton (so agent tools can reach the scheduler) ──

--- a/langstage/server/routes_cron.py
+++ b/langstage/server/routes_cron.py
@@ -17,7 +17,9 @@ def create_cron_router(scheduler: CronScheduler) -> APIRouter:
 
     @router.get("")
     async def list_jobs():
-        return scheduler.list_jobs()
+        # Enriched with each schedule's last run state so a client can surface a
+        # run stuck awaiting review (gh #78).
+        return await scheduler.list_jobs_with_state()
 
     @router.post("", status_code=201)
     async def create_job(body: CronCreate):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.13"
+version = "0.13.14"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -13,17 +13,36 @@ from langstage.scheduler import (
 )
 
 
+class FakeStore:
+    """Minimal task store: task_id -> state, matching the bit of TaskStore.get()
+    the scheduler's overlap check reads."""
+
+    def __init__(self):
+        self.states: dict[str, str] = {}
+
+    async def get(self, task_id):
+        state = self.states.get(task_id)
+        return {"task_id": task_id, "state": state} if state is not None else None
+
+
 class FakeRunner:
-    """Records enqueue calls (the scheduler is now a producer onto the runner)."""
+    """Records enqueue calls (the scheduler is now a producer onto the runner)
+    and exposes a store so overlap protection can query prior-run state."""
 
     def __init__(self):
         self.enqueued = []
+        self.store = FakeStore()
+        self._n = 0
 
     async def enqueue(self, *, title, prompt, agent_spec=None, parent_id=None):
+        self._n += 1
+        task_id = f"task-{self._n}"
         self.enqueued.append(
-            {"title": title, "prompt": prompt, "agent_spec": agent_spec, "parent_id": parent_id}
+            {"title": title, "prompt": prompt, "agent_spec": agent_spec,
+             "parent_id": parent_id, "task_id": task_id}
         )
-        return "task-fake"
+        self.store.states[task_id] = "queued"
+        return task_id
 
 
 # ── cron validation ──────────────────────────────────────────────────
@@ -95,6 +114,91 @@ async def test_run_now():
     assert await s.run_now(job.id) is True
     assert await s.run_now("missing") is False
     assert len(runner.enqueued) == 1
+
+
+# ── overlap protection (gh #78) ──────────────────────────────────────
+
+
+async def test_fire_skips_while_previous_run_unresolved():
+    runner = FakeRunner()
+    s = CronScheduler(runner)
+    job = s.add_job(name="j", cron="* * * * *", prompt="p")
+
+    await s._fire(job)                       # first automatic fire enqueues
+    assert len(runner.enqueued) == 1
+    tid = job.last_task_id
+    assert tid
+
+    # The run parks at the HITL review gate; an automatic re-fire must skip.
+    runner.store.states[tid] = "review_needed"
+    await s._fire(job)
+    assert len(runner.enqueued) == 1, "must not enqueue while prev run awaits review"
+    assert "skipped" in (job.last_status or "")
+    assert "review_needed" in job.last_status
+    assert job.run_count == 1, "a skipped fire is not a run"
+
+    # Same for still-ongoing / still-queued previous runs.
+    for state in ("ongoing", "queued"):
+        runner.store.states[tid] = state
+        await s._fire(job)
+    assert len(runner.enqueued) == 1
+
+
+async def test_fire_proceeds_once_previous_run_finishes():
+    runner = FakeRunner()
+    s = CronScheduler(runner)
+    job = s.add_job(name="j", cron="* * * * *", prompt="p")
+
+    await s._fire(job)
+    runner.store.states[job.last_task_id] = "done"
+    await s._fire(job)                       # prev resolved → fire again
+    assert len(runner.enqueued) == 2
+    assert job.run_count == 2
+    assert job.last_status == "queued"
+
+
+async def test_run_now_bypasses_overlap_protection():
+    runner = FakeRunner()
+    s = CronScheduler(runner)
+    job = s.add_job(name="j", cron="* * * * *", prompt="p")
+
+    await s._fire(job)
+    runner.store.states[job.last_task_id] = "review_needed"
+    # Explicit manual trigger runs even though the previous run is unresolved.
+    assert await s.run_now(job.id) is True
+    assert len(runner.enqueued) == 2
+
+
+async def test_list_jobs_with_state_reports_last_run_state():
+    runner = FakeRunner()
+    s = CronScheduler(runner)
+    job = s.add_job(name="j", cron="* * * * *", prompt="p")
+
+    enriched = await s.list_jobs_with_state()
+    assert enriched[0]["last_run_state"] is None      # no run yet
+
+    await s._fire(job)
+    runner.store.states[job.last_task_id] = "review_needed"
+    enriched = await s.list_jobs_with_state()
+    assert enriched[0]["last_task_id"] == job.last_task_id
+    assert enriched[0]["last_run_state"] == "review_needed"
+
+
+async def test_overlap_protection_is_noop_without_a_store():
+    # A runner without a store must not break firing (best-effort protection).
+    class NoStoreRunner:
+        def __init__(self):
+            self.enqueued = []
+
+        async def enqueue(self, *, title, prompt, agent_spec=None, parent_id=None):
+            self.enqueued.append(title)
+            return "t"
+
+    s = CronScheduler(NoStoreRunner())
+    job = s.add_job(name="j", cron="* * * * *", prompt="p")
+    await s._fire(job)
+    await s._fire(job)                       # no store to check → proceeds
+    assert len(s._runner.enqueued) == 2
 
 
 async def test_next_run_populated_on_create_for_started_scheduler():


### PR DESCRIPTION
## What & why

Closes #78.

A cron fire enqueues onto the **same** task board as a manual delegation, so a scheduled agent that tripped a human-in-the-loop review gate parked at `review_needed` waiting for a human who — for an *unattended* schedule — never came, and **every subsequent fire added another stuck task**. This wasn't an edge case: the built-in **default agent gates `bash`** (`interrupt_on=dict(bash=True)`), so scheduling it silently stalled at review whenever it used bash.

## Fix

Cron-style **overlap protection** — a schedule doesn't re-fire over its own unresolved run:

- `CronScheduler._fire(job, *, force=False)` skips an **automatic** fire while the schedule's previous run is still `queued` / `ongoing` / `review_needed` (the unresolved-state set is imported from the task engine so it stays in lockstep). A skip is not counted as a run.
- **Surfaced** on the schedule row: `last_status = "skipped: previous run still review_needed"` (the row already renders `last_status`, so this shows with no frontend change).
- `GET /api/cron` now returns `last_task_id` + `last_run_state` per schedule (via a new `list_jobs_with_state()`), so a client can proactively flag a run awaiting review.
- Manual **Run now** (`POST /api/cron/{id}/run`) passes `force=True` — an explicit user action still fires regardless.

Behavior is uniform across the human, REST, and agent surfaces (they all go through `_fire`). Keeps `review_needed` as the destination — no auto-approve (that would defeat the gate); the [design discussion is in #78](https://github.com/dkedar7/langstage/issues/78).

## Tests

`tests/test_scheduler.py` (+5): skip while prev run is `review_needed` / `ongoing` / `queued`; proceed once it's `done`; `run_now` bypasses; `list_jobs_with_state` reports `last_run_state`; no-store runner is a safe no-op. Full suite: **188 passing, 1 skipped**.

Also verified end-to-end against the real `SessionAdapter` + `TaskRunner` + SQLite store with an interrupting agent: the original repro (3 fires → 3 stuck tasks) is now **3 fires → 1 task**, skip surfaced, run-now still fires.

## Follow-ups (not in this PR)

- Frontend: a proactive "⚠ awaiting review" badge on the schedule row using `last_run_state` (the backend now exposes it; today the skip only shows *after* the next fire, via `last_status`).
- The richer per-schedule `on_interrupt` policy (`review` | `skip` | `fail`) and a creation-time warning when the agent is interrupt-gated, from the #78 discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
