### PR TITLE
fix: langstage chat enters the resolved workspace before the turn (gh #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.13.31 — 2026-07-26
+
+### Fixed
+- **`langstage chat` now `chdir`s into the resolved workspace before the turn, so the
+  agent's process `os.getcwd()` and its relative file ops actually land in the workspace
+  — matching a browser turn instead of only *naming* the workspace in the injected
+  context (gh #110).** This is the residual gap left after #106. That fix made `chat`
+  inject the same `[Working directory: <workspace>]` context line the web chat does, but
+  `chat` never entered the workspace the way the web server does: `run()` calls
+  `CoworkApp._enter_workspace()` (which does `os.chdir(workspace_root())`, per ADR 0006),
+  while `chat` constructed `CoworkApp(...)` and called `run_turn_sync(app.agent, …)`
+  directly — never `run()`, never `_enter_workspace()`. So the injected line said the
+  working directory was the workspace while the process cwd stayed the **launch** dir, and
+  a bring-your-own agent's raw relative write (`Path("out.txt").write_text(...)`) landed
+  **outside** the workspace the file browser shows — inconsistently with what the same
+  turn does in the browser.
+  - `chat` now enters the resolved workspace (via `app._enter_workspace()`) after
+    `CoworkApp` has resolved and `apply_workspace`'d it and before `run_turn_sync`, exactly
+    mirroring `run()`. The chdir is **unconditional**, so `--no-context` follows the
+    workspace too — cwd tracks the resolved workspace whether or not the context line is
+    injected.
+  - The CLI restores the caller's **prior cwd after the turn**, so a library/embedded
+    caller of the chat path isn't left with a changed cwd.
+  - The web/`run()` path and `__init__`'s deliberate no-cwd-side-effect contract are
+    unchanged (embedding `CoworkApp` still never moves the process cwd).
+
 ## 0.13.30 — 2026-07-25
 
 ### Fixed

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -1,5 +1,7 @@
 """CLI: langstage run [OPTIONS]."""
 
+import os
+
 import click
 
 from langstage.app import CoworkApp
@@ -414,15 +416,29 @@ def chat(agent_spec, demo, workspace, as_json, no_context, prompt):
     from langstage.oneturn import run_turn_sync
     from langstage.server import routes_chat
 
-    # Feed the agent the SAME per-message context (current time + resolved workspace)
-    # the web paths inject via routes_chat.context_parts(), so a `langstage chat` turn
-    # is genuinely identical to a browser turn - honoring the readiness-gate promise for
-    # time-aware / workspace-aware agents (gh #106). CoworkApp above already resolved and
-    # applied the workspace, so context_parts() reads the right one. --no-context restores
-    # the terse "prompt in -> answer out" echo for scripting. No cwd (the CLI has no file
-    # browser), so context reports the resolved workspace root - a browser's default folder.
-    context = None if no_context else routes_chat.context_parts()
-    result = run_turn_sync(app.agent, prompt, context_parts=context)
+    # Enter the resolved workspace before the turn — the same chdir `run()` does via
+    # `_enter_workspace()` (ADR 0006) — so a bring-your-own agent's raw relative file ops
+    # (`Path("out.txt").write_text(...)`) land IN the workspace, where the file browser
+    # shows them, instead of the launch cwd. Without this, `chat` injected a
+    # `[Working directory: <workspace>]` line (below) while the process cwd stayed the
+    # launch dir, so the agent's `os.getcwd()` and its relative writes disagreed with a
+    # browser turn — the residual gap after #106 (gh #110). Do it unconditionally, before
+    # building the context, so `--no-context` follows the workspace too. Restore the prior
+    # cwd afterward so a library/embedded caller of this path isn't left with a changed cwd.
+    prior_cwd = os.getcwd()
+    app._enter_workspace()
+    try:
+        # Feed the agent the SAME per-message context (current time + resolved workspace)
+        # the web paths inject via routes_chat.context_parts(), so a `langstage chat` turn
+        # is genuinely identical to a browser turn - honoring the readiness-gate promise for
+        # time-aware / workspace-aware agents (gh #106). CoworkApp above already resolved and
+        # applied the workspace, so context_parts() reads the right one. --no-context restores
+        # the terse "prompt in -> answer out" echo for scripting. No cwd (the CLI has no file
+        # browser), so context reports the resolved workspace root - a browser's default folder.
+        context = None if no_context else routes_chat.context_parts()
+        result = run_turn_sync(app.agent, prompt, context_parts=context)
+    finally:
+        os.chdir(prior_cwd)
 
     if as_json:
         import json as _json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.30"
+version = "0.13.31"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_chat_complete.py
+++ b/tests/test_chat_complete.py
@@ -186,3 +186,83 @@ def test_cli_no_context_flag_restores_the_terse_echo():
     assert "[Working directory:" not in raw_content
     assert "[Current time:" not in raw_content
     assert default_content != raw_content
+
+
+# ── chat enters the resolved workspace before the turn (gh #110) ──────────────
+
+# A bring-your-own agent whose single node reports its process cwd and does a RAW
+# relative write (`Path("probe_out.txt").write_text(cwd)`) — the file lands wherever
+# the process cwd is, so where it appears is a direct probe of whether `chat` chdir'd
+# into the workspace. Mirrors the issue's probe_agent.py pattern.
+_PROBE_AGENT_SRC = '''
+import os
+from pathlib import Path
+
+from langchain_core.messages import AIMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+
+def _probe(state):
+    cwd = os.getcwd()
+    Path("probe_out.txt").write_text(cwd, encoding="utf-8")
+    return {"messages": [AIMessage(content=f"cwd={cwd}")]}
+
+
+builder = StateGraph(MessagesState)
+builder.add_node("probe", _probe)
+builder.add_edge(START, "probe")
+builder.add_edge("probe", END)
+graph = builder.compile()
+'''
+
+
+@pytest.mark.parametrize("extra", [[], ["--no-context"]], ids=["default", "no-context"])
+def test_chat_enters_workspace_so_relative_writes_land_there(tmp_path, monkeypatch, extra):
+    """gh #110: `langstage chat` must `chdir` into the resolved workspace before the turn,
+    the way `run()` does via `_enter_workspace()` — not merely inject a
+    `[Working directory: <workspace>]` line while the process cwd stays the launch dir
+    (the residual gap after #106). Otherwise a BYO agent's `os.getcwd()` and its raw
+    relative file ops disagree with a browser turn: they land in the LAUNCH dir, outside
+    the workspace the file browser shows.
+
+    Drive the real CLI with a probe agent that reports its cwd and writes a relative file,
+    from a launch cwd that is deliberately NOT the workspace, and assert the write landed
+    in the workspace (and the reported cwd equals it). `--no-context` is covered too: the
+    chdir is unconditional, so cwd follows the workspace whether or not the context line is
+    injected. Before the fix, the relative file landed in the launch dir and this fails.
+    """
+    import os
+    from pathlib import Path
+
+    from click.testing import CliRunner
+
+    from langstage.cli import main
+
+    workspace = tmp_path / "ws"
+    launch = tmp_path / "launch"
+    workspace.mkdir()
+    launch.mkdir()
+    probe = tmp_path / "probe_agent.py"
+    probe.write_text(_PROBE_AGENT_SRC, encoding="utf-8")
+
+    # Launch from a clean dir distinct from the workspace, so "landed in the workspace"
+    # is distinguishable from "landed in the launch dir" (the bug).
+    monkeypatch.chdir(launch)
+    result = CliRunner().invoke(
+        main,
+        ["chat", "--agent", f"{probe}:graph", "--workspace", str(workspace), *extra, "go"],
+    )
+    assert result.exit_code == 0, result.output
+
+    # The raw relative write landed IN the workspace, not the launch dir.
+    assert (workspace / "probe_out.txt").exists(), "relative write did not land in the workspace"
+    assert not (launch / "probe_out.txt").exists(), "relative write leaked into the launch dir"
+
+    # And the agent's actual os.getcwd() during the turn WAS the resolved workspace —
+    # the file's contents are that cwd.
+    reported = Path((workspace / "probe_out.txt").read_text(encoding="utf-8"))
+    assert reported.resolve() == workspace.resolve()
+
+    # Nice-to-have (gh #110): the CLI restores the caller's prior cwd after the turn, so a
+    # library/embedded caller of the chat path isn't left with a changed cwd.
+    assert Path(os.getcwd()).resolve() == launch.resolve()


### PR DESCRIPTION
## Problem

`langstage chat` resolves the workspace and injects a `[Working directory: <workspace>]` line into the prompt (added in #106), but it never `chdir`s into that workspace the way the web server does. So the agent's process `os.getcwd()` stays the **launch** dir, and a bring-your-own agent's raw relative file ops (`Path("out.txt").write_text(...)`) land **outside** the workspace the file browser shows — inconsistently with what the same turn does in a browser. This is the residual gap after #106.

### Root cause

`CoworkApp._enter_workspace()` does `os.chdir(workspace_root())` (ADR 0006) and is called only from `CoworkApp.run()` — deliberately not from `__init__`, so embedding has no cwd side effect. The `chat` command constructed `CoworkApp(...)` then called `run_turn_sync(app.agent, …)` directly — never `run()`, never `_enter_workspace()`. So the injected context named the workspace while the process cwd stayed the launch dir.

### Before / after (probe agent that reports its cwd + does a raw relative write, launched from a dir ≠ workspace)

**Before:** injected context `[Working directory: …\ws]`, but agent `cwd=…\launch`; `probe_out.txt` written to the **launch** dir, not the workspace.

**After:** agent `cwd=…\ws`; `probe_out.txt` written to the **workspace**; caller's prior cwd restored after the turn.

## Fix

- `chat` now calls `app._enter_workspace()` after `CoworkApp` has resolved and `apply_workspace`'d the workspace and before `run_turn_sync`, mirroring `run()`.
- The chdir is **unconditional**, so `--no-context` follows the workspace too.
- The CLI **restores the caller's prior cwd after the turn**, so a library/embedded caller of the chat path isn't left with a changed cwd.
- The web/`run()` path and `__init__`'s no-cwd-side-effect contract are unchanged.

## Tests

Adds a regression test parametrized over default and `--no-context`, driving the real `chat` CLI with a probe agent that reports its cwd and does a raw relative write, launched from a dir distinct from the workspace. Asserts the write lands in the workspace, the reported cwd equals the workspace, and the caller's prior cwd is restored. Full suite: **325 passed, 3 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B