### PR TITLE
fix: reject non-5-field cron expressions instead of silently accepting them (gh #108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 0.13.30 — 2026-07-25
+
+### Fixed
+- **`POST /api/cron` (and the `schedule_run` agent tool) now reject any non-5-field
+  cron expression with the same clean 400 the 4-field case already got — so a 6- or
+  7-field cron pasted from another scheduler can no longer be silently accepted and
+  fired at an unintended time (gh #108).** Validation delegated entirely to
+  `croniter.is_valid`, which also accepts croniter's **6-field (seconds)** and
+  **7-field (seconds + year)** extensions. But both the endpoint's own 400 message and
+  the README document **standard 5-field UTC cron only** (*"Cron is interpreted in UTC.
+  `0 9 * * *` fires at 09:00 UTC"*). The result was a silent-misinterpretation bug: a
+  4-field cron was correctly rejected with *"Expected 5 fields 'min hour day month
+  weekday'"*, but a 6-field Quartz/Spring/k8s-style cron such as `30 0 9 * * *` was
+  **accepted (201)** and read by croniter as `min=30 hour=0 day=9 month=* weekday=*
+  second=*` — a `next_run` on the **9th at 00:30 UTC**, not the ~09:00 the user meant —
+  with no error and no warning. That is the exact class of misinterpretation the
+  strict-5-field message was written to prevent.
+  - `validate_cron` now asserts the field count **before** croniter:
+    `len(expr.split()) != 5` raises the existing *"Expected 5 fields …"* `ValueError`,
+    so anything but a standard 5-field expression is rejected up front. `str.split()`
+    (no argument) splits on runs of whitespace, so `"0  9 * * *"` (double space) is
+    still 5 fields; steps and ranges like `*/15 * * * *` and `0 9 * * 1-5` still pass.
+  - The guard lives in the **single shared** `validate_cron`, which both the HTTP
+    create path (`POST /api/cron` → `CronScheduler.add_job`) and the agent-facing
+    `schedule_run` tool call — so both surfaces enforce the identical 5-field contract,
+    and the endpoint's 400 message is finally true. The 4-field rejection is unchanged.
+
 ## 0.13.29 — 2026-07-25
 
 ### Fixed

--- a/langstage/scheduler.py
+++ b/langstage/scheduler.py
@@ -49,10 +49,24 @@ def _now_iso() -> str:
 
 
 def validate_cron(expr: str) -> None:
-    """Raise ValueError if ``expr`` isn't a valid 5-field cron expression."""
+    """Raise ValueError if ``expr`` isn't a valid **5-field** cron expression.
+
+    croniter also accepts 6-field (seconds) and 7-field (seconds + year)
+    expressions, but langstage documents and interprets standard 5-field UTC
+    cron only ('min hour day month weekday'). Without an explicit field-count
+    check, a 6-field Quartz/Spring/k8s-style cron pasted from another scheduler
+    is *silently* accepted by croniter and fires at a time the user never
+    intended — the exact misinterpretation the strict-5-field error message
+    promises to prevent (gh #108). So reject any non-5-field expression up
+    front, with the same clean error the 4-field case already gets.
+    """
     if croniter is None:  # pragma: no cover
         raise RuntimeError("croniter is required for scheduling. pip install croniter")
-    if not croniter.is_valid(expr):
+    # ``str.split()`` with no argument splits on runs of whitespace and drops
+    # empty fields, so '0  9 * * *' (double space) is still 5 fields. The count
+    # guard runs first so a croniter-valid 6-/7-field expression is rejected too,
+    # not just expressions croniter itself rejects (too few fields / garbage).
+    if len(expr.split()) != 5 or not croniter.is_valid(expr):
         raise ValueError(
             f"Invalid cron expression: {expr!r}. Expected 5 fields "
             "'min hour day month weekday', e.g. '*/15 * * * *' or '0 9 * * 1-5'."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.29"
+version = "0.13.30"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_routes_cron.py
+++ b/tests/test_routes_cron.py
@@ -1,0 +1,114 @@
+"""Contract tests for the POST /api/cron field-count guard (gh #108).
+
+`croniter` accepts 5-, 6- and 7-field expressions (its seconds / year
+extensions), but langstage documents and interprets standard 5-field UTC cron
+only — and the 400 message promises exactly that ("Expected 5 fields …"). Before
+the fix a 6-field Quartz/Spring/k8s-style cron pasted from another scheduler was
+silently accepted (201) and fired at an unintended time. These tests pin that
+any non-5-field expression is rejected with the same clean 400 the 4-field case
+already got, while valid 5-field expressions (including steps/ranges) still 201.
+
+The route is driven over ``httpx.ASGITransport`` — never a real server (starting
+one would hang). ``add_job`` on an unstarted scheduler computes ``next_run``
+synchronously via croniter and never touches the runner, so a trivial stub
+runner suffices.
+"""
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from langstage.scheduler import (
+    CronScheduler,
+    set_scheduler,
+    schedule_run,
+    validate_cron,
+)
+from langstage.server.routes_cron import create_cron_router
+
+
+class _StubRunner:
+    """The create path never fires, so no runner behaviour is exercised."""
+
+
+def _client():
+    scheduler = CronScheduler(_StubRunner())
+    app = FastAPI()
+    app.include_router(create_cron_router(scheduler))
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://t")
+    return client, scheduler
+
+
+_FIVE_FIELD_MSG = "Expected 5 fields 'min hour day month weekday'"
+
+
+# ── the endpoint contract ────────────────────────────────────────────────────
+
+
+async def test_four_field_cron_rejected_unchanged():
+    """The pre-existing 4-field rejection is untouched — same 400, same message."""
+    client, _ = _client()
+    async with client as c:
+        r = await c.post("/api/cron", json={"name": "A", "cron": "0 9 * *", "prompt": "x"})
+    assert r.status_code == 400
+    assert _FIVE_FIELD_MSG in r.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    "cron",
+    ["0 9 * * *", "*/15 * * * *", "0 9 * * 1-5", "0  9 * * *"],
+)
+async def test_valid_five_field_crons_accepted(cron):
+    """Plain, step (*/15), range (1-5), and double-spaced 5-field crons all 201."""
+    client, _ = _client()
+    async with client as c:
+        r = await c.post("/api/cron", json={"name": "ok", "cron": cron, "prompt": "x"})
+    assert r.status_code == 201, r.text
+    assert r.json()["next_run"]  # computed synchronously on create
+
+
+@pytest.mark.parametrize(
+    "cron",
+    [
+        "30 0 9 * * *",     # 6-field (croniter seconds) — the issue's case B
+        "0 9 * * * * *",    # 7-field — the issue's case C
+        "0 0 9 * * * 2030", # 7-field with year
+    ],
+)
+async def test_six_and_seven_field_crons_now_rejected(cron):
+    """Before gh #108 these were silently accepted (201) and fired at the wrong
+    time; now they get the same clean 400 the 4-field case gets."""
+    client, scheduler = _client()
+    async with client as c:
+        r = await c.post("/api/cron", json={"name": "B", "cron": cron, "prompt": "x"})
+    assert r.status_code == 400
+    assert _FIVE_FIELD_MSG in r.json()["detail"]
+    assert scheduler.list_jobs() == []  # nothing persisted from a rejected create
+
+
+# ── the agent-tool path shares the same validation ───────────────────────────
+
+
+def test_validate_cron_rejects_six_and_seven_fields():
+    """The single shared validator (used by both POST /api/cron and the
+    schedule_run agent tool) enforces the 5-field contract."""
+    validate_cron("0 9 * * *")          # 5 fields ok
+    validate_cron("*/15 * * * *")       # steps ok
+    validate_cron("0 9 * * 1-5")        # ranges ok
+    validate_cron("0  9 * * *")         # double space still 5 fields
+    for bad in ("30 0 9 * * *", "0 9 * * * * *", "0 0 9 * * * 2030"):
+        with pytest.raises(ValueError):
+            validate_cron(bad)
+
+
+def test_schedule_run_agent_tool_rejects_six_field_cron():
+    """The agent tool goes through add_job -> validate_cron, so it rejects a
+    6-field cron too (no schedule created)."""
+    s = CronScheduler(_StubRunner())
+    set_scheduler(s)
+    try:
+        out = schedule_run.invoke({"name": "B", "cron": "30 0 9 * * *", "prompt": "p"})
+        assert "Could not schedule" in out
+        assert _FIVE_FIELD_MSG in out
+        assert s.list_jobs() == []
+    finally:
+        set_scheduler(None)

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ wheels = [
 
 [[package]]
 name = "langstage"
-version = "0.13.29"
+version = "0.13.30"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Fixes #108. `POST /api/cron` validated the `cron` string by delegating to `croniter.is_valid`, which also accepts croniter's **6-field (seconds)** and **7-field (seconds + year)** extensions — but both the endpoint's own 400 message and the README document **standard 5-field UTC cron only** (*"Cron is interpreted in UTC. `0 9 * * *` fires at 09:00 UTC"*).

The result was a silent-misinterpretation bug:
- a **4-field** cron was correctly rejected `400` with *"Expected 5 fields 'min hour day month weekday'"*,
- but a **6-field** Quartz/Spring/k8s-style cron like `30 0 9 * * *` was **accepted (201)** and read by croniter as `min=30 hour=0 day=9 month=* weekday=* second=*` — a `next_run` on the **9th at 00:30 UTC**, not the ~09:00 the user meant — with no error or warning,
- **7-field** crons likewise accepted.

## Fix

Add an explicit field-count check to `validate_cron` (the **single shared** validator) *before* delegating to croniter:

```python
if len(expr.split()) != 5 or not croniter.is_valid(expr):
    raise ValueError(... "Expected 5 fields 'min hour day month weekday' ...")
```

- `str.split()` with no argument splits on runs of whitespace, so `"0  9 * * *"` (double space) is still 5 fields.
- Steps/ranges (`*/15 * * * *`, `0 9 * * 1-5`) still pass.
- The 4-field rejection is unchanged (same message).

Because the guard lives in the shared `validate_cron`, **both** creation surfaces enforce the identical contract: the HTTP path (`POST /api/cron` → `CronScheduler.add_job`) **and** the agent-facing `schedule_run` tool (also `add_job` → `validate_cron`). No second fix site needed.

## Behavior (via the regression test)

| Fields | Example | Before | After |
|---|---|---|---|
| 4 | `0 9 * *` | 400 (message) | 400 (unchanged) |
| 5 | `0 9 * * *`, `*/15 * * * *`, `0 9 * * 1-5`, `0  9 * * *` | 201 | 201 |
| 6 | `30 0 9 * * *` | **201 (silent, wrong time)** | **400 (5-field message)** |
| 7 | `0 9 * * * * *`, `0 0 9 * * * 2030` | **201** | **400 (5-field message)** |

## Tests

New `tests/test_routes_cron.py` drives `POST /api/cron` over `httpx.ASGITransport` (no real server) plus covers the shared validator and the `schedule_run` agent-tool path. Verified fail-before / pass-after by reverting only the source (keeping the test): the 6-/7-field, validator, and agent-tool assertions fail without the fix; the 4-field and valid-5-field assertions pass both ways.

Full suite: **323 passed, 3 skipped** (baseline 313+3, plus 10 new tests).

Version bumped 0.13.29 → 0.13.30; `uv.lock` refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B