### PR TITLE
fix: enforce the theme enum on env / TOML / Python-API, not just --theme (gh #104)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.13.28 — 2026-07-23
+
+### Fixed
+- **The `theme` enum is now enforced on the env / TOML / Python-API paths, not
+  just the `--theme` CLI flag (gh #104).** `theme` is documented as a three-value
+  enum — `--theme [light|dark|auto]` in the CLI `--help`, `theme = "auto"` in the
+  `init` template, `# "light" | "dark" | "auto"` in `config.py` — but that enum was
+  enforced on **only** the `--theme` flag (a click `Choice`). `LANGSTAGE_THEME`,
+  `ui.theme` in `langstage.toml`, and the Python `AppConfig(theme=…)` constructor
+  all resolved any string silently: an invalid value flowed through `AppConfig`,
+  was reported by `--show-config` / `config` as a legitimately-resolved setting,
+  and shipped to the client via `GET /api/config`, where the bundled UI (which
+  only matches `dark`/`light`/`auto`) silently ignored it — the same
+  "advertised != honored" gap the Configuration surface exists to rule out, with
+  `--show-config` confirming a value the CLI would have rejected.
+  - The three ambient paths (env / TOML / the `AppConfig(theme=…)` constructor)
+    now **degrade** an invalid value to the default `"auto"` and print a one-line
+    stderr `note:` naming the bad value and the accepted set — `note: ignoring
+    invalid theme 'purple' (expected one of: light, dark, auto); using default
+    'auto' instead.` This follows the "degrade, don't crash on ambient config"
+    contract langstage-core adopted for malformed numeric config (>= 1.0.23):
+    crashing an entrypoint on an env var or a config file is worse than degrading,
+    so an invalid `theme` in `langstage.toml` must not brick the server.
+    `--show-config` then reports `theme = auto [default]` — never crediting the
+    rejected env var / TOML key as the source — and the client can no longer
+    receive an un-honorable theme.
+  - The interactive `--theme` flag keeps its immediate hard `Choice` rejection
+    (`Error: Invalid value for '--theme': 'purple' is not one of 'light', 'dark',
+    'auto'.`, exit 2): rejecting an interactive argument on the spot is fine;
+    degrading ambient config is the safer default.
+  - The enum is **case-sensitive**, exactly matching the CLI's
+    `Choice(["light", "dark", "auto"])`, so the accepted set is identical across
+    all four sources. It is enforced in `AppConfig` by a post-resolution
+    normalization: `__post_init__` covers the direct Python constructor and,
+    through `resolve()`'s `cls(**values)`, the env and TOML paths too; `resolve()`
+    then repoints the recorded source to `default` so `--show-config` attributes
+    the degraded value correctly. A valid value still resolves normally with its
+    real source.
+
 ## 0.13.27 — 2026-07-23
 
 ### Added

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -5,10 +5,12 @@ workspace_root, host, port, debug, title) and adds cowork's UI keys, all
 resolved through the shared chain — defaults < deepagents.toml < DEEPAGENT_* env
 < overrides (Python/CLI args). cowork gains `deepagents.toml` support this way.
 """
+
 import os
+import sys
 import warnings
 from dataclasses import dataclass, fields, replace
-from typing import ClassVar, Optional
+from typing import Any, ClassVar, Optional
 
 from langstage_core.host import HostConfig
 
@@ -66,6 +68,48 @@ def __getattr__(name: str):
 
         return workspace_root()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# The documented three-value UI theme enum. It was enforced on ONLY the --theme
+# CLI flag (a click.Choice); env (LANGSTAGE_THEME), TOML (ui.theme), and the
+# Python-API AppConfig(theme=...) resolved any string silently -- so an invalid
+# value was reported by --show-config as legitimately resolved and shipped to the
+# client, where the UI silently ignored it (gh #104). Enforced now on all three
+# non-CLI paths via AppConfig below. Case-sensitive, exactly matching the CLI's
+# click.Choice(["light", "dark", "auto"]), so the accepted set is identical across
+# all four sources.
+_VALID_THEMES = ("light", "dark", "auto")
+_DEFAULT_THEME = "auto"
+
+# Dedupe the invalid-theme note across the several resolve() calls one process
+# makes (import-time module constants, --show-config, the launcher), mirroring the
+# malformed env/TOML-value notes in langstage_core.host. Keyed on the bad value.
+_warned_invalid_theme: set = set()
+
+
+def _warn_invalid_theme(value: Any) -> None:
+    """One-line stderr note when a theme from env / TOML / the Python constructor
+    isn't one of the accepted values.
+
+    Crashing an entrypoint on ambient config (an env var or langstage.toml) is
+    worse than degrading, so -- like the graceful malformed-numeric handling
+    langstage-core adopted (>= 1.0.23): degrade to the default and print a
+    one-line note -- an invalid theme falls back to the default and names both the
+    bad value and the accepted set here. The interactive --theme flag keeps its
+    hard click.Choice rejection; only the ambient paths degrade. ASCII-only so it
+    can't crash a cp1252 Windows console. (gh #104)
+    """
+    key = repr(value)
+    if key in _warned_invalid_theme:
+        return
+    _warned_invalid_theme.add(key)
+    accepted = ", ".join(_VALID_THEMES)
+    print(
+        f"note: ignoring invalid theme {value!r} "
+        f"(expected one of: {accepted}); using default {_DEFAULT_THEME!r} instead.",
+        file=sys.stderr,
+    )
+
 
 _SAVE_PROMPT = (
     "Please capture this conversation as a detailed workflow markdown file in "
@@ -153,6 +197,37 @@ class AppConfig(HostConfig):
         "show_files": "ui.show_files",
         "task_concurrency": "tasks.concurrency",
     }
+
+    def __post_init__(self) -> None:
+        # Enforce the theme enum on EVERY construction path -- crucially including
+        # the direct Python-API constructor AppConfig(theme=...), which never
+        # touches resolve(). resolve() builds its result via cls(**values) too, so
+        # this one hook also covers the env (LANGSTAGE_THEME) and TOML (ui.theme)
+        # paths. An invalid value degrades to the default with a note rather than
+        # crashing the entrypoint (see _warn_invalid_theme); resolve() below then
+        # repoints the recorded source to "default" so --show-config never credits
+        # the rejected env var / TOML key with the degraded value. (gh #104)
+        if self.theme not in _VALID_THEMES:
+            _warn_invalid_theme(self.theme)
+            self.theme = _DEFAULT_THEME
+            self._theme_degraded = True
+        else:
+            self._theme_degraded = False
+
+    @classmethod
+    def resolve(cls, **kwargs: Any) -> "AppConfig":
+        """Resolve through the shared chain, then finalize the theme enum.
+
+        __post_init__ (run inside the base resolve()'s cls(**values)) has already
+        degraded an invalid env/TOML/override theme to the default and emitted the
+        note; here we only correct the recorded source so --show-config reports
+        ``theme = auto [default]`` instead of crediting the env var / TOML key that
+        supplied the rejected value. A valid theme keeps its real source. (gh #104)
+        """
+        obj = super().resolve(**kwargs)
+        if getattr(obj, "_theme_degraded", False):
+            obj._sources["theme"] = "default"  # type: ignore[attr-defined]
+        return obj  # type: ignore[return-value]
 
     @classmethod
     def from_env(cls) -> "AppConfig":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.27"
+version = "0.13.28"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,11 @@
 """Tests for configuration resolution."""
 
-import os
-import pytest
+import re
+
+from click.testing import CliRunner
+
+from langstage import cli as cli_mod
+from langstage import config as config_mod
 from langstage.config import AppConfig
 
 
@@ -68,3 +72,114 @@ def test_custom_css_not_in_client_dict():
     cfg = AppConfig(custom_css="theme.css")
     d = cfg.to_client_dict()
     assert "custom_css" not in d
+
+
+# ── theme enum enforced on the non-CLI paths (env / TOML / Python-API) ────────
+# gh #104: the documented three-value theme enum was enforced on ONLY the --theme
+# CLI flag (a click.Choice). env (LANGSTAGE_THEME), TOML (ui.theme), and the
+# Python-API AppConfig(theme=...) accepted any string silently, so an invalid
+# value was reported by --show-config as legitimately resolved and shipped to the
+# client (GET /api/config), where the UI silently ignored it. Those ambient paths
+# now DEGRADE an invalid value to the default "auto" with a one-line stderr note
+# -- crashing an entrypoint on ambient config is worse than degrading, matching
+# langstage-core's graceful malformed-numeric handling (>= 1.0.23). The --theme
+# CLI flag keeps its immediate hard click.Choice rejection.
+#
+# These drive the config resolver and --show-config only, never the server-
+# starting `run` command: the graceful degrade means `run` would get a valid
+# config, start the server, and hang the test.
+
+
+def _clear_theme_note_dedupe():
+    # The note dedupes per bad value across a process; clear it so each test can
+    # observe its own note regardless of test order.
+    config_mod._warned_invalid_theme.clear()
+
+
+def test_invalid_env_theme_degrades_to_default_with_note(monkeypatch, capsys):
+    _clear_theme_note_dedupe()
+    monkeypatch.setenv("LANGSTAGE_THEME", "purple")
+    cfg = AppConfig.from_env()  # must NOT raise
+
+    assert cfg.theme == "auto"  # degraded to the default, not "purple"
+    assert cfg.sources["theme"] == "default"  # not credited to the rejected env var
+    err = capsys.readouterr().err
+    assert "ignoring invalid theme 'purple'" in err
+    assert "light, dark, auto" in err  # names the accepted set
+
+
+def test_invalid_toml_theme_degrades_to_default_with_note(
+    tmp_path, monkeypatch, capsys
+):
+    _clear_theme_note_dedupe()
+    (tmp_path / "langstage.toml").write_text('[ui]\ntheme = "banana"\n')
+    monkeypatch.chdir(tmp_path)
+    cfg = AppConfig.resolve()  # must NOT raise
+
+    assert cfg.theme == "auto"
+    assert cfg.sources["theme"] == "default"  # not "toml (langstage.toml)"
+    err = capsys.readouterr().err
+    assert "ignoring invalid theme 'banana'" in err
+
+
+def test_invalid_python_api_theme_degrades_to_default(capsys):
+    _clear_theme_note_dedupe()
+    cfg = AppConfig(theme="chartreuse")  # direct constructor -- never touches resolve()
+
+    assert cfg.theme == "auto"
+    assert "ignoring invalid theme 'chartreuse'" in capsys.readouterr().err
+    # ...and so the invalid value can never reach the client via GET /api/config.
+    assert cfg.to_client_dict()["theme"] == "auto"
+
+
+def test_show_config_reports_degraded_theme_as_default(tmp_path, monkeypatch):
+    # --show-config must never present an un-honorable theme as a resolved value.
+    _clear_theme_note_dedupe()
+    (tmp_path / "langstage.toml").write_text('[ui]\ntheme = "fuchsia"\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["--show-config"])
+
+    assert result.exit_code == 0, result.output
+    # theme resolves to auto, attributed to [default] -- never presented as the
+    # "fuchsia" it read (the note may still name fuchsia as the ignored value;
+    # what matters is it is never shown as a resolved value).
+    assert re.search(r"theme\s*=\s*auto\s+\[default\]", result.output), result.output
+    assert not re.search(r"theme\s*=\s*fuchsia", result.output), result.output
+
+
+def test_valid_env_theme_still_resolves_with_source(monkeypatch):
+    # A VALID value must resolve normally with correct source attribution.
+    monkeypatch.setenv("LANGSTAGE_THEME", "dark")
+    cfg = AppConfig.from_env()
+    assert cfg.theme == "dark"
+    assert cfg.sources["theme"] == "env:LANGSTAGE_THEME"
+
+
+def test_valid_toml_theme_still_resolves_with_source(tmp_path, monkeypatch):
+    (tmp_path / "langstage.toml").write_text('[ui]\ntheme = "light"\n')
+    monkeypatch.chdir(tmp_path)
+    cfg = AppConfig.resolve()
+    assert cfg.theme == "light"
+    assert "toml" in cfg.sources["theme"]
+
+
+def test_theme_enum_is_case_sensitive_like_the_cli(monkeypatch, capsys):
+    # The --theme flag's click.Choice(["light","dark","auto"]) is case-sensitive;
+    # the ambient paths match it, so the accepted set is identical across all four
+    # sources. "Dark" is therefore invalid and degrades.
+    _clear_theme_note_dedupe()
+    monkeypatch.setenv("LANGSTAGE_THEME", "Dark")
+    cfg = AppConfig.from_env()
+    assert cfg.theme == "auto"
+    assert "ignoring invalid theme 'Dark'" in capsys.readouterr().err
+
+
+def test_cli_theme_flag_still_hard_rejects():
+    # The interactive --theme flag keeps its immediate click.Choice rejection at
+    # parse time (exit 2, before the command body runs, so no server starts) --
+    # only ambient config degrades. Guards that this fix left the CLI path alone.
+    result = CliRunner().invoke(
+        cli_mod.main, ["run", "--theme", "purple", "--demo", "--no-browser"]
+    )
+    assert result.exit_code == 2
+    assert "Invalid value for '--theme'" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.27"
+version = "0.13.28"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes #104. `theme` is documented as a three-value enum — `--theme [light|dark|auto]`, `theme = "auto"` in the `init` template, `# "light" | "dark" | "auto"` in `config.py` — but the enum was enforced on **only** the `--theme` CLI flag (a click `Choice`). `LANGSTAGE_THEME`, `ui.theme` in `langstage.toml`, and the Python `AppConfig(theme=…)` constructor all resolved any string silently: the invalid value flowed through `AppConfig`, was reported by `--show-config` / `config` as a legitimately-resolved setting, and shipped to the client via `GET /api/config`, where the bundled UI (which only matches `dark`/`light`/`auto`) silently ignored it.

## Approach — degrade, don't crash (reject only the interactive flag)

The three ambient paths (env / TOML / the `AppConfig(theme=…)` constructor) now **degrade** an invalid value to the default `"auto"` and print a one-line stderr `note:` naming the bad value and the accepted set:

```
note: ignoring invalid theme 'purple' (expected one of: light, dark, auto); using default 'auto' instead.
```

This follows the "degrade, don't crash on ambient config" contract langstage-core adopted for malformed numeric config (>= 1.0.23): crashing an entrypoint on an env var or a config file is worse than degrading, so an invalid `theme` in `langstage.toml` must not brick the server. `--show-config` then reports `theme = auto [default]` — never crediting the rejected env var / TOML key as the source — and the client can no longer receive an un-honorable theme.

The interactive `--theme` flag keeps its **immediate hard `Choice` rejection** (`Error: Invalid value for '--theme': …`, exit 2): rejecting an interactive argument on the spot is fine; degrading ambient config is the safer default.

## Implementation

Post-resolution normalization in `AppConfig` (`langstage/config.py`):
- `__post_init__` enforces the enum on **every** construction path — the direct Python constructor, and (through the base `resolve()`'s `cls(**values)`) the env and TOML paths. Invalid → degrade to `"auto"` + note.
- `resolve()` repoints the recorded source to `default` when the theme was degraded, so `--show-config` attributes the value correctly rather than crediting the rejected env var / TOML key.
- The enum is **case-sensitive**, exactly matching the CLI's `Choice(["light", "dark", "auto"])`, so the accepted set is identical across all four sources. A valid value still resolves normally with its real source.

## Behavior before / after

| Source | Invalid value | Before | After |
|---|---|---|---|
| `--theme` (CLI) | `purple` | rejected, exit 2 | rejected, exit 2 (unchanged) |
| `LANGSTAGE_THEME` (env) | `purple` | resolved to `purple`, shipped to client | `auto` + `note:`; `--show-config` → `theme = auto [default]` |
| `ui.theme` (TOML) | `banana` | resolved to `banana` | `auto` + `note:`; source `[default]` |
| `AppConfig(theme=…)` (Python) | `chartreuse` | accepted silently | `auto` + `note:`; `to_client_dict()["theme"] == "auto"` |

## Tests

Added 8 regression tests to `tests/test_config.py` covering invalid env / TOML / Python-API (each degrades to `auto` with the note), `--show-config` attributing the degraded value to `[default]`, case sensitivity, valid values still resolving with their source, and the CLI flag still hard-rejecting. They drive the config resolver and `--show-config` only, never the server-starting `run` command (the graceful degrade would let `run` start a real server and hang). Verified they fail on the pre-fix source and pass after.

Full suite: **311 passed, 3 skipped** (was 303 + 8 new). Version bumped `0.13.27 → 0.13.28`; `uv.lock` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
