### PR TITLE
Clean errors + safer defaults: exact init round-trip, non-loopback auth warning, clean run errors (#88, #89, #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.13.20 — 2026-07-14
+
+### Fixed
+- **`langstage init` now emits the FULL workflow-prompt defaults, so uncommenting one is
+  always a valid, exact value (gh #88).** The scaffold truncated the three long defaults —
+  `workflow.save_prompt`, `workflow.run_prompt`, `workflow.create_prompt` — to ~72 characters
+  plus a literal `...`, then quoted the fragment. The generated file's own header invites
+  "uncomment and edit only what you need" and the README promises a `config -> init -> config`
+  round-trip is **exact**, but uncommenting one of these lines silently wrote a **corrupted**
+  prompt: the trailing `...` became part of the value and the real instruction (e.g. `Execute
+  each step as described in the workflow file.`) was gone — a data bug, not just cosmetic
+  display truncation, which `config --json` (which does not truncate) faithfully resolved.
+  `_render_value()` now emits every default in full as a valid single-line TOML basic string
+  (TOML imposes no length limit; quotes/backslashes/newlines are already escaped), so the
+  advertised round-trip is exact for all fields and no line is ever a
+  syntactically-valid-but-semantically-broken preview. The `init` tests assert the three
+  prompts round-trip to their built-in defaults and that no `...` truncation leaks in.
+
 ## 0.13.19 — 2026-07-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.13.22 — 2026-07-14
+
+### Fixed
+- **`langstage run --agent <spec>` reports a bad spec as a clean one-line error, not a raw
+  traceback (gh #90).** `run` only caught `RuntimeError` around building the app (the
+  missing-`deepagents`-extra case, #46), so every *other* common `--agent` mistake — a path
+  that doesn't exist (`FileNotFoundError`), a file with no such attribute (`AttributeError`),
+  or a malformed spec missing the required `:attr` suffix (`ValueError`) — escaped as a
+  multi-frame Python traceback for what is usually a one-character typo. That contradicted the
+  clean-error intent of #46 and was inconsistent with the sibling `check`, which already
+  reports the identical failures as `[fail] failed to load: …`. `run` now catches the loader's
+  exception classes too (`ValueError` / `FileNotFoundError` / `AttributeError` / `ImportError`,
+  alongside `RuntimeError`) and surfaces them as `Error: …` (a `click.ClickException`),
+  matching `check`'s error UX. Exit code stays `1`.
+
 ## 0.13.21 — 2026-07-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.13.21 — 2026-07-14
+
+### Added
+- **A startup warning when binding a non-loopback host with no authentication (gh #89).**
+  `langstage run --host 0.0.0.0` (the natural choice on a remote box or in a container) with
+  no `--auth-password` exposes the **entire** REST surface — chat, the workspace file browser
+  (read/write/delete/upload), and the task board — unauthenticated to anyone who can reach the
+  port, and nothing signaled it: the startup banner was identical to a safe `localhost` bind.
+  `run()` now prints a clear warning to stderr when the resolved host is non-loopback
+  (`0.0.0.0`, `::`, or a concrete address — anything but `localhost` / `127.0.0.0/8` / `::1`)
+  **and** no auth password is set, naming the host and pointing at the fix (`--auth-password`
+  / `LANGSTAGE_AUTH_PASSWORD`, or a `localhost` bind behind an SSH tunnel). It **warns but
+  still starts** — the least-surprising behavior, and auth is a one-flag fix. Auth itself was
+  already correct (it returns `401`/`200` and keeps `/api/health` exempt when a password is
+  set); the gap was purely that the dangerous default was silent. README documents it.
+
 ## 0.13.20 — 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ langstage init --path ./cfg/   # target a directory or file
 | Show Canvas tab | `--show-canvas/--no-show-canvas` | `LANGSTAGE_SHOW_CANVAS` | Auto — on when `CanvasMiddleware` is attached |
 | Show Files tab | `--show-files/--no-show-files` | `LANGSTAGE_SHOW_FILES` | `true` |
 
+> **Exposing the server to the network?** The default `localhost` bind is reachable only from the same machine. If you bind a non-loopback host (`--host 0.0.0.0`, or a concrete LAN address) to reach it from elsewhere, **set `--auth-password`** (or `LANGSTAGE_AUTH_PASSWORD`) — otherwise the *entire* REST surface (chat, the workspace file browser with read/write/delete/upload, and the task board) is reachable, unauthenticated, by anyone on the network. LangStage prints a startup warning in that case but still starts; the safest alternative is to keep the `localhost` bind and reach it over an SSH tunnel.
+
 ## Slash Commands
 
 Type `/` in the chat input to access built-in commands:

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -1,8 +1,10 @@
 """CoworkApp — main entry point for the application."""
 
 import asyncio
+import ipaddress
 import logging
 import os
+import sys
 import threading
 import time
 import webbrowser
@@ -37,6 +39,48 @@ def _in_running_event_loop() -> bool:
     except RuntimeError:
         return False
     return True
+
+
+def _is_loopback_host(host: str | None) -> bool:
+    """True when binding ``host`` only exposes the server on the local machine.
+
+    Loopback = ``localhost``, the ``127.0.0.0/8`` block, or ``::1``. Everything
+    else — ``0.0.0.0`` (all IPv4 interfaces), ``::`` (all IPv6), or a concrete LAN
+    address — is reachable from other machines. A falsy host means "use uvicorn's
+    default", which is loopback, so treat it as safe. An unresolvable hostname is
+    treated as non-loopback (err toward warning) since it may resolve off-box.
+    """
+    if not host:
+        return True
+    h = host.strip().lower().strip("[]")  # tolerate an IPv6 literal like "[::1]"
+    if h == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(h).is_loopback
+    except ValueError:
+        return False
+
+
+def _exposure_warning(host: str | None, auth_password: str | None) -> str | None:
+    """Return a startup warning when the server is about to be exposed off-box with
+    no authentication, else ``None``.
+
+    A non-loopback host with no auth password means the WHOLE REST surface — chat,
+    the workspace file browser (read/write/delete/upload), the task board, config —
+    is reachable, unauthenticated, by anyone who can hit the port, and nothing else
+    signals it (the banner is identical to a loopback bind). Warn but still start —
+    the least-surprising option, and auth is a one-flag fix. (gh #89)
+    """
+    if auth_password:
+        return None
+    if _is_loopback_host(host):
+        return None
+    return (
+        f"WARNING: binding {host} with no authentication. The chat, workspace "
+        "files, and task APIs are reachable by anyone on the network. Set "
+        "--auth-password (or LANGSTAGE_AUTH_PASSWORD) to require credentials, or "
+        "bind localhost (the default) and use an SSH tunnel."
+    )
 
 
 class BackgroundServer:
@@ -250,6 +294,14 @@ class CoworkApp:
         # Point power users at the built-in, always-in-sync REST API docs — the
         # FastAPI OpenAPI schema is served but was undocumented/undiscoverable (gh #71).
         print(f"LangStage: {url}  |  REST API docs: {url}/docs")
+
+        # Loudly flag the silent-open-server footgun: a non-loopback bind (0.0.0.0,
+        # a LAN IP) with no auth password exposes the entire REST surface to the
+        # network with no other signal. Print to stderr so it stands out from the
+        # banner and survives stdout redirection. (gh #89)
+        exposure = _exposure_warning(self.config.host, self.config.auth_password)
+        if exposure:
+            print(exposure, file=sys.stderr)
 
         if open_browser:
             # Open browser after a short delay (server needs to start first)

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -77,11 +77,17 @@ def run(agent_spec, demo, workspace, port, host, debug, title, subtitle, welcome
             show_canvas=show_canvas,
             show_files=show_files,
         )
-    except RuntimeError as e:
-        # Building the built-in default agent needs the `deepagents` extra + an LLM
-        # key; on a clean `pip install langstage` it isn't there. Surface the clean,
-        # correctly-packaged message (from default_agent.create_default_agent) as a
-        # one-line CLI error instead of a traceback. (gh #46)
+    except (RuntimeError, ValueError, FileNotFoundError, AttributeError, ImportError) as e:
+        # Two distinct failure classes, both surfaced as a clean one-line CLI error
+        # instead of a raw traceback:
+        #  - RuntimeError: building the built-in default agent needs the `deepagents`
+        #    extra + an LLM key; on a clean `pip install langstage` it isn't there.
+        #    (gh #46)
+        #  - ValueError / FileNotFoundError / AttributeError / ImportError: the common
+        #    `--agent` typos — malformed spec, a path that doesn't exist, a missing
+        #    attribute, an unimportable module — all raised by the shared loader. This
+        #    mirrors how the sibling `check` command reports the identical failures as
+        #    `[fail] failed to load: …` rather than dumping a traceback. (gh #90)
         raise click.ClickException(str(e)) from e
     app.run(open_browser=not no_browser)
 

--- a/langstage/config_template.py
+++ b/langstage/config_template.py
@@ -58,8 +58,13 @@ def _render_value(name: str, value: Any) -> str:
     if value is None:
         return _EXAMPLES.get(name, '""')
     s = str(value)  # str or Path
-    if len(s) > 80:
-        s = s[:77] + "..."  # illustrative only (the line is commented out)
+    # Emit the FULL default as a valid single-line TOML basic string — never a
+    # truncated "…" preview. The scaffold's own header promises the shown value is
+    # the built-in default and that a `config -> init -> config` round-trip is
+    # exact, and it invites uncommenting any line; a truncated string is
+    # syntactically valid but semantically broken, so uncommenting e.g. a workflow
+    # prompt silently wrote a corrupt value. TOML basic strings can be any length
+    # on one line, and `_toml_quote` escapes quotes/backslashes/newlines. (gh #88)
     return _toml_quote(s)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.21"
+version = "0.13.22"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.19"
+version = "0.13.20"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.20"
+version = "0.13.21"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, AsyncMock
 from pathlib import Path
 from httpx import AsyncClient, ASGITransport
 
+from langstage.app import _exposure_warning, _is_loopback_host
 from langstage.config import AppConfig
 from langstage.server.main import create_fastapi_app
 
@@ -310,3 +311,74 @@ async def test_delete_without_path_returns_422(client):
 async def test_delete_missing_file_returns_404(client):
     d = await client.delete("/api/files/delete?path=nope/missing.txt")
     assert d.status_code == 404
+
+
+# ── non-loopback host + no auth exposure warning (gh #89) ────────────────────
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["localhost", "127.0.0.1", "127.0.0.2", "::1", "[::1]", None, "",
+     "LOCALHOST", "  localhost  "],
+)
+def test_is_loopback_host_true(host):
+    assert _is_loopback_host(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["0.0.0.0", "::", "192.168.1.10", "10.0.0.5", "myserver.internal", "example.com"],
+)
+def test_is_loopback_host_false(host):
+    assert _is_loopback_host(host) is False
+
+
+def test_exposure_warning_fires_for_non_loopback_without_auth():
+    """The dangerous default: a network-reachable bind with no password. The
+    warning must name the host and point at the fix."""
+    msg = _exposure_warning("0.0.0.0", "")
+    assert msg is not None
+    assert "0.0.0.0" in msg
+    assert "auth" in msg.lower()
+    assert "--auth-password" in msg or "LANGSTAGE_AUTH_PASSWORD" in msg
+
+
+def test_exposure_warning_silent_when_auth_set():
+    """A password closes the hole — no warning even on 0.0.0.0."""
+    assert _exposure_warning("0.0.0.0", "hunter2") is None
+
+
+def test_exposure_warning_silent_on_loopback():
+    """The safe, default case (localhost) never warns, with or without auth."""
+    assert _exposure_warning("localhost", "") is None
+    assert _exposure_warning("127.0.0.1", "") is None
+    assert _exposure_warning(None, "") is None
+
+
+def _make_run_app(workspace, mock_agent, monkeypatch, host):
+    """Build a CoworkApp whose run() won't bind a socket or move the process cwd."""
+    import langstage.app as app_mod
+    from langstage.app import CoworkApp
+
+    monkeypatch.setattr(app_mod.uvicorn, "run", lambda *a, **k: None)
+    monkeypatch.setattr(app_mod.CoworkApp, "_enter_workspace", lambda self: None)
+    return CoworkApp(agent=mock_agent, workspace=workspace, host=host, port=8050,
+                     title="T", agent_name="A", show_canvas=False, show_files=False)
+
+
+def test_run_prints_exposure_warning_to_stderr(workspace, mock_agent, monkeypatch, capsys):
+    """End-to-end: run() on 0.0.0.0 with no auth prints the warning (to stderr) and
+    still starts the server (warn-but-start). uvicorn is stubbed so nothing binds."""
+    app = _make_run_app(workspace, mock_agent, monkeypatch, host="0.0.0.0")
+    app.run(open_browser=False)
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "0.0.0.0" in err
+
+
+def test_run_no_warning_on_localhost(workspace, mock_agent, monkeypatch, capsys):
+    """The default localhost bind must not print the exposure warning."""
+    app = _make_run_app(workspace, mock_agent, monkeypatch, host="localhost")
+    app.run(open_browser=False)
+    err = capsys.readouterr().err
+    assert "WARNING" not in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,47 @@ def _write(tmp_path, name, body):
     return p
 
 
+# ── run: clean CLI error on a bad --agent spec, not a raw traceback (gh #90) ──
+
+
+def _assert_clean_run_error(result):
+    """A bad `run --agent` must exit non-zero with click's clean `Error: …` line —
+    NOT let the loader's raw exception escape as an unhandled traceback."""
+    assert result.exit_code != 0, result.output
+    # The raw loader exception must not leak out unhandled (that's the traceback bug).
+    assert not isinstance(
+        result.exception, (FileNotFoundError, AttributeError, ValueError, ImportError)
+    ), f"raw {type(result.exception).__name__} escaped instead of a clean ClickException"
+    # click formats a ClickException as a one-line "Error: <message>".
+    assert "Error:" in result.output, result.output
+
+
+def test_run_bad_agent_path_is_clean_error(tmp_path):
+    """CASE 1 — `--agent` points at a file that doesn't exist (a path typo)."""
+    missing = tmp_path / "bad.py"  # never created
+    result = CliRunner().invoke(
+        cli_mod.main, ["run", "--agent", f"{missing}:graph", "--no-browser"]
+    )
+    _assert_clean_run_error(result)
+
+
+def test_run_missing_attr_is_clean_error(tmp_path):
+    """CASE 2 — file exists but has no such attribute (AttributeError)."""
+    agent = _write(tmp_path, "mod.py", "x = 1\n")
+    result = CliRunner().invoke(
+        cli_mod.main, ["run", "--agent", f"{agent}:graph", "--no-browser"]
+    )
+    _assert_clean_run_error(result)
+
+
+def test_run_malformed_spec_is_clean_error():
+    """CASE 3 — malformed spec, missing the required ':attr' suffix (ValueError)."""
+    result = CliRunner().invoke(
+        cli_mod.main, ["run", "--agent", "mymodule", "--no-browser"]
+    )
+    _assert_clean_run_error(result)
+
+
 def test_check_fails_on_uncompiled_stategraph(tmp_path):
     """Preflight must catch the #1 BYO mistake — exporting the builder, not the
     compiled graph — instead of a confident `[ ok ] loads` + exit 0. (gh #39)"""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,6 +31,46 @@ def test_template_uncommented_round_trips_to_defaults():
     assert data["debug"] is False
 
 
+def test_template_long_prompt_defaults_are_full_not_truncated():
+    """gh #88: the long workflow-prompt defaults must be emitted in FULL, not cut
+    to a `...` preview. A truncated string is valid TOML but semantically broken, so
+    uncommenting the line (which the header invites) silently wrote a corrupt value,
+    breaking the advertised "exact round-trip" guarantee."""
+    from langstage.config import _CREATE_PROMPT, _RUN_PROMPT, _SAVE_PROMPT
+
+    txt = render_langstage_toml()
+    # No truncated/broken default may leak into the scaffold at all.
+    assert "..." not in txt, "init must not emit a truncated `...` default"
+
+    # Uncomment every simple `# key = ...` line (as a user would) and re-parse.
+    live = "\n".join(re.sub(r"^# (\w+ = )", r"\1", ln) for ln in txt.splitlines())
+    data = tomllib.loads(live)
+    # The three workflow prompts round-trip EXACTLY to the built-in defaults.
+    assert data["workflow"]["save_prompt"] == _SAVE_PROMPT
+    assert data["workflow"]["run_prompt"] == _RUN_PROMPT
+    assert data["workflow"]["create_prompt"] == _CREATE_PROMPT
+
+
+def test_init_uncommented_prompt_resolves_to_the_builtin_default():
+    """gh #88: end-to-end — `init`, uncomment run_prompt, then resolve. The config
+    must resolve to the FULL built-in default, not a truncated fragment (the exact
+    `config -> init -> config` round-trip the README promises)."""
+    from pathlib import Path
+
+    from langstage.config import _RUN_PROMPT
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        assert runner.invoke(main, ["init"]).exit_code == 0
+        toml = Path("langstage.toml")
+        text = "\n".join(
+            re.sub(r"^# (run_prompt = )", r"\1", ln) for ln in toml.read_text().splitlines()
+        )
+        toml.write_text(text)
+        cfg = AppConfig.resolve()
+        assert cfg.run_workflow_prompt == _RUN_PROMPT
+
+
 def test_template_covers_every_configurable_key():
     """Lockstep with `config`: every field `config` can read has a line here."""
     txt = render_langstage_toml()


### PR DESCRIPTION
Three dogfood-filed defects, one commit each (each bumps the version + adds a dated CHANGELOG entry, per convention).

Closes #88
Closes #89
Closes #90

## `langstage init` writes full workflow-prompt defaults (#88)

`init` truncated the three long defaults (`workflow.save_prompt` / `run_prompt` / `create_prompt`) to ~72 chars + a literal `...`, then quoted the fragment. The scaffold's header invites uncommenting any line and the README promises the `config → init → config` round-trip is **exact**, but uncommenting one silently wrote a corrupted prompt (the `...` became part of the value; the real instruction was gone) — a data bug `config --json` faithfully resolved.

`_render_value()` now emits every default in full as a valid single-line TOML basic string (TOML has no length limit; quotes/backslashes/newlines are already escaped). The round-trip is exact for all fields and no line is a valid-but-broken preview.

## Warn on a non-loopback bind with no auth (#89)

`run --host 0.0.0.0` with no `--auth-password` exposed the whole REST surface — chat, the workspace file browser (read/write/delete/upload), and the task board — unauthenticated to anyone on the network, with nothing to signal it (the banner was identical to a safe `localhost` bind). Auth itself was already correct; the gap was the silent dangerous default.

`run()` now prints a clear warning to **stderr** when the resolved host is non-loopback (`0.0.0.0`, `::`, or a concrete address — anything but `localhost` / `127.0.0.0/8` / `::1`) **and** no auth password is set, naming the host and pointing at the fix. It **warns but still starts** (least-surprising; auth is a one-flag fix). README documents it.

> Note: the sibling `langstage-agui` AG-UI serve path lives in the **separate `langstage-core`** package and would benefit from the same guard — flagged there for a follow-up; `langstage` is the target here.

## `run --agent <spec>` surfaces a bad spec cleanly, not as a traceback (#90)

`run` only caught `RuntimeError` around building the app (the missing-`deepagents`-extra case, #46), so the common `--agent` typos — a path that doesn't exist (`FileNotFoundError`), a missing attribute (`AttributeError`), or a malformed spec with no `:attr` suffix (`ValueError`) — escaped as a full Python traceback for a one-character mistake, inconsistent with the sibling `check`.

`run` now catches the loader's exception classes too and raises a `click.ClickException`, so they print as a one-line `Error: …`. Exit code stays `1`.

## Testing

- Full suite green: **229 passed, 2 skipped** (was 204 passed, 2 skipped; +25 test cases across 6 new test functions).
- Each new test was confirmed **fail-before / pass-after** by reverting only the source.
- New coverage: `init` full-prompt round-trip + no-`...` + end-to-end resolve (#88); `_is_loopback_host` / `_exposure_warning` classification + `run()` prints-to-stderr on `0.0.0.0` and stays silent on `localhost` (#89); `run` clean-error for bad path / missing attr / malformed spec (#90).
- CI runs `pytest -q` only (no ruff gate); frontend e2e/visual jobs are untouched by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
