### PR TITLE
fix: show schedule times in UTC so the "9am" presets are accurate (gh #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.17 — 2026-07-12
+
+### Fixed
+- **Schedules now show times in UTC, so the "9am" presets mean what they say (gh #83).** The
+  scheduler interprets cron in UTC (a `0 9 * * *` schedule fires at 09:00 UTC, stable across host
+  timezones and DST), but the Schedules tab rendered `next_run` / `last_run` in the browser's
+  **local** timezone — so on a non-UTC host the "Daily 9am" preset displayed a mismatched time
+  (e.g. `5:00 AM`), and the shown next-run contradicted the entered cron. The tab now renders
+  those times in **UTC** with a `UTC` label, the hour-specific presets are labeled `9am UTC`, and
+  the cron field notes "times are UTC". Interpretation is unchanged (still UTC — the right default
+  for an unattended, possibly-containerized scheduler); `GET /api/cron` already returned explicit
+  `…+00:00` timestamps. README documents the UTC behavior.
+
 ## 0.13.16 — 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The **Board** tab turns LangStage into a lightweight agent control room: delegat
   ```
 
 - **Scheduled runs** (the Schedules tab) enqueue onto the same board.
+- **Cron is interpreted in UTC.** `0 9 * * *` fires at **09:00 UTC** — so scheduled runs are stable regardless of the host's timezone (and don't shift with DST) — and the Schedules tab shows `next` / `last` times in UTC to match, with the hour-specific presets labeled `9am UTC`. `next_run` in `GET /api/cron` is already an explicit UTC timestamp (`…+00:00`).
 - **A schedule never overlaps its own run.** If the previous fire's task is still queued, running, or **awaiting human review**, the next *automatic* fire is skipped (the schedule row shows `skipped: previous run still …`) instead of piling up duplicate tasks. This matters when the scheduled agent has a human-in-the-loop gate — e.g. the default agent gates `bash` — because such a run parks at **review** on the board for you to approve, and the schedule waits for you rather than stacking stuck reviews. Manual **Run now** bypasses this. `GET /api/cron` surfaces each schedule's `last_task_id` + `last_run_state` so a client can flag one awaiting review.
 
 Task REST API: `GET /api/tasks`, `POST /api/tasks` (delegate), `GET /api/tasks/{id}/events`, and `POST /api/tasks/{id}/{cancel,retry,resume,message}`. Concurrency is bounded by `LANGSTAGE_TASK_CONCURRENCY` (default 3).

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -24,6 +24,12 @@ test.describe('langstage', () => {
 
     await page.getByRole('button', { name: 'Schedules' }).click();
 
+    // Presets that name an hour are labeled UTC, matching the UTC cron
+    // interpretation (gh #83).
+    await expect(
+      page.getByRole('button', { name: 'Weekdays 9am UTC' })
+    ).toBeVisible();
+
     // The scheduler is in-memory and shared across the test run, so use a
     // unique name to avoid colliding with jobs from other tests/retries.
     const name = `Nightly digest ${Date.now()}`;
@@ -37,6 +43,8 @@ test.describe('langstage', () => {
     // The new job appears in the list with its name and cron expression.
     await expect(page.getByText(name)).toBeVisible();
     await expect(page.getByText('0 9 * * 1-5').first()).toBeVisible();
+    // next_run is rendered in UTC (09:00 UTC), matching the entered cron. (gh #83)
+    await expect(page.getByText(/09:00 UTC/).first()).toBeVisible();
   });
 
   test('rejects an invalid cron expression', async ({ page }) => {

--- a/frontend/src/components/SchedulesPanel.tsx
+++ b/frontend/src/components/SchedulesPanel.tsx
@@ -10,18 +10,32 @@ interface SchedulesPanelProps {
 }
 
 // Natural-language presets so the common cases don't require writing raw cron.
+// Schedules run in UTC (the server interprets cron against UTC), so the presets
+// that name a specific hour say "UTC" to match — otherwise "9am" would mislead a
+// user in another timezone. (gh #83)
 const CRON_PRESETS: { label: string; cron: string }[] = [
   { label: "Every 15 min", cron: "*/15 * * * *" },
   { label: "Hourly", cron: "0 * * * *" },
-  { label: "Daily 9am", cron: "0 9 * * *" },
-  { label: "Weekdays 9am", cron: "0 9 * * 1-5" },
-  { label: "Weekly Mon", cron: "0 9 * * 1" },
+  { label: "Daily 9am UTC", cron: "0 9 * * *" },
+  { label: "Weekdays 9am UTC", cron: "0 9 * * 1-5" },
+  { label: "Mon 9am UTC", cron: "0 9 * * 1" },
 ];
 
 function fmt(iso: string | null): string {
   if (!iso) return "—";
   try {
-    return new Date(iso).toLocaleString();
+    // Show times in UTC (with a UTC label) because the cron is interpreted in
+    // UTC — rendering next_run in the browser's local zone made "9am" input
+    // display as a mismatched local time. (gh #83)
+    const s = new Date(iso).toLocaleString([], {
+      timeZone: "UTC",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    return `${s} UTC`;
   } catch {
     return iso;
   }
@@ -109,7 +123,7 @@ export function SchedulesPanel({ jobs, onCreate, onDelete, onRun }: SchedulesPan
         />
         <div className="flex items-center justify-between">
           <span className="text-[10px] text-[var(--color-text-muted)]">
-            e.g. <code>*/15 * * * *</code> · <code>0 9 * * 1-5</code> · in-memory while the app runs
+            e.g. <code>*/15 * * * *</code> · <code>0 9 * * 1-5</code> · times are UTC · in-memory while the app runs
           </span>
           <button
             type="submit"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.16"
+version = "0.13.17"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## What & why

Closes #83.

The scheduler interprets cron in **UTC** (a `0 9 * * *` schedule fires at 09:00 UTC — stable across host timezones and DST; see the `_compute_next` comment), but the Schedules tab rendered `next_run` / `last_run` in the **browser's local** timezone. So on a non-UTC host the **"Daily 9am"** preset displayed a mismatched time (e.g. `5:00 AM` on US-Eastern), and the shown next-run contradicted the cron the user entered — the inconsistency this dogfood finding flagged.

## Fix (keep UTC interpretation, make the UI consistent + explicit)

- `SchedulesPanel` renders `next` / `last` times in **UTC** with a `UTC` label (was `toLocaleString()`), so the displayed time matches the entered cron.
- Hour-specific presets are labeled **`9am UTC`** (`Daily 9am UTC`, `Weekdays 9am UTC`, `Mon 9am UTC`); `Every 15 min` / `Hourly` are unchanged (no specific hour).
- The cron field helper notes **"times are UTC"**.
- README documents that cron is interpreted in UTC.

Interpretation is unchanged — UTC is the right default for an unattended, possibly-containerized scheduler. `GET /api/cron`'s `next_run` was already an explicit `…+00:00` timestamp, so programmatic clients were never ambiguous; this fixes the human surface.

## Tests

`frontend/e2e/smoke.spec.ts`: the schedule test now asserts the **`Weekdays 9am UTC`** preset is visible and that a `0 9 * * 1-5` schedule renders **`09:00 UTC`** as its next run. Verified in a real browser (Chromium) against the rebuilt frontend; `tsc -b && vite build` clean. (The visual-regression gate is scoped to the empty/welcome state, so preset/label changes don't touch baselines.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY