### PR TITLE
fix: /api/files/delete accepts path query param + DELETE verb (gh #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.13.18 — 2026-07-12
+
+### Fixed
+- **`/api/files/delete` now accepts `path` as a query parameter and a `DELETE` verb, so the
+  documented `delete?path=P` round-trip actually works (gh #81).** The README advertises delete
+  as symmetric with `read` / `download` / `upload` (all query-param `path`) and promises
+  `upload?path=P` round-trips with `delete?path=P` — but delete only accepted `POST` + a JSON
+  body `{"path": ...}`, so `DELETE …?path=P` returned 405 and `POST …?path=P` returned 422, and a
+  client written straight from the docs silently left files behind. `delete` now takes `path` as
+  a query parameter via **either `POST` or `DELETE`**, matching the other files routes; the
+  `POST` + JSON body form still works (the file-browser UI uses it). `/openapi.json` reflects
+  both methods + the `path` parameter.
+
 ## 0.13.17 — 2026-07-12
 
 ### Fixed

--- a/langstage/server/routes_files.py
+++ b/langstage/server/routes_files.py
@@ -118,15 +118,42 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
 
-    @r.post("/delete")
-    async def delete_path(body: PathRequest):
-        """Delete a file or directory."""
+    def _delete(target: str):
         try:
-            result = file_manager.delete_path(body.path)
-            return result
+            return file_manager.delete_path(target)
         except FileNotFoundError:
-            raise HTTPException(status_code=404, detail=f"Not found: {body.path}")
+            raise HTTPException(status_code=404, detail=f"Not found: {target}")
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+
+    @r.post("/delete")
+    async def delete_path(
+        path: str | None = Query(
+            None,
+            description="File/dir path relative to workspace. Query form is symmetric "
+            'with read/download/upload (so delete?path=P round-trips); a JSON body '
+            '{"path": ...} also works.',
+        ),
+        body: PathRequest | None = None,
+    ):
+        """Delete a file or directory. Accepts ``path`` as a **query** parameter —
+        ``delete?path=P``, symmetric with read/download/upload so the documented
+        round-trip holds — or a JSON body ``{"path": ...}`` (used by the file
+        browser UI). (gh #81)"""
+        target = path if path is not None else (body.path if body else None)
+        if not target:
+            raise HTTPException(
+                status_code=422,
+                detail='Provide `path` as a query parameter or a JSON body {"path": ...}.',
+            )
+        return _delete(target)
+
+    @r.delete("/delete")
+    async def delete_path_verb(
+        path: str = Query(..., description="File/dir path relative to workspace."),
+    ):
+        """``DELETE /api/files/delete?path=P`` — the natural REST verb, symmetric
+        with the other files routes. (gh #81)"""
+        return _delete(path)
 
     return r

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.17"
+version = "0.13.18"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -256,3 +256,57 @@ async def test_upload_path_escape_returns_400(client):
         files={"file": ("x.txt", b"x", "text/plain")},
     )
     assert up.status_code == 400
+
+
+# ── /api/files/delete: path query param + DELETE verb (gh #81) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_query_param_round_trips_with_upload(client):
+    # gh #81: the README promises delete?path=P round-trips with upload?path=P.
+    up = await client.post(
+        "/api/files/upload?path=del/a.txt",
+        files={"file": ("a.txt", b"bye", "text/plain")},
+    )
+    assert up.status_code == 200, up.text
+    # DELETE verb + query param — the natural REST shape the docs imply.
+    d = await client.delete("/api/files/delete?path=del/a.txt")
+    assert d.status_code == 200, d.text
+    assert d.json()["path"] == "del/a.txt"
+    assert (await client.get("/api/files/read?path=del/a.txt")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_post_with_query_param(client):
+    # POST + query param (mirroring upload?path=) also works.
+    await client.post(
+        "/api/files/upload?path=del/b.txt",
+        files={"file": ("b.txt", b"x", "text/plain")},
+    )
+    d = await client.post("/api/files/delete?path=del/b.txt")
+    assert d.status_code == 200, d.text
+    assert (await client.get("/api/files/read?path=del/b.txt")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_post_json_body_still_works(client):
+    # Back-compat: the file-browser UI posts a JSON body {"path": ...}.
+    await client.post(
+        "/api/files/upload?path=del/c.txt",
+        files={"file": ("c.txt", b"x", "text/plain")},
+    )
+    d = await client.post("/api/files/delete", json={"path": "del/c.txt"})
+    assert d.status_code == 200, d.text
+    assert (await client.get("/api/files/read?path=del/c.txt")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_without_path_returns_422(client):
+    d = await client.post("/api/files/delete")
+    assert d.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_file_returns_404(client):
+    d = await client.delete("/api/files/delete?path=nope/missing.txt")
+    assert d.status_code == 404


### PR DESCRIPTION
## What & why

Closes #81.

The README advertises `delete` as symmetric with `read` / `download` / `upload` (all query-param `path`) and explicitly promises `upload?path=P` **round-trips** with `delete?path=P`. But the delete route only accepted **`POST` + a JSON body `{"path": ...}`** — so `DELETE …?path=P` returned **405** and `POST …?path=P` returned **422**. A programmatic client written straight from the docs silently failed to delete and left files behind. (Filed by the nightly dogfood routine.)

## Fix (option 2 from the issue — keep the round-trip story true)

`/api/files/delete` now takes `path` as a **query parameter** via either **`POST` or `DELETE`**, matching `read`/`download`/`upload`. The existing **`POST` + JSON body** form still works — the file-browser UI (`useFileTree.ts`) uses it — so this is fully backward compatible. `/openapi.json` now shows both methods, each with a `path` query parameter (the issue noted it previously exposed only `post` with no parameters).

No README change needed: the fix makes the already-documented `delete?path=P` round-trip true.

## Tests

`tests/test_app.py` (+5): `upload?path=P` → `DELETE …?path=P` round-trip (file gone); `POST …?path=P`; `POST` + JSON body (back-compat); missing-path → 422; missing-file → 404. Full suite: **200 passing, 1 skipped**.

Verified live with the issue's exact curls against a running server: `DELETE ?path=` **405 → 200**, `POST ?path=` **422 → 200**, `POST` + JSON body still **200** — all three delete the file.

> Stacks on 0.13.17; this is 0.13.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY