### PR TITLE
fix: agent-created schedules no longer error + leave a zombie (gh #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.16 — 2026-07-12
+
+### Fixed
+- **Agent-created schedules actually work now — `schedule_run` no longer fails with "no running
+  event loop" and leaves a zombie schedule (gh #82).** `schedule_run` is a **sync** tool, so
+  LangGraph runs it in a **worker thread**; on a started server `add_job()` called
+  `asyncio.create_task()` from that thread, which raised `RuntimeError: no running event loop`.
+  The tool reported failure — but the job was **already inserted** and never rolled back, so it
+  showed up in `GET /api/cron` and the Schedules tab with **no run-loop started** and never
+  fired (a zombie). Since the built-in default agent carries `LANGSTAGE_TOOLS`, this was the
+  documented path, not an edge case. The scheduler now **captures its event loop at `start()`**
+  and starts a job's run-loop **thread-safely** (`call_soon_threadsafe` when called off the
+  loop), so `schedule_run` works from the tool thread; and `add_job()` **rolls back** the insert
+  if the run-loop can't start, so a failure never leaves a zombie. The REST/UI path was
+  unaffected (its handler already runs on the loop).
+
 ## 0.13.15 — 2026-07-11
 
 ### Added

--- a/langstage/scheduler.py
+++ b/langstage/scheduler.py
@@ -94,6 +94,10 @@ class CronScheduler:
         self._jobs: dict[str, CronJob] = {}
         self._tasks: dict[str, asyncio.Task] = {}
         self._started = False
+        # The event loop the scheduler runs on, captured at start(). Lets
+        # _start_job spawn a run-loop from a non-loop thread (the sync
+        # schedule_run tool runs in a worker thread) instead of failing. (gh #82)
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
     # ── queries ──────────────────────────────────────────────────────
     def list_jobs(self) -> list[dict[str, Any]]:
@@ -136,7 +140,14 @@ class CronScheduler:
         # create (only a follow-up GET showed it). (gh #37)
         job.next_run = self._compute_next(job.cron)
         if self._started:
-            self._start_job(job)
+            try:
+                self._start_job(job)
+            except Exception:
+                # Never leave a registered-but-unstarted (zombie) schedule: if the
+                # run-loop can't be started, roll back the insert and surface the
+                # error to the caller (the schedule_run tool / POST handler). (gh #82)
+                self._jobs.pop(job.id, None)
+                raise
         return job
 
     def remove_job(self, job_id: str) -> bool:
@@ -159,6 +170,10 @@ class CronScheduler:
     # ── lifecycle ────────────────────────────────────────────────────
     def start(self) -> None:
         """Start run-loops for all enabled jobs (call once the loop is running)."""
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - start() is always called on the loop
+            self._loop = None
         self._started = True
         for job in self._jobs.values():
             if job.enabled and job.id not in self._tasks:
@@ -169,6 +184,7 @@ class CronScheduler:
             task.cancel()
         self._tasks.clear()
         self._started = False
+        self._loop = None
 
     # ── internals ────────────────────────────────────────────────────
     @staticmethod
@@ -182,7 +198,27 @@ class CronScheduler:
         return nxt.astimezone(timezone.utc).isoformat(timespec="seconds")
 
     def _start_job(self, job: CronJob) -> None:
-        self._tasks[job.id] = asyncio.create_task(self._run_loop(job))
+        """Create the job's run-loop task. Safe to call from any thread (gh #82):
+        the sync ``schedule_run`` tool runs in a worker thread with no running
+        loop, so ``asyncio.create_task`` there raised ``RuntimeError: no running
+        event loop`` and left a zombie. When off the scheduler's loop we hand the
+        spawn to that loop via ``call_soon_threadsafe`` instead."""
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is not None and (self._loop is None or running is self._loop):
+            self._spawn_run_loop(job)
+        elif self._loop is not None:
+            self._loop.call_soon_threadsafe(self._spawn_run_loop, job)
+        else:  # pragma: no cover - no loop anywhere; add_job() rolls back the insert
+            raise RuntimeError("scheduler has no running event loop to start the job on")
+
+    def _spawn_run_loop(self, job: CronJob) -> None:
+        """Create the run-loop task. Runs on the scheduler's loop thread; guarded
+        against a job removed between scheduling and this (possibly deferred) call."""
+        if job.id in self._jobs and job.id not in self._tasks:
+            self._tasks[job.id] = asyncio.create_task(self._run_loop(job))
 
     async def _run_loop(self, job: CronJob) -> None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.15"
+version = "0.13.16"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -226,6 +226,70 @@ async def test_schedule_run_tool_reports_next_run_on_started_scheduler():
         s.shutdown()
 
 
+# ── agent-created schedules run off the loop thread (gh #82) ─────────
+
+
+async def _wait_for_task(scheduler, job_id, tries=50):
+    """call_soon_threadsafe defers the run-loop spawn to the loop; let it run."""
+    for _ in range(tries):
+        if job_id in scheduler._tasks:
+            return True
+        await asyncio.sleep(0.01)
+    return False
+
+
+async def test_off_loop_add_job_starts_run_loop_not_zombie():
+    # The sync schedule_run tool runs in a worker thread; add_job from there used
+    # to raise "no running event loop" and leave a registered-but-unstarted job.
+    s = CronScheduler(FakeRunner())
+    s.start()  # captures the loop
+    try:
+        job = await asyncio.to_thread(
+            lambda: s.add_job(name="n", cron="* * * * *", prompt="p", created_by="agent")
+        )
+        assert job.id in s._jobs
+        assert await _wait_for_task(s, job.id), "run-loop must be started (no zombie)"
+    finally:
+        s.shutdown()
+
+
+async def test_schedule_run_tool_from_worker_thread_succeeds():
+    # The exact bug: the tool returned "no running event loop" and the schedule
+    # never fired. Now it reports success and the job has a live run-loop.
+    s = CronScheduler(FakeRunner())
+    s.start()
+    set_scheduler(s)
+    try:
+        out = await asyncio.to_thread(
+            lambda: schedule_run.invoke({"name": "nightly", "cron": "* * * * *", "prompt": "p"})
+        )
+        assert "no running event loop" not in out
+        assert "Scheduled 'nightly'" in out
+        jobs = s.list_jobs()
+        assert len(jobs) == 1
+        assert await _wait_for_task(s, jobs[0]["id"]), "agent schedule must have a run-loop"
+    finally:
+        set_scheduler(None)
+        s.shutdown()
+
+
+async def test_add_job_rolls_back_when_run_loop_cannot_start(monkeypatch):
+    # If starting the run-loop fails, add_job must not leave a zombie in _jobs.
+    s = CronScheduler(FakeRunner())
+    s.start()
+
+    def boom(job):
+        raise RuntimeError("cannot start")
+
+    monkeypatch.setattr(s, "_start_job", boom)
+    try:
+        with pytest.raises(RuntimeError):
+            s.add_job(name="x", cron="* * * * *", prompt="p")
+        assert s.list_jobs() == [], "a failed start must roll back the insert"
+    finally:
+        s.shutdown()
+
+
 # ── agent tools ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What & why

Closes #82.

`schedule_run` is a **sync** LangChain tool, so LangGraph runs it in a **worker thread**. On a started server, `CronScheduler.add_job()` called `asyncio.create_task()` from that thread → `RuntimeError: no running event loop`. The tool caught it and reported *"Could not schedule run: no running event loop"* — but the job was **already inserted** into `_jobs` and never rolled back, so it appeared in `GET /api/cron` and the Schedules tab with **no run-loop started** and never fired (a zombie). The built-in default agent carries `LANGSTAGE_TOOLS`, so this was the *documented* path.

## Fix

- Capture the event loop at `start()`.
- `_start_job` is now **thread-safe**: create the run-loop task directly when on the scheduler's loop, otherwise hand the spawn to the captured loop via `call_soon_threadsafe` — so `schedule_run` works from the tool's worker thread.
- `add_job()` **rolls back** the `_jobs` insert if the run-loop can't start, so a failure never leaves a zombie.

REST/UI were unaffected (their route handler already runs on the loop); manual `run_now` unchanged.

## Tests

`tests/test_scheduler.py` (+3): an off-loop `add_job` starts a run-loop (no zombie); the real `schedule_run` tool invoked from a worker thread returns success with a **live run-loop** (the exact regression); `add_job` rolls back on a start failure. Full suite: **195 passing, 1 skipped**.

Also verified live against the real `SessionAdapter` + `TaskRunner` + SQLite store: an agent tool call from a worker thread now returns `Scheduled 'nightly'…` (was "no running event loop") with `created_by=agent` and a live run-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY