### PR TITLE
fix: langstage chat injects the same per-message context as the web chat (gh #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## 0.13.29 — 2026-07-25
+
+### Fixed
+- **`langstage chat` now injects the same per-message context the web chat does, so
+  a headless turn is genuinely identical to a browser turn — matching what it (and
+  `oneturn.py`) already advertised (gh #106).** The two "buffered one-turn" siblings
+  that share `langstage/oneturn.py:complete_turn` — the CLI `langstage chat` and the
+  HTTP `POST /api/chat/complete` — fed the agent **different inputs** for the same
+  prompt. Both web paths (`POST /api/chat` SSE **and** `POST /api/chat/complete`)
+  prepend a per-message context block — `[Current time: …]` + `[Working directory: …]`
+  — via `routes_chat.context_parts()`; `langstage chat` deliberately did not. That
+  contradicted the very claim both docstrings made — the `chat` docstring's *"the reply
+  is exactly what a browser would render"* and `oneturn.py`'s *"identical to what a
+  browser would have rendered"* — and it silently defeated the feature's whole purpose:
+  `chat` / `check --live` are sold as a low-ceremony **readiness gate** that mirrors a
+  production turn, but for any time-aware or workspace-aware agent — including the
+  **built-in default agent, whose entire system prompt is about operating in the
+  workspace** — the gate validated a materially different input than what ships. The
+  keyless echo demo made the divergence visible: `langstage chat --demo "ping"` replied
+  `You said: ping`, while `POST /api/chat/complete {"content":"ping"}` replied
+  `You said: [Current time: …]\n[Working directory: …]\n\nping`.
+  - `langstage chat` now calls the **same** `routes_chat.context_parts()` the web paths
+    use and forwards it through the shared `complete_turn`, so both siblings feed the
+    agent the same input and produce the same reply. `CoworkApp` has already resolved
+    and `apply_workspace`'d the workspace by the time the context is built, so the
+    reported `[Working directory: …]` is the real resolved workspace root (the browser's
+    default folder), not the launch cwd. The CLI has no file browser, so no `cwd`
+    subfolder is applied.
+  - A new **`--no-context`** flag opts back out — the terse `prompt in -> answer out`
+    echo, for clean scriptable output — at the explicit cost of no longer being
+    browser-identical. This keeps the #101 "clean `--demo` echo" use case one flag away
+    without letting the *default* silently misrepresent a browser turn.
+  - The overstated equivalence claims in the `chat` command docstring and `oneturn.py`'s
+    module docstring are corrected to describe the shipped behavior precisely: identity
+    of *output* follows from feeding the *same input*, which both callers now do by
+    default; `--no-context` is the documented exception. The historical 0.13.27
+    changelog entry is left as-is (it records what shipped then); this release makes its
+    "exactly what a browser would render" description true by default.
+
 ## 0.13.28 — 2026-07-23
 
 ### Fixed

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -371,15 +371,25 @@ def check(agent_spec, demo, live, as_json):
 @click.option("--json", "as_json", is_flag=True, default=False,
               help="Emit the reply as JSON ({content, tool_calls}) for scripting/CI, "
                    "instead of just the assistant text.")
+@click.option("--no-context", "no_context", is_flag=True, default=False,
+              help="Withhold the per-message time + working-directory context the web "
+                   "chat injects, for a terse scriptable echo. By default `chat` injects "
+                   "that context so the reply mirrors a browser turn; --no-context opts "
+                   "out (cleaner output, but no longer browser-identical).")
 @click.argument("prompt")
-def chat(agent_spec, demo, workspace, as_json, prompt):
+def chat(agent_spec, demo, workspace, as_json, no_context, prompt):
     """Run ONE turn against the agent and print the assistant reply to stdout.
 
     The headless companion to the web stage - prompt in, answer out, with no server
     and no SSE dance. Keyless-testable with ``--demo``; honors the same
     ``--workspace`` / ``langstage.toml`` / ``LANGSTAGE_*`` resolution as ``run``.
-    Reuses the same streaming core the server drives (the shared ``SessionAdapter``),
-    so the reply is exactly what a browser would render, buffered into one turn.
+    Reuses the same streaming core the server drives (the shared ``SessionAdapter``)
+    **and injects the same per-message context (current time + resolved workspace) the
+    web chat does**, so for the same prompt the reply is genuinely what a browser would
+    render, buffered into one turn. That makes it a faithful readiness gate even for a
+    time-aware or workspace-aware agent (including the built-in default agent, whose
+    whole system prompt is about the workspace). Pass ``--no-context`` for the terse
+    echo that omits that context - cleaner for scripting, but no longer browser-identical.
 
     Exits non-zero if the agent errors (like ``check --live``), so it doubles as a
     readiness gate that also *shows* the answer. Add ``--json`` for a machine-readable
@@ -402,10 +412,17 @@ def chat(agent_spec, demo, workspace, as_json, prompt):
         raise click.ClickException(str(e) or type(e).__name__) from e
 
     from langstage.oneturn import run_turn_sync
+    from langstage.server import routes_chat
 
-    # No per-message time/cwd context injected here (unlike the web chat): the CLI
-    # is a clean "prompt in -> answer out" smoke test, so the reply isn't cluttered.
-    result = run_turn_sync(app.agent, prompt)
+    # Feed the agent the SAME per-message context (current time + resolved workspace)
+    # the web paths inject via routes_chat.context_parts(), so a `langstage chat` turn
+    # is genuinely identical to a browser turn - honoring the readiness-gate promise for
+    # time-aware / workspace-aware agents (gh #106). CoworkApp above already resolved and
+    # applied the workspace, so context_parts() reads the right one. --no-context restores
+    # the terse "prompt in -> answer out" echo for scripting. No cwd (the CLI has no file
+    # browser), so context reports the resolved workspace root - a browser's default folder.
+    context = None if no_context else routes_chat.context_parts()
+    result = run_turn_sync(app.agent, prompt, context_parts=context)
 
     if as_json:
         import json as _json

--- a/langstage/oneturn.py
+++ b/langstage/oneturn.py
@@ -12,8 +12,18 @@ It does **not** reimplement streaming. It drives the same
 :class:`~langstage_core.adapters.SessionAdapter` the web server drives — the exact
 path ``POST /api/chat`` + ``GET /api/stream`` use — and simply *buffers* the
 serialized event frames into one assembled result instead of forwarding them over
-SSE. So the reply, tool calls, and terminal outcome are identical to what a browser
-would have rendered; the CLI and the HTTP endpoint share this one implementation.
+SSE. So for the *same submitted input* the reply, tool calls, and terminal outcome
+are identical to what a browser would have rendered; the CLI and the HTTP endpoint
+share this one implementation.
+
+Identity of the *input* is the caller's job, not this module's: ``complete_turn``
+takes ``context_parts`` and forwards them verbatim to ``SessionAdapter.submit_message``.
+The HTTP endpoint (``POST /api/chat/complete``) and ``langstage chat`` both pass the
+same per-message context — ``[Current time: …]`` + ``[Working directory: …]`` from
+``routes_chat.context_parts()`` — by default (gh #106), so a ``langstage chat`` turn
+truly mirrors a browser turn: a time-aware or workspace-aware agent sees the same input
+either way. (``langstage chat --no-context`` deliberately withholds that context for
+terse scriptable output, and is then no longer browser-identical — by request.)
 """
 from __future__ import annotations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.28"
+version = "0.13.29"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_chat_complete.py
+++ b/tests/test_chat_complete.py
@@ -104,3 +104,85 @@ def test_run_turn_sync_drives_one_turn_end_to_end():
     result = run_turn_sync(_stub(), "sync smoke")
     assert result.ok
     assert "sync smoke" in result.content
+
+
+# ── the two siblings feed the agent the SAME input (gh #106) ─────────────────
+
+
+def test_cli_and_endpoint_feed_the_agent_the_same_input(monkeypatch):
+    """gh #106: `langstage chat` and `POST /api/chat/complete` share `complete_turn`
+    and are documented as producing an identical, browser-faithful reply — so they must
+    feed the agent the *same input* for the same prompt. Previously the CLI withheld the
+    per-message `[Current time]` / `[Working directory]` context the web paths inject, so
+    the demo echo agent (which reflects its input) returned different replies.
+
+    Drive the endpoint via `httpx.ASGITransport` and the CLI via `CliRunner`, both keyless
+    with `--demo` and the same prompt, and assert the replies match. `context_parts` is
+    pinned to a fixed value so the assertion is deterministic (no per-second timestamp /
+    workspace drift) and targets the real invariant: the CLI now injects the SAME context
+    the endpoint does. Fails before the fix (CLI fed no context), passes after.
+
+    This test is synchronous (not the module's default async): the CLI's `run_turn_sync`
+    calls `asyncio.run`, which can't be nested inside a running loop, so the endpoint leg
+    runs in its own `asyncio.run` and the CLI leg runs after it.
+    """
+    import asyncio
+    import json
+
+    from click.testing import CliRunner
+
+    from langstage import cli as cli_mod
+    from langstage.server import routes_chat
+
+    fixed = ["[Current time: 2026-07-25 00:00:00 UTC]", "[Working directory: /ws]"]
+    # Both siblings resolve `context_parts` from routes_chat at call time (the endpoint
+    # via its module global, the CLI via `routes_chat.context_parts()`), so one patch
+    # covers both. The demo echoes its full input, exposing any divergence.
+    monkeypatch.setattr(routes_chat, "context_parts", lambda cwd=None: list(fixed))
+
+    async def _endpoint_reply() -> str:
+        async with _client(_stub()) as c:
+            r = await c.post("/api/chat/complete", json={"content": "ping"})
+        assert r.status_code == 200
+        return r.json()["content"]
+
+    endpoint_content = asyncio.run(_endpoint_reply())
+
+    cli_result = CliRunner().invoke(cli_mod.main, ["chat", "--demo", "--json", "ping"])
+    assert cli_result.exit_code == 0, cli_result.output
+    cli_content = json.loads(cli_result.output)["content"]
+
+    # Same shared complete_turn + same demo agent + same injected context => same reply.
+    assert cli_content == endpoint_content
+    # And the context really is injected (guards against a both-empty false pass).
+    assert "[Working directory: /ws]" in cli_content
+    assert "ping" in cli_content
+
+
+def test_cli_no_context_flag_restores_the_terse_echo():
+    """gh #106: `--no-context` opts back out of the browser-identical context injection
+    for a clean scriptable echo — so the CLI's default (context injected) and its escape
+    hatch (context withheld) are demonstrably different, and the flag exists at all
+    (before the fix it did not, and the default omitted the context)."""
+    import json
+
+    from click.testing import CliRunner
+
+    from langstage import cli as cli_mod
+
+    default = CliRunner().invoke(cli_mod.main, ["chat", "--demo", "--json", "ping"])
+    raw = CliRunner().invoke(
+        cli_mod.main, ["chat", "--demo", "--no-context", "--json", "ping"]
+    )
+    assert default.exit_code == 0, default.output
+    assert raw.exit_code == 0, raw.output
+
+    default_content = json.loads(default.output)["content"]
+    raw_content = json.loads(raw.output)["content"]
+
+    # Default injects the real per-message context; --no-context strips it.
+    assert "[Working directory:" in default_content
+    assert "[Current time:" in default_content
+    assert "[Working directory:" not in raw_content
+    assert "[Current time:" not in raw_content
+    assert default_content != raw_content

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.28"
+version = "0.13.29"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem (gh #106)

The two "buffered one-turn" siblings that share `langstage/oneturn.py:complete_turn` — the CLI `langstage chat` and the HTTP `POST /api/chat/complete` — fed the agent **different inputs for the same prompt**. Both web paths (`POST /api/chat` SSE **and** `POST /api/chat/complete`) prepend a per-message context block — `[Current time: …]` + `[Working directory: …]` — via `routes_chat.context_parts()`. `langstage chat` deliberately did not.

That contradicted the very claim both docstrings made — the `chat` docstring's *"the reply is exactly what a browser would render"* and `oneturn.py`'s *"identical to what a browser would have rendered"* — and it silently defeated the feature's whole purpose. `chat` / `check --live` are sold as a low-ceremony **readiness gate that mirrors a production turn**, but for any time-aware or workspace-aware agent — including the **built-in default agent, whose entire system prompt is about operating in the workspace** — the gate validated a materially different input than what ships.

## Decision — issue option 1 (make `chat` faithful), as a hybrid

Faithful **by default**, with a `--no-context` escape hatch. Option 1 is the higher-value fix (the feature's whole selling point, #101/#103, is being the low-ceremony stand-in for a real turn), and the hybrid keeps #101's clean scriptable echo one flag away without letting the *default* misrepresent a browser turn.

- **`langstage chat` now injects the same context.** It calls the same `routes_chat.context_parts()` the web paths use and forwards it through the shared `complete_turn`, so both siblings feed the agent the same input and produce the same reply. `CoworkApp` has already `apply_workspace`'d the resolved workspace by then, so the reported `[Working directory: …]` is the real workspace root (a browser's default folder), not the launch cwd.
- **New `--no-context` flag** restores the terse `prompt in -> answer out` echo — at the explicit cost of no longer being browser-identical.
- **Docstrings corrected** (`chat` command + `oneturn.py` module) to describe the shipped behavior precisely: identity of *output* follows from feeding the *same input*, which both callers now do by default; `--no-context` is the documented exception. (No README line made the false claim; the historical 0.13.27 CHANGELOG entry is left as-is — this release makes its description true by default.)

## Dogfood — the issue's exact keyless repro (`--demo`, `ping`)

Endpoint driven via `httpx.ASGITransport` (no real server — the repo's test rule), same workspace:

```
A) langstage chat --demo "ping"
(demo agent) You said: [Current time: 2026-07-25 05:58:56 UTC]
[Working directory: …\dogfood_ws_7qico2gn]

ping

B) POST /api/chat/complete {"content":"ping"}
(demo agent) You said: [Current time: 2026-07-25 05:58:57 UTC]
[Working directory: …\dogfood_ws_7qico2gn]

ping
```

Both now inject `[Current time]` + `[Working directory]`, and the working directory is byte-identical; the only delta is the live per-second clock (each calls `datetime.now()` a moment apart, exactly as two browser turns would). Normalizing the timestamp, the replies are **byte-exact equal**. Before the fix, A was `You said: ping` with no context at all.

## Tests

`tests/test_chat_complete.py`:
- `test_cli_and_endpoint_feed_the_agent_the_same_input` — drives the endpoint via `ASGITransport` and the CLI via `CliRunner`, both keyless `--demo`, and asserts they feed the agent the same input (identical reply); `context_parts` pinned for determinism.
- `test_cli_no_context_flag_restores_the_terse_echo` — the escape hatch.

Both **fail before the fix and pass after** (verified by reverting `cli.py` with the tests kept). Full suite: **313 passed, 3 skipped**.

## Notes

- Version bumped to **0.13.29** with a dated CHANGELOG entry; `uv.lock` updated (version line only).
- No ruff config exists and CI (`.github/workflows/test.yml`, local + remote) runs no ruff step; pristine `main` files already fail default `ruff format --check` (the maintainer hand-formats). I therefore did **not** run `ruff format` (it would revert unrelated hand-formatted lines) and matched the surrounding style; my changes add zero new `ruff check` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B