### PR TITLE
fix: surface a missing bundled frontend at startup, /api/health, and check (Closes #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.13.25 — 2026-07-18
+
+### Fixed
+- **A missing bundled frontend is now a loud, machine-readable condition instead of a
+  browser-only surprise (gh #96).** 0.13.24 stopped frontend-less wheels from being *built*;
+  this makes one that already shipped — or a mis-set install — impossible to miss at runtime.
+  Previously the one thing this package exists to serve could be entirely absent while every
+  signal stayed green: `langstage run` printed a happy URL, uvicorn logged `Application startup
+  complete`, `/api/health` returned `{"status":"ok"}`, and `langstage check` passed. The only
+  way to find out was to open a browser and get raw JSON where the workspace should be — which
+  is precisely how the 0.13.20–0.13.23 cut sat unnoticed on PyPI (gh #94). The absence now
+  surfaces at three touch-points, all driven by one shared `frontend_bundled()` predicate so
+  they cannot drift apart:
+  - **Startup warning** — a `WARNING:` line to **stderr** (like the non-loopback auth warning
+    from #89, so it stands out from the banner and survives stdout redirection) naming the
+    missing artifact, the consequence, and both fixes.
+  - **`/api/health?ready=1`** — a `checks.frontend` field (`"ok"` / `"missing"`), giving uptime
+    monitors, k8s, and CI a hook to catch a broken deploy that a plain `200` hides. It is
+    **reported, not gating**: the readiness verdict is computed before it is added, because the
+    REST/WS surface is fully functional without the SPA and a backend-only install is supported
+    (the packaging hook honours `LANGSTAGE_SKIP_FRONTEND_BUILD=1`). Failing readiness would pull
+    a working API out of a load balancer.
+  - **`langstage check`** — a `[warn] bundled frontend missing …` line and a `checks.frontend`
+    object under `--json`, so a preflight can assert the UI actually shipped, not just that the
+    agent loads. Warning-level: the exit-code contract is unchanged.
+
 ## 0.13.24 — 2026-07-16
 
 ### Fixed

--- a/langstage/app.py
+++ b/langstage/app.py
@@ -83,6 +83,32 @@ def _exposure_warning(host: str | None, auth_password: str | None) -> str | None
     )
 
 
+def _frontend_warning() -> str | None:
+    """Return a startup warning when the built SPA is missing, else ``None``.
+
+    The one thing this package exists to serve — the web UI — can be entirely
+    absent and nothing in the terminal says so: the banner prints a happy URL,
+    uvicorn logs "Application startup complete", and ``/api/health`` returns ok.
+    The failure is invisible until a human opens a browser and finds raw JSON
+    where the workspace should be. That is exactly how frontend-less wheels
+    shipped to PyPI as 0.13.20–0.13.23 and sat there unnoticed (gh #94, #96).
+
+    Warn but still start — the REST/WS API is fully usable without the SPA, and a
+    backend-only install is supported. (gh #96)
+    """
+    from langstage.server.main import frontend_bundled
+
+    if frontend_bundled():
+        return None
+    return (
+        "WARNING: bundled frontend not found (langstage/static/index.html missing) - "
+        "the web UI is unavailable; GET / will serve a JSON placeholder. This usually "
+        "means the installed wheel shipped without the SPA. Reinstall with "
+        "`pip install --upgrade --force-reinstall langstage`, or build it locally with "
+        "`cd frontend && npm run build`."
+    )
+
+
 class BackgroundServer:
     """Handle for a LangStage server running on a background thread.
 
@@ -302,6 +328,12 @@ class CoworkApp:
         exposure = _exposure_warning(self.config.host, self.config.auth_password)
         if exposure:
             print(exposure, file=sys.stderr)
+
+        # Same treatment for the silent-missing-UI footgun: stderr, so it stands out
+        # from the banner and survives stdout redirection. (gh #96)
+        missing_frontend = _frontend_warning()
+        if missing_frontend:
+            print(missing_frontend, file=sys.stderr)
 
         if open_browser:
             # Open browser after a short delay (server needs to start first)

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -341,6 +341,24 @@ def check(agent_spec, demo, live, as_json):
             say(f"{fail} live turn failed: {result.reason}")
             finish(1)
 
+    # Everything above preflights the *agent*. This one preflights the *install*:
+    # a wheel that shipped without the SPA serves a JSON placeholder at `/` and
+    # gives no other signal, so a CI gate could pass a deploy whose entire UI is
+    # missing. Reported as a warning, not a failure — the REST/WS API works fine
+    # without it and a backend-only install is supported — so the exit-code
+    # contract is unchanged. (gh #96)
+    from langstage.server.main import frontend_bundled
+
+    has_frontend = frontend_bundled()
+    report["checks"]["frontend"] = {
+        "ok": has_frontend,
+        "detail": "bundled SPA present" if has_frontend
+        else "bundled frontend missing - web UI unavailable (JSON placeholder only)",
+    }
+    say(f"{ok} bundled frontend present - web UI will serve" if has_frontend
+        else f"{warn} bundled frontend missing - web UI unavailable "
+             "(JSON placeholder only); reinstall or `cd frontend && npm run build`")
+
     say("\nAlways available from the UI regardless of the agent: chat, "
         "tool-call view, file browser, the task board (delegate), and schedules.")
     finish(0)

--- a/langstage/server/main.py
+++ b/langstage/server/main.py
@@ -46,6 +46,22 @@ def _static_dir() -> Path:
     return Path(__file__).parent.parent / "static"
 
 
+def frontend_bundled() -> bool:
+    """Is the built SPA actually present in this install?
+
+    The one predicate behind every place the missing-frontend condition surfaces —
+    the serving branch below, the startup warning in ``app.py``, the ``/api/health``
+    readiness payload, and ``langstage check`` (gh #96). They previously could not
+    all agree because only the serving branch tested for it, so a frontend-less
+    wheel served a JSON placeholder while the terminal, the health probe, and the
+    doctor all reported a clean bill of health (gh #94).
+
+    Routed through :func:`_static_dir` so the existing test seam keeps working.
+    """
+    static_dir = _static_dir()
+    return static_dir.exists() and (static_dir / "index.html").exists()
+
+
 def create_fastapi_app(
     agent,
     workspace: Path,
@@ -192,7 +208,15 @@ def create_fastapi_app(
         except Exception as exc:  # noqa: BLE001 - any failure means not ready
             checks["task_store"] = f"unreachable: {type(exc).__name__}"
 
+        # Readiness gate is computed BEFORE the frontend check is added, deliberately.
+        # A missing SPA makes the web UI unavailable but leaves the REST/WS surface
+        # fully functional, and a backend-only install is a supported configuration
+        # (the packaging hook honours LANGSTAGE_SKIP_FRONTEND_BUILD=1). Failing
+        # readiness on it would mark those deployments permanently un-Ready and pull
+        # a working API out of a load balancer. So it is *reported*, not *gating* —
+        # a monitor that cares can assert on `checks.frontend` explicitly. (gh #96)
         ok = all(v == "ok" for v in checks.values())
+        checks["frontend"] = "ok" if frontend_bundled() else "missing"
         return JSONResponse(
             {"status": "ok" if ok else "degraded", "version": _app_version(), "checks": checks},
             status_code=200 if ok else 503,
@@ -219,7 +243,7 @@ def create_fastapi_app(
 
     # Static file serving (pre-built React app)
     static_dir = _static_dir()
-    if static_dir.exists() and (static_dir / "index.html").exists():
+    if frontend_bundled():
         # Serve static assets
         assets_dir = static_dir / "assets"
         if assets_dir.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.24"
+version = "0.13.25"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -372,7 +372,10 @@ def test_run_prints_exposure_warning_to_stderr(workspace, mock_agent, monkeypatc
     app = _make_run_app(workspace, mock_agent, monkeypatch, host="0.0.0.0")
     app.run(open_browser=False)
     err = capsys.readouterr().err
-    assert "WARNING" in err
+    # Assert the exposure warning specifically. run() emits more than one kind of
+    # startup WARNING since gh #96 (the missing-frontend notice is the other), so a
+    # bare "WARNING" substring no longer identifies which one fired.
+    assert "no authentication" in err
     assert "0.0.0.0" in err
 
 
@@ -381,4 +384,7 @@ def test_run_no_warning_on_localhost(workspace, mock_agent, monkeypatch, capsys)
     app = _make_run_app(workspace, mock_agent, monkeypatch, host="localhost")
     app.run(open_browser=False)
     err = capsys.readouterr().err
-    assert "WARNING" not in err
+    # Scoped to the exposure warning — the missing-frontend warning (gh #96) is a
+    # separate condition with its own coverage in tests/test_frontend_visibility.py,
+    # and legitimately fires here because a source checkout has no built SPA.
+    assert "no authentication" not in err

--- a/tests/test_frontend_visibility.py
+++ b/tests/test_frontend_visibility.py
@@ -1,0 +1,154 @@
+"""The missing-frontend condition must be visible, not browser-only (gh #96).
+
+A wheel can ship without the SPA (that is exactly what 0.13.20-0.13.23 did, gh #94)
+and every signal a human or a machine looks at stayed green: the startup banner
+printed a happy URL, uvicorn logged "Application startup complete", `/api/health`
+returned ok, and `langstage check` passed. The only way to find out was to open a
+browser and see raw JSON.
+
+These tests pin the three touch-points that now surface it, in both directions —
+present and missing — so the condition cannot silently go quiet again.
+"""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from langstage import app as app_mod
+from langstage.server import main as main_mod
+
+
+@pytest.fixture
+def bundled(monkeypatch):
+    """Patch the single frontend predicate's underlying path (the existing seam)."""
+
+    def _set(present: bool, tmp_path):
+        static = tmp_path / "static"
+        static.mkdir(exist_ok=True)
+        if present:
+            (static / "index.html").write_text("<!doctype html><div id=root></div>")
+        monkeypatch.setattr(main_mod, "_static_dir", lambda: static)
+        return static
+
+    return _set
+
+
+# --------------------------------------------------------------------------
+# 1. Startup warning
+# --------------------------------------------------------------------------
+
+def test_startup_warning_when_frontend_missing(bundled, tmp_path):
+    bundled(False, tmp_path)
+    warning = app_mod._frontend_warning()
+    assert warning is not None
+    # Must name the concrete missing artifact and the user-visible consequence —
+    # a bare "frontend missing" leaves the reader unable to act on it.
+    assert "langstage/static/index.html" in warning
+    assert "JSON placeholder" in warning
+    assert warning.startswith("WARNING:")
+
+
+def test_no_startup_warning_when_frontend_present(bundled, tmp_path):
+    bundled(True, tmp_path)
+    assert app_mod._frontend_warning() is None
+
+
+# --------------------------------------------------------------------------
+# 2. /api/health readiness payload
+# --------------------------------------------------------------------------
+
+def _client(tmp_path, monkeypatch):
+    from tests.test_frontend_packaging import _app_with_static  # reuse the app builder
+
+    return TestClient(_app_with_static(tmp_path, main_mod._static_dir(), monkeypatch))
+
+
+def test_health_reports_frontend_missing(bundled, tmp_path, monkeypatch):
+    bundled(False, tmp_path)
+    with _client(tmp_path, monkeypatch) as client:
+        body = client.get("/api/health?ready=1").json()
+    assert body["checks"]["frontend"] == "missing"
+
+
+def test_health_reports_frontend_ok(bundled, tmp_path, monkeypatch):
+    bundled(True, tmp_path)
+    with _client(tmp_path, monkeypatch) as client:
+        body = client.get("/api/health?ready=1").json()
+    assert body["checks"]["frontend"] == "ok"
+
+
+def test_missing_frontend_does_not_fail_readiness(bundled, tmp_path, monkeypatch):
+    """A missing SPA is reported, never gating.
+
+    The REST/WS surface is fully functional without it and a backend-only install
+    is supported (the packaging hook honours LANGSTAGE_SKIP_FRONTEND_BUILD=1).
+    Returning 503 here would mark those deployments permanently un-Ready and pull
+    a working API out of a load balancer.
+    """
+    bundled(False, tmp_path)
+    with _client(tmp_path, monkeypatch) as client:
+        resp = client.get("/api/health?ready=1")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_liveness_payload_is_unchanged(bundled, tmp_path, monkeypatch):
+    """Plain /api/health stays a minimal liveness probe — no checks block."""
+    bundled(False, tmp_path)
+    with _client(tmp_path, monkeypatch) as client:
+        body = client.get("/api/health").json()
+    assert "checks" not in body
+
+
+# --------------------------------------------------------------------------
+# 3. langstage check
+# --------------------------------------------------------------------------
+
+def _run_check(monkeypatch, extra_args=()):
+    from click.testing import CliRunner
+
+    from langstage.cli import main
+
+    return CliRunner().invoke(main, ["check", "--demo", *extra_args])
+
+
+def test_check_warns_when_frontend_missing(bundled, tmp_path, monkeypatch):
+    bundled(False, tmp_path)
+    result = _run_check(monkeypatch)
+    assert "bundled frontend missing" in result.stdout
+    # Warning only — the exit-code contract must not change (0 = agent is fine).
+    assert result.exit_code == 0
+
+
+def test_check_json_exposes_frontend_field(bundled, tmp_path, monkeypatch):
+    """The machine-readable hook a CI gate asserts on."""
+    bundled(False, tmp_path)
+    result = _run_check(monkeypatch, ["--json"])
+    report = json.loads(result.stdout)
+    assert report["checks"]["frontend"]["ok"] is False
+    assert "web UI unavailable" in report["checks"]["frontend"]["detail"]
+
+
+def test_check_json_reports_frontend_ok_when_present(bundled, tmp_path, monkeypatch):
+    bundled(True, tmp_path)
+    result = _run_check(monkeypatch, ["--json"])
+    report = json.loads(result.stdout)
+    assert report["checks"]["frontend"]["ok"] is True
+
+
+# --------------------------------------------------------------------------
+# The three surfaces must agree — that disagreement *was* the bug
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize("present", [True, False])
+def test_all_three_surfaces_agree(bundled, tmp_path, monkeypatch, present):
+    bundled(present, tmp_path)
+
+    warned = app_mod._frontend_warning() is not None
+    with _client(tmp_path, monkeypatch) as client:
+        health_missing = client.get("/api/health?ready=1").json()["checks"]["frontend"] == "missing"
+    report = json.loads(_run_check(monkeypatch, ["--json"]).stdout)
+    check_missing = not report["checks"]["frontend"]["ok"]
+
+    assert warned == health_missing == check_missing == (not present)

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.13"
+version = "0.13.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Closes #96.

## The gap

#94 was a frontend-less wheel reaching PyPI. #95 stopped one from being *built*. This closes the other half: making one that **already shipped** — or a mis-set install — impossible to miss at runtime.

Before this, the entire web UI could be absent while every signal a human or a machine looks at stayed green:

```
LangStage: http://localhost:8051  |  REST API docs: http://localhost:8051/docs
INFO:     Application startup complete.
```
```json
{"status":"ok","version":"0.13.23","checks":{"agent":"ok","task_store":"ok"}}
```

The only way to find out was to open a browser and get raw JSON where the workspace should be. That is precisely how 0.13.20–0.13.23 sat unnoticed on the index.

## The fix

Three touch-points, all routed through **one** shared `frontend_bundled()` predicate so they can't drift apart — the previous state, where only the serving branch tested for it, *was* the bug.

**1. Startup warning** (stderr, matching the #89 non-loopback auth warning so it survives stdout redirection):

```
WARNING: bundled frontend not found (langstage/static/index.html missing) - the web UI is
unavailable; GET / will serve a JSON placeholder. This usually means the installed wheel
shipped without the SPA. Reinstall with `pip install --upgrade --force-reinstall langstage`,
or build it locally with `cd frontend && npm run build`.
```

**2. `/api/health?ready=1`**:

```json
{"status":"ok","version":"0.13.24","checks":{"agent":"ok","task_store":"ok","frontend":"missing"}}
```

**3. `langstage check`**:

```
[warn] bundled frontend missing - web UI unavailable (JSON placeholder only); reinstall or `cd frontend && npm run build`
```
```json
"frontend": { "ok": false, "detail": "bundled frontend missing - web UI unavailable (JSON placeholder only)" }
```

## One deliberate design call: reported, not gating

The issue suggested `?ready=1` could "optionally reflect it". I've made it **report** the condition without failing readiness — the verdict is computed *before* `checks.frontend` is added, and `check` keeps its exit-code contract.

Rationale: the REST/WS surface is fully functional without the SPA, and a backend-only install is an explicitly supported configuration (the packaging hook honours `LANGSTAGE_SKIP_FRONTEND_BUILD=1`, and the CI minimal-install job relies on it). Returning 503 would mark those deployments permanently un-Ready and pull a working API out of a load balancer. A monitor that *does* care can assert on `checks.frontend` directly, which is the machine-readable hook the issue actually asked for.

Happy to flip it to gating if you'd rather, but I think that would break more than it catches.

## Verification

Dogfooded against a real server with `langstage/static` absent — all three surfaces fired, and `GET /` still served the placeholder with `/api/health?ready=1` returning **HTTP 200**.

`tests/test_frontend_visibility.py` — 11 tests covering all three touch-points in both directions, including a parametrized test asserting the three surfaces **agree** with each other. Verified they genuinely catch the defect: reverting the source and re-running gives **9 failed, 2 passed** (the 2 are the guard tests pinning behavior this PR deliberately preserves — readiness not gated, liveness payload unchanged).

Full suite: **252 passed, 3 skipped**.

## One existing test changed

`test_run_prints_exposure_warning_to_stderr` and `test_run_no_warning_on_localhost` asserted on a bare `"WARNING"` substring. `run()` now emits two kinds of startup warning, so that substring no longer identifies which one fired — they now assert the exposure-specific text (`"no authentication"`). Intent preserved, assertion made precise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B