### PR TITLE
fix: build & bundle the frontend into the wheel so pip install ships the UI (Closes #94)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,13 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install with NO extras (declared deps only)
+        env:
+          # This job exercises the backend import + CLI on a bare install; it has no Node
+          # and doesn't test the web UI. `pip install .` is a real (non-editable) wheel
+          # build, which now runs the frontend build hook (gh #94), so skip it here and
+          # install a backend-only wheel. Real release wheels (built with Node) still ship
+          # the SPA, guarded by the hook.
+          LANGSTAGE_SKIP_FRONTEND_BUILD: '1'
         run: |
           python -m pip install --upgrade pip
           pip install .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.13.24 — 2026-07-16
+
+### Fixed
+- **A clean `pip install langstage` now actually ships the web UI — `GET /` serves the
+  React SPA, not the JSON placeholder (gh #94).** Regression in 0.13.20–0.13.23: the
+  published wheels contained **no** `langstage/static/` at all, so a fresh install fell
+  through to the "no pre-built frontend" placeholder branch in `server/main.py` and the
+  entire chat workspace — the whole point of the stage — was missing. Root cause was pure
+  packaging: the Vite build output (`langstage/static/`) is git-ignored, and
+  `[tool.hatch.build] artifacts = ["langstage/static/**"]` only *re-includes* git-ignored
+  files that **already exist** at build time — it never builds them. Nothing in the manual
+  `uv build` release path ran `npm run build` first (the old `build_frontend.py` was an
+  untracked dev script), so the wheel was assembled with an empty tree and shipped no UI.
+  Fixed with a Hatchling wheel build hook (`hatch_build.py`) that builds the SPA
+  (`npm ci && npm run build`) into `langstage/static/` before the wheel is packed, with a
+  skip-if-already-built guard and a **publish guard that fails the build if
+  `langstage/static/index.html` is still missing** — so an empty-UI wheel can never reach
+  PyPI again. The hook is a no-op for the sdist and for editable installs (`pip install -e`)
+  and honours `LANGSTAGE_SKIP_FRONTEND_BUILD=1`, so Node is only needed to cut a real
+  release wheel — the Python test/dev loop and a backend-only `pip install .` don't require
+  it. Publishing 0.13.24 replaces the broken 0.13.20–0.13.23 cut.
+
 ## 0.13.23 — 2026-07-15
 
 ### Fixed

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,138 @@
+"""Hatchling wheel build hook: bundle the built React SPA into the wheel (gh #94).
+
+Why this exists
+---------------
+The web UI is a Vite/React app under ``frontend/``. Its build output lands in
+``langstage/static/`` (see ``frontend/vite.config.ts``), which is git-ignored — so that
+directory is empty in a fresh clone and in the unpacked sdist. The
+``[tool.hatch.build] artifacts = ["langstage/static/**"]`` line in ``pyproject.toml`` only
+*re-includes* git-ignored files that already exist at build time; it never creates them.
+So a plain ``uv build`` (the manual release path) produced a wheel with no
+``langstage/static/`` at all — ``pip install langstage`` shipped no frontend and ``GET /``
+served the JSON placeholder instead of the SPA (regression in 0.13.20–0.13.23).
+
+What it does
+------------
+For a real (non-editable) wheel build, it guarantees ``langstage/static/index.html`` exists
+before the archive is assembled (``artifacts`` then bundles the tree):
+
+* **skip-if-exists** — if the SPA is already built (a CI tree that ran ``npm run build``, or
+  a prior local build), do nothing. No Node needed.
+* otherwise run ``npm ci && npm run build`` in ``frontend/`` to produce it.
+* **publish guard** — if ``index.html`` still isn't present afterwards, fail the build so an
+  empty-UI wheel can never reach PyPI again.
+
+Skipped for the ``sdist`` target and for ``editable`` installs (``pip install -e``): the
+Python test suite and the dev loop don't need the compiled SPA, so those paths never
+require Node. Set ``LANGSTAGE_SKIP_FRONTEND_BUILD=1`` to force-skip the build (e.g. a
+Node-less ``pip install .`` that only exercises the backend, as the CI minimal-install job
+does).
+
+The core is factored into :func:`build_frontend_into_wheel` so it is unit-testable without
+constructing a Hatchling interface (see ``tests/test_frontend_packaging.py``).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Callable
+
+try:
+    from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+except ModuleNotFoundError:  # hatchling lives in the build env, not the runtime/test venv
+    BuildHookInterface = object  # type: ignore[assignment,misc]
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _skip_env_set() -> bool:
+    return os.environ.get("LANGSTAGE_SKIP_FRONTEND_BUILD", "").strip().lower() in _TRUTHY
+
+
+def build_frontend_into_wheel(
+    root: str | os.PathLike[str],
+    target_name: str,
+    version: str,
+    *,
+    display: Callable[[str], None] | None = None,
+) -> str:
+    """Ensure the built SPA exists at ``<root>/langstage/static`` for a wheel build.
+
+    Returns a short status token describing what happened:
+    ``"skip:not-wheel"``, ``"skip:editable"``, ``"skip:prebuilt"``, ``"skip:env"``, or
+    ``"built"``. Raises ``RuntimeError`` if it must build but can't, or if the build
+    produced no ``index.html`` (the publish guard).
+    """
+    log = display or (lambda _msg: None)
+
+    # Only the wheel carries runtime assets; the sdist just ships source.
+    if target_name != "wheel":
+        return "skip:not-wheel"
+    # Editable installs (`pip install -e`) build an "editable" wheel — the dev loop and the
+    # Python test suite don't need the compiled SPA, so never require Node.
+    if version == "editable":
+        return "skip:editable"
+
+    root = Path(root)
+    static_dir = root / "langstage" / "static"
+    index_html = static_dir / "index.html"
+
+    if index_html.is_file():
+        log(f"langstage: using pre-built frontend at {static_dir}")
+        return "skip:prebuilt"
+
+    if _skip_env_set():
+        log(
+            "langstage: LANGSTAGE_SKIP_FRONTEND_BUILD set — building a backend-only wheel "
+            "with NO frontend (GET / will serve the JSON placeholder)."
+        )
+        return "skip:env"
+
+    _run_npm_build(root, log)
+
+    if not index_html.is_file():
+        raise RuntimeError(
+            "langstage build hook: the frontend build finished but "
+            f"{index_html} is missing — refusing to build a no-UI wheel (gh #94)."
+        )
+    log(f"langstage: bundled built frontend from {static_dir}")
+    return "built"
+
+
+def _run_npm_build(root: Path, log: Callable[[str], None]) -> None:
+    frontend = root / "frontend"
+    if not (frontend / "package.json").is_file():
+        raise RuntimeError(
+            "langstage build hook: no frontend/ source to build and no pre-built "
+            f"langstage/static/index.html present (looked in {frontend}). Build the SPA first "
+            "(cd frontend && npm ci && npm run build), or set LANGSTAGE_SKIP_FRONTEND_BUILD=1 "
+            "for a backend-only wheel."
+        )
+
+    npm = shutil.which("npm")
+    if npm is None:
+        raise RuntimeError(
+            "langstage build hook: `npm` not found on PATH — Node.js is required to build the "
+            "bundled frontend. Install Node, or pre-build the SPA (cd frontend && npm run "
+            "build), or set LANGSTAGE_SKIP_FRONTEND_BUILD=1 for a backend-only wheel."
+        )
+
+    install = "ci" if (frontend / "package-lock.json").is_file() else "install"
+    log(f"langstage: building frontend (npm {install} && npm run build) in {frontend}…")
+    subprocess.run([npm, install], cwd=str(frontend), check=True)
+    subprocess.run([npm, "run", "build"], cwd=str(frontend), check=True)
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        build_frontend_into_wheel(
+            self.root,
+            self.target_name,
+            version,
+            display=self.app.display_info,
+        )

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -36,6 +36,16 @@ def _app_version() -> str:
         return "0.0.0+unknown"
 
 
+def _static_dir() -> Path:
+    """Directory holding the pre-built React SPA (``langstage/static``).
+
+    Populated at packaging time by the ``hatch_build.py`` build hook (gh #94), so a
+    wheel installed from PyPI serves the real UI. A single source of truth for the
+    path — also the seam the packaging/serving tests patch (see
+    ``tests/test_frontend_packaging.py``)."""
+    return Path(__file__).parent.parent / "static"
+
+
 def create_fastapi_app(
     agent,
     workspace: Path,
@@ -208,7 +218,7 @@ def create_fastapi_app(
             return FileResponse(icon_local_path)
 
     # Static file serving (pre-built React app)
-    static_dir = Path(__file__).parent.parent / "static"
+    static_dir = _static_dir()
     if static_dir.exists() and (static_dir / "index.html").exists():
         # Serve static assets
         assets_dir = static_dir / "assets"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.23"
+version = "0.13.24"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -66,6 +66,17 @@ cowork-dash = "langstage.cli:main"
 
 [tool.hatch.build]
 artifacts = ["langstage/static/**"]
+
+# Build the React/Vite SPA into langstage/static/ before the wheel is assembled, so a
+# published wheel actually ships the web UI (gh #94). Without this, `artifacts` above only
+# re-includes the git-ignored static/ tree *if it already exists* — a plain `uv build`
+# never built it, so 0.13.20–0.13.23 shipped no frontend. See hatch_build.py. The hook is
+# a no-op for editable installs (`pip install -e`) and skips when the SPA is already built,
+# so Node is only needed to cut a real release wheel. `uv build` builds the wheel from the
+# sdist, and both hatch_build.py and frontend/ (needed by the hook) are VCS-tracked and so
+# ship in the default sdist.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["langstage", "cowork_dash"]

--- a/tests/test_frontend_packaging.py
+++ b/tests/test_frontend_packaging.py
@@ -1,0 +1,179 @@
+"""The bundled frontend must ship in the wheel and be served at ``/`` (gh #94).
+
+Regression guard for the 0.13.20–0.13.23 packaging bug: a clean ``pip install langstage``
+shipped **no** ``langstage/static/`` at all, so ``GET /`` served the JSON placeholder
+instead of the React SPA. Root cause was that the git-ignored ``langstage/static/`` tree
+was never built before packaging and ``artifacts`` only *re-includes* files that already
+exist. The fix is the ``hatch_build.py`` wheel build hook.
+
+Most tests here are Node-free and deterministic — they exercise the hook's decision logic
+and the server's static-vs-placeholder branch directly. One end-to-end test actually builds
+a wheel and asserts the SPA is inside it; it skips unless the build tooling + a pre-built
+frontend are present (as they are on a release machine / the CI e2e job).
+"""
+
+import shutil
+import subprocess
+import tomllib
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import hatch_build
+import langstage.server.main as main_mod
+from langstage.config import AppConfig
+from langstage.server.main import create_fastapi_app
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_STATIC_INDEX = _PROJECT_ROOT / "langstage" / "static" / "index.html"
+
+
+# ── pyproject wiring ─────────────────────────────────────────────────────────
+
+
+def test_build_hook_registered_for_the_wheel_target():
+    """pyproject must wire hatch_build.py as the wheel build hook — the mechanism that
+    puts the SPA in the wheel. Before the fix there was no hook, only the (insufficient)
+    artifacts glob."""
+    with open(_PROJECT_ROOT / "pyproject.toml", "rb") as fh:
+        cfg = tomllib.load(fh)
+    hook = cfg["tool"]["hatch"]["build"]["targets"]["wheel"]["hooks"]["custom"]
+    assert hook["path"] == "hatch_build.py"
+    assert (_PROJECT_ROOT / hook["path"]).is_file()
+    # The artifacts glob that re-includes the built (git-ignored) tree is still present.
+    assert "langstage/static/**" in cfg["tool"]["hatch"]["build"]["artifacts"]
+
+
+# ── hook decision logic (Node-free) ──────────────────────────────────────────
+
+
+def _no_npm(*_a, **_k):  # pragma: no cover - only hit if the guard is broken
+    raise AssertionError("npm must not run on this path")
+
+
+def test_hook_skips_when_frontend_already_built(tmp_path, monkeypatch):
+    """skip-if-exists: a pre-built static/ tree is used as-is, no Node invoked."""
+    (tmp_path / "langstage" / "static").mkdir(parents=True)
+    (tmp_path / "langstage" / "static" / "index.html").write_text("<!doctype html>")
+    monkeypatch.setattr(hatch_build.subprocess, "run", _no_npm)
+    assert hatch_build.build_frontend_into_wheel(tmp_path, "wheel", "standard") == "skip:prebuilt"
+
+
+def test_hook_skips_for_editable_installs(tmp_path, monkeypatch):
+    """`pip install -e` (editable wheel) must never require Node — the dev/test loop
+    doesn't need the compiled SPA."""
+    monkeypatch.delenv("LANGSTAGE_SKIP_FRONTEND_BUILD", raising=False)
+    monkeypatch.setattr(hatch_build.subprocess, "run", _no_npm)
+    assert hatch_build.build_frontend_into_wheel(tmp_path, "wheel", "editable") == "skip:editable"
+
+
+def test_hook_skips_for_sdist(tmp_path, monkeypatch):
+    monkeypatch.setattr(hatch_build.subprocess, "run", _no_npm)
+    assert hatch_build.build_frontend_into_wheel(tmp_path, "sdist", "standard") == "skip:not-wheel"
+
+
+def test_hook_honours_skip_env(tmp_path, monkeypatch):
+    """The escape hatch used by the CI minimal-install job: build a backend-only wheel
+    without Node."""
+    monkeypatch.setenv("LANGSTAGE_SKIP_FRONTEND_BUILD", "1")
+    monkeypatch.setattr(hatch_build.subprocess, "run", _no_npm)
+    assert hatch_build.build_frontend_into_wheel(tmp_path, "wheel", "standard") == "skip:env"
+
+
+def test_hook_publish_guard_fails_when_it_cannot_build(tmp_path, monkeypatch):
+    """The publish guard: a real wheel build with no pre-built SPA and nothing to build it
+    from must FAIL loudly, so an empty-UI wheel can never reach PyPI again."""
+    monkeypatch.delenv("LANGSTAGE_SKIP_FRONTEND_BUILD", raising=False)
+    # Empty root: no langstage/static and no frontend/ source -> hard error.
+    with pytest.raises(RuntimeError, match="frontend"):
+        hatch_build.build_frontend_into_wheel(tmp_path, "wheel", "standard")
+
+
+def test_hook_errors_when_npm_missing(tmp_path, monkeypatch):
+    """A real wheel build that needs to compile the SPA but has no npm fails with an
+    actionable message (rather than silently shipping no UI)."""
+    monkeypatch.delenv("LANGSTAGE_SKIP_FRONTEND_BUILD", raising=False)
+    frontend = tmp_path / "frontend"
+    frontend.mkdir()
+    (frontend / "package.json").write_text("{}")
+    monkeypatch.setattr(hatch_build.shutil, "which", lambda _name: None)
+    with pytest.raises(RuntimeError, match="npm"):
+        hatch_build.build_frontend_into_wheel(tmp_path, "wheel", "standard")
+
+
+# ── server: SPA vs placeholder branch (Node-free) ────────────────────────────
+
+
+def _app_with_static(tmp_path, static_dir, monkeypatch):
+    monkeypatch.setattr(main_mod, "_static_dir", lambda: static_dir)
+    ws = tmp_path / "ws"
+    ws.mkdir(exist_ok=True)
+    agent = MagicMock()
+    agent.checkpointer = MagicMock()
+    config = AppConfig(workspace_root=ws, title="T")
+    return create_fastapi_app(agent=agent, workspace=ws, config=config)
+
+
+def test_get_root_serves_the_spa_when_static_present(tmp_path, monkeypatch):
+    """The behaviour a correctly-packaged wheel must deliver: GET / returns the real SPA
+    HTML (not the JSON placeholder) and /assets/* serves the hashed bundle."""
+    static = tmp_path / "static"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text(
+        '<!doctype html><html><body><div id="root"></div></body></html>'
+    )
+    (static / "assets" / "index-abc123.js").write_text("console.log('spa')")
+    (static / "favicon.ico").write_bytes(b"\x00")
+
+    client = TestClient(_app_with_static(tmp_path, static, monkeypatch))
+
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "text/html" in r.headers.get("content-type", "")
+    assert '<div id="root">' in r.text
+    assert "LangStage backend is running" not in r.text  # NOT the placeholder
+
+    asset = client.get("/assets/index-abc123.js")
+    assert asset.status_code == 200
+    assert "spa" in asset.text
+
+
+def test_get_root_is_the_json_placeholder_when_static_absent(tmp_path, monkeypatch):
+    """Documents the broken-wheel symptom (#94): with no bundled static/, GET / falls back
+    to the JSON placeholder. This is exactly what the packaging fix prevents in a release."""
+    client = TestClient(_app_with_static(tmp_path, tmp_path / "nope", monkeypatch))
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "application/json" in r.headers.get("content-type", "")
+    assert r.json()["message"] == "LangStage backend is running."
+
+
+# ── end-to-end: the built wheel actually contains the SPA ────────────────────
+
+
+@pytest.mark.skipif(shutil.which("uv") is None, reason="needs `uv` to build a wheel")
+@pytest.mark.skipif(
+    not _STATIC_INDEX.is_file(),
+    reason="frontend not pre-built in this tree (run: cd frontend && npm ci && npm run build)",
+)
+def test_uv_build_wheel_bundles_the_spa(tmp_path):
+    """The real thing the issue's RECORD check measured, inverted: a wheel built from this
+    tree contains langstage/static/index.html + the hashed JS/CSS assets. Skips in the
+    Node-less unit-test job; runs on a release machine / any tree with a built frontend."""
+    out = tmp_path / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(out)],
+        cwd=str(_PROJECT_ROOT),
+        check=True,
+    )
+    wheels = list(out.glob("*.whl"))
+    assert len(wheels) == 1, wheels
+    with zipfile.ZipFile(wheels[0]) as zf:
+        names = zf.namelist()
+    assert "langstage/static/index.html" in names
+    assert any(
+        n.startswith("langstage/static/assets/") and n.endswith(".js") for n in names
+    ), [n for n in names if "static" in n]


### PR DESCRIPTION
## Summary

A clean `pip install langstage` (0.13.20–0.13.23) shipped **no frontend** — `GET /` served the JSON placeholder instead of the React SPA, because the published wheels contained **no `langstage/static/`** at all. This restores the bundled web UI and makes it impossible to publish an empty-UI wheel again. Closes #94.

## Root cause (packaging)

Pure packaging, no server-code bug:

- The Vite build output lives in `langstage/static/`, which is **git-ignored** (`.gitignore:210`).
- `[tool.hatch.build] artifacts = ["langstage/static/**"]` only **re-includes** git-ignored files that *already exist* at build time — it never builds them.
- Nothing in the manual `uv build` release path ran `npm run build` first (the old `build_frontend.py` was an untracked dev script). So the wheel was assembled from an empty tree and shipped no UI.

Fail-before evidence — a clean `uv build` of 0.13.23 produced a wheel with **zero** `static/`/`.html`/`.js`/`.css` entries (matching the issue's `RECORD` finding).

## Fix

A Hatchling **wheel build hook** (`hatch_build.py`) that guarantees `langstage/static/index.html` exists before the wheel is packed:

- **skip-if-exists** — a pre-built tree (CI that ran `npm run build`, or a prior local build) is used as-is; no Node needed.
- otherwise runs `npm ci && npm run build` in `frontend/`.
- **publish guard** — if `index.html` is still missing afterwards, the build **fails**, so an empty-UI wheel can never reach PyPI again.

The hook is a **no-op for the sdist and for editable installs** (`pip install -e`) and honours `LANGSTAGE_SKIP_FRONTEND_BUILD=1`. So **Node is only required to cut a real release wheel** — the Python test/dev loop and a backend-only `pip install .` don't need it. `uv build` builds the wheel from the sdist, and both `hatch_build.py` and `frontend/` are VCS-tracked so they ship in the default sdist for the hook to run against.

Also: extracted `main._static_dir()` as the single source of truth for the SPA path (and the test seam), and updated the CI `minimal-install` job (which does a Node-less `pip install .`) to set `LANGSTAGE_SKIP_FRONTEND_BUILD=1`.

## Verification (end-to-end)

1. **Wheel contents** — clean `rm -rf dist langstage/static && uv build` (hook built the SPA inside the unpacked sdist), wheel now has **50** static entries incl. `langstage/static/index.html`, `assets/index-*.js` (848 KB), `assets/index-*.css`, `favicon.ico`. (Was **0** before.)
2. **Fresh install** — `pip install dist/langstage-0.13.24-*.whl` into a throwaway venv, `langstage run --demo`:
   - `GET /` → `200 text/html`, `<!DOCTYPE html>` + `<div id="root">` (the SPA, **not** the placeholder)
   - `GET /assets/index-*.js` → `200 application/javascript`
   - `GET /api/health` → `200 {"status":"ok","version":"0.13.24"}`
3. **Tests** — full suite **243 passed, 1 skipped** (pre-existing `deepagents`-extra skip). New `tests/test_frontend_packaging.py` covers the hook's decision logic, the serve-SPA-vs-placeholder branch, and an end-to-end assertion that a built wheel contains the SPA.

## Does CI need Node?

Only to build/verify a **real wheel**. The existing e2e/visual jobs already set up Node and run `npm run build`. The Python unit-test matrix uses editable installs (hook is a no-op), and the `minimal-install` job now skips the hook — so no Node is added to those jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFhpZ6DJkyCM6sQB99uNY
