### PR TITLE
Fix unsafe CORS (security) + three dogfood bugs, batched for 0.13.32 (#112, #113, #114, #115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.13.32 — 2026-07-31
+
+### Security
+- **CORS no longer reflects every origin with credentials on the default local server
+  (gh #113).** The server attached `CORSMiddleware` with `allow_origins=["*"]` **and**
+  `allow_credentials=True`; Starlette turns that combination into "reflect the caller's
+  `Origin` back + `Access-Control-Allow-Credentials: true`", so on the default
+  `langstage run` (localhost, no password) **any web page the user visited could make
+  credentialed cross-origin requests to their local server and read the responses** —
+  read/write the workspace file browser, read chat/config, delegate agent runs, create
+  cron jobs. CORS is now **loopback-only by default**: credentialed access is granted
+  only to `http(s)://localhost`, `127.0.0.1`, or `[::1]` (any port) via
+  `allow_origin_regex`, which is everything the same-origin SPA and a local Vite dev
+  server need — a drive-by origin (`https://evil.example`, the `null` origin of a
+  sandboxed iframe/`file://`) is never reflected, so the browser hands it no grant to
+  read the response. A user who genuinely needs to allow specific cross-origin sites can
+  opt in with `LANGSTAGE_CORS_ORIGINS` (comma-separated); a literal `*` there is honored
+  only with `allow_credentials=False` (the browser forbids `*` + credentials anyway).
+
+### Fixed
+- **Invalid `LANGSTAGE_SHOW_FILES` / `LANGSTAGE_SHOW_CANVAS` values now degrade with a
+  note instead of being silently swallowed to auto and still credited to the env var in
+  `--show-config` (gh #112).** `theme` got this treatment in #104, but the two boolean UI
+  fields went through a lenient parser that mapped **any** unrecognized string to `None`
+  (auto) with no signal — so `LANGSTAGE_SHOW_FILES=flase` (a typo of `false`, meant to
+  **hide** the Files tab) silently **showed** it, and `--show-config` misleadingly
+  reported `[env:LANGSTAGE_SHOW_FILES]` as honored. These two fields now resolve through a
+  **strict** caster: a non-empty unrecognized value is rejected by the shared resolver's
+  malformed-value guard, which emits the one-line `note: ignoring malformed …; using
+  default None instead.` and repoints the recorded source to `[default]` — matching the
+  #104 / `theme` behavior. Valid values (`on`/`off`/`1`/`0`/…) resolve unchanged.
+- **The file-browser preview now renders plain-text `.log` / `.ini` / `.cfg` / `.conf`
+  as text instead of `binary` (download-only) (gh #114).** The preview path
+  (`GET /api/files/preview`, the only files endpoint the SPA calls to view a file) decided
+  "is this text?" from `file_manager.LANGUAGE_MAP`, which omitted those extensions — while
+  the read path's `file_utils.is_text_file` / `TEXT_EXTENSIONS` already treated them as
+  text, so the two detectors contradicted each other (notably for `server.log`, which
+  `--demo`/`run` itself writes). Preview's text set is now the **union** of `LANGUAGE_MAP`
+  and `TEXT_EXTENSIONS`, sharing one source of truth so the two can't drift apart again;
+  the binary guard is unchanged for genuinely non-text files.
+- **`langstage chat` no longer crashes with `UnicodeEncodeError` when the agent reply
+  contains a non-cp1252 character (emoji/CJK/arrows) on a non-UTF-8 console (gh #115).**
+  The reply was printed via a bare `click.echo`, which on the default Windows cp1252
+  console raised as soon as the reply held an emoji/CJK/arrow — **losing the answer** and,
+  worse, flipping the exit code to a false `1` even though the agent succeeded, breaking
+  `chat`'s documented readiness-gate contract (a CI/cron gate saw a failure purely because
+  the correct answer had an emoji in it). The reply is now written with an error-tolerant
+  policy (`errors="backslashreplace"`), so an un-encodable char degrades to an ASCII
+  `\uXXXX` escape (the same fidelity `--json` already got from `ensure_ascii`), the answer
+  is shown, and the exit code reflects the agent's real outcome.
+
 ## 0.13.31 — 2026-07-26
 
 ### Fixed

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -12,6 +12,26 @@ from langstage.config import AppConfig
 DEMO_AGENT_SPEC = "langstage_core.demo.stub:graph"
 
 
+def _echo_streamsafe(message: str, *, err: bool = False) -> None:
+    """``click.echo`` that degrades un-encodable characters instead of crashing.
+
+    On a non-UTF-8 console (the default Windows cp1252 for a Western locale),
+    writing agent text that contains an emoji / CJK / arrow raises
+    ``UnicodeEncodeError`` — which both loses the reply and, for ``chat``, flips the
+    exit code from the agent's real (success) outcome to a false ``1``, breaking the
+    documented readiness-gate contract. Encode against the stream's own encoding with
+    ``errors="backslashreplace"`` so an un-encodable char degrades to an ASCII
+    ``\\uXXXX`` escape (the same fidelity the ``--json`` path already gets from
+    ``ensure_ascii``) and the turn completes. (gh #115)
+    """
+    try:
+        click.echo(message, err=err)
+    except UnicodeEncodeError:
+        stream = click.get_text_stream("stderr" if err else "stdout")
+        enc = getattr(stream, "encoding", None) or "utf-8"
+        click.echo(message.encode(enc, errors="backslashreplace").decode(enc), err=err)
+
+
 @click.group(invoke_without_command=True)
 @click.version_option(package_name="langstage", prog_name="langstage")
 @click.option(
@@ -449,10 +469,12 @@ def chat(agent_spec, demo, workspace, as_json, no_context, prompt):
         click.echo(_json.dumps(payload, indent=2))
     else:
         if result.content:
-            click.echo(result.content)
+            # Encoding-tolerant so an emoji/CJK/arrow in the reply can't crash the
+            # turn (and falsely exit 1) on a cp1252 console. (gh #115)
+            _echo_streamsafe(result.content)
         if not result.ok:
             reason = result.error or f"turn did not complete: {result.outcome}"
-            click.echo(f"Error: {reason}", err=True)
+            _echo_streamsafe(f"Error: {reason}", err=True)
 
     if not result.ok:
         raise SystemExit(1)

--- a/langstage/config.py
+++ b/langstage/config.py
@@ -32,20 +32,51 @@ def _env_canonical_first(canonical: str, legacy: str) -> Optional[str]:
     return None
 
 
+_BOOL_TRUE = ("1", "true", "yes", "on")
+_BOOL_FALSE = ("0", "false", "no", "off")
+
+
 def _parse_optional_bool(value: Optional[str]) -> Optional[bool]:
     """Parse an env-var string into an optional bool.
 
     True for '1'/'true'/'yes'/'on', False for '0'/'false'/'no'/'off', None for
-    empty/unrecognized (auto-detect mode).
+    empty/unrecognized (auto-detect mode). Lenient — the strict resolver caster
+    below (:func:`_parse_bool_strict`) is what the ``_ENV`` map uses so a typo
+    degrades with a note instead of being silently swallowed to auto.
     """
     if value is None or value == "":
         return None
     lowered = str(value).strip().lower()
-    if lowered in ("1", "true", "yes", "on"):
+    if lowered in _BOOL_TRUE:
         return True
-    if lowered in ("0", "false", "no", "off"):
+    if lowered in _BOOL_FALSE:
         return False
     return None
+
+
+def _parse_bool_strict(value: Optional[str]) -> Optional[bool]:
+    """Strict bool caster for the resolver's ``_ENV`` map (show_canvas / show_files).
+
+    Recognized tokens -> True/False; a NON-EMPTY unrecognized value RAISES
+    ``ValueError`` so the shared resolver's malformed-value guard degrades it to the
+    default (``None`` = auto) with a one-line stderr note and does NOT credit the env
+    var as the source. This brings the two boolean UI fields in line with the theme
+    enum (#104) and the numeric fields, closing the "invalid value reported as
+    legitimately resolved" gap for these two fields (gh #112). An empty value is an
+    intentional "auto" and stays ``None`` (and never reaches this caster from the env
+    path anyway — ``resolve()`` skips empty env vars).
+    """
+    if value is None or value == "":
+        return None
+    lowered = str(value).strip().lower()
+    if lowered in _BOOL_TRUE:
+        return True
+    if lowered in _BOOL_FALSE:
+        return False
+    raise ValueError(
+        f"expected a boolean (one of: {', '.join(_BOOL_TRUE + _BOOL_FALSE)}), "
+        f"got {value!r}"
+    )
 
 
 # WORKSPACE_ROOT is read by tools.py (bash cwd + file tools) and default_agent.py.
@@ -175,8 +206,11 @@ class AppConfig(HostConfig):
         "run_workflow_prompt": ("DEEPAGENT_RUN_WORKFLOW_PROMPT", str),
         "create_workflow_prompt": ("DEEPAGENT_CREATE_WORKFLOW_PROMPT", str),
         "custom_css": ("DEEPAGENT_CUSTOM_CSS", str),
-        "show_canvas": ("DEEPAGENT_SHOW_CANVAS", _parse_optional_bool),
-        "show_files": ("DEEPAGENT_SHOW_FILES", _parse_optional_bool),
+        # Strict casters so a typo (LANGSTAGE_SHOW_FILES=flase) degrades to the
+        # default with a note and isn't credited to the env var in --show-config,
+        # matching the theme/#104 treatment for these two bool fields (gh #112).
+        "show_canvas": ("DEEPAGENT_SHOW_CANVAS", _parse_bool_strict),
+        "show_files": ("DEEPAGENT_SHOW_FILES", _parse_bool_strict),
         # Canonical LANGSTAGE_TASK_CONCURRENCY wins; DEEPAGENT_TASK_CONCURRENCY is the
         # deprecated fallback (resolved by _env_pair, same as every other key). (gh #102)
         "task_concurrency": ("DEEPAGENT_TASK_CONCURRENCY", int),

--- a/langstage/server/middleware.py
+++ b/langstage/server/middleware.py
@@ -1,12 +1,27 @@
 """CORS and authentication middleware."""
 
 import base64
+import os
 import secrets
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import Response
 from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+# Credentialed cross-origin access is granted ONLY to loopback origins by default:
+# localhost / 127.0.0.1 / [::1], http or https, any port. That's everything the
+# same-origin SPA and a local Vite dev server (http://localhost:5173) need, while a
+# drive-by website's Origin (https://evil.example, http://attacker.test, or the
+# `null` origin of a sandboxed iframe / file://) does NOT match -- so the browser is
+# never handed `access-control-allow-origin: <that site>` with credentials, closing
+# the reflect-any-origin hole that let any page read/write the workspace and drive
+# the agent on the default local server. (gh #113)
+_LOOPBACK_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$"
+
+# Env opt-in for a user who genuinely needs to allow specific cross-origin sites.
+_CORS_ORIGINS_ENV = "LANGSTAGE_CORS_ORIGINS"
 
 
 class BasicAuthMiddleware:
@@ -66,6 +81,32 @@ class BasicAuthMiddleware:
         )
 
 
+def _resolve_cors(env_origins: str | None) -> dict:
+    """Compute safe CORS kwargs for ``CORSMiddleware``.
+
+    Default: credentialed access is granted only to loopback origins via
+    ``allow_origin_regex`` (:data:`_LOOPBACK_ORIGIN_REGEX`) -- enough for the
+    same-origin SPA and a local dev server, but a drive-by website is never
+    reflected, so it can't read/write the workspace or drive the agent (gh #113).
+
+    Opt-in: ``LANGSTAGE_CORS_ORIGINS`` is a comma-separated list of origins a user
+    genuinely needs to allow. Those are matched exactly, with credentials. A literal
+    ``*`` is honored but FORCES ``allow_credentials=False`` -- the browser forbids
+    ``*`` together with credentials, and shipping the reflect-any-origin combination
+    is exactly the anti-pattern this closes.
+    """
+    common = {"allow_methods": ["*"], "allow_headers": ["*"]}
+    entries = [o.strip() for o in (env_origins or "").split(",") if o.strip()]
+    if entries:
+        if "*" in entries:
+            # `*` can never be combined with credentials (browser rule + gh #113).
+            return {"allow_origins": ["*"], "allow_credentials": False, **common}
+        return {"allow_origins": entries, "allow_credentials": True, **common}
+    # Safe default: loopback-only, credentialed (covers the Vite dev server too, so
+    # debug needs no special-casing anymore).
+    return {"allow_origin_regex": _LOOPBACK_ORIGIN_REGEX, "allow_credentials": True, **common}
+
+
 def add_middleware(
     app: FastAPI,
     debug: bool = False,
@@ -73,21 +114,9 @@ def add_middleware(
     auth_password: str = "",
 ) -> None:
     """Add middleware stack. CORS is always added; basic auth is conditional."""
-    # CORS (added first so preflight OPTIONS work even with auth)
-    origins = []
-    if debug:
-        origins = [
-            "http://localhost:5173",
-            "http://127.0.0.1:5173",
-        ]
-
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins if origins else ["*"],
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # CORS (added first so preflight OPTIONS work even with auth). Loopback-only by
+    # default; LANGSTAGE_CORS_ORIGINS opts specific sites in. (gh #113)
+    app.add_middleware(CORSMiddleware, **_resolve_cors(os.getenv(_CORS_ORIGINS_ENV)))
 
     # Basic auth (only when a password is configured). The "admin" default now
     # lives in the config layer, so use the resolved value directly — what

--- a/langstage/workspace/file_manager.py
+++ b/langstage/workspace/file_manager.py
@@ -8,6 +8,8 @@ from typing import AsyncGenerator
 
 from watchfiles import awatch, Change
 
+from ..file_utils import TEXT_EXTENSIONS
+
 
 # Extensions → CodeMirror language modes
 LANGUAGE_MAP = {
@@ -124,7 +126,12 @@ class FileManager:
     _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".bmp", ".ico"}
     _HTML_EXTS = {".html", ".htm"}
     _CSV_EXTS = {".csv", ".tsv"}
-    _TEXT_EXTS = set(LANGUAGE_MAP.keys())  # all mapped extensions are text
+    # Union of the two independent text-file allowlists so preview and read agree on
+    # what counts as text: every syntax-highlightable extension (LANGUAGE_MAP) PLUS
+    # everything the read path's is_text_file / TEXT_EXTENSIONS treats as text
+    # (.log/.ini/.cfg/.conf/.env/...). Sharing TEXT_EXTENSIONS is the single source of
+    # truth that keeps the two detectors from drifting apart again (gh #114).
+    _TEXT_EXTS = set(LANGUAGE_MAP.keys()) | TEXT_EXTENSIONS
 
     def read_file(self, path: str) -> dict:
         """Read file content with language detection."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.31"
+version = "0.13.32"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,6 +8,7 @@ from httpx import AsyncClient, ASGITransport
 from langstage.app import _exposure_warning, _is_loopback_host
 from langstage.config import AppConfig
 from langstage.server.main import create_fastapi_app
+from langstage.server.middleware import _resolve_cors
 
 
 @pytest.fixture
@@ -120,6 +121,80 @@ async def test_delete_session_endpoint(client):
     resp = await client.delete("/api/session/fake-session-id")
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
+
+
+# ── CORS is loopback-only by default, not reflect-any-origin (gh #113) ────────
+# The server used to attach CORSMiddleware with allow_origins=["*"] +
+# allow_credentials=True, which Starlette turns into "reflect ANY origin + allow
+# credentials" — so any website the user visited could make credentialed
+# cross-origin requests to their local server and read the responses (read/write the
+# workspace, drive the agent). CORS is now loopback-only by default, with an explicit
+# LANGSTAGE_CORS_ORIGINS opt-in.
+
+
+@pytest.mark.asyncio
+async def test_cors_does_not_reflect_a_random_site_with_credentials(client):
+    # The core of the fix: a drive-by origin must NOT be handed
+    # access-control-allow-origin for itself (which, with credentials, would let it
+    # read the response cross-origin).
+    resp = await client.get("/api/config", headers={"Origin": "https://evil.example"})
+    assert resp.status_code == 200  # the request itself still succeeds server-side...
+    # ...but the browser gets no grant to read it cross-origin.
+    assert resp.headers.get("access-control-allow-origin") != "https://evil.example"
+    assert resp.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.asyncio
+async def test_cors_does_not_reflect_the_null_origin(client):
+    # The `null` origin (sandboxed iframe / file://) was reflected too — also closed.
+    resp = await client.get("/api/config", headers={"Origin": "null"})
+    assert resp.headers.get("access-control-allow-origin") is None
+
+
+@pytest.mark.asyncio
+async def test_cors_preflight_delete_from_random_site_is_not_granted(client):
+    # A state-changing preflight (DELETE) from a hostile origin must not be allowed.
+    resp = await client.options(
+        "/api/files/delete",
+        headers={
+            "Origin": "https://evil.example",
+            "Access-Control-Request-Method": "DELETE",
+        },
+    )
+    assert resp.headers.get("access-control-allow-origin") != "https://evil.example"
+
+
+@pytest.mark.asyncio
+async def test_cors_allows_credentialed_access_from_loopback_spa(client):
+    # The same-origin SPA / a local Vite dev server (http://localhost:<port>) is a
+    # loopback origin and DOES get credentialed CORS, so the local UI keeps working.
+    origin = "http://localhost:5173"
+    resp = await client.get("/api/config", headers={"Origin": origin})
+    assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == origin
+    assert resp.headers.get("access-control-allow-credentials") == "true"
+
+
+def test_resolve_cors_default_is_loopback_regex_with_credentials():
+    cfg = _resolve_cors(None)
+    assert "allow_origin_regex" in cfg  # loopback-only, not a "*" allow-list
+    assert cfg["allow_credentials"] is True
+    assert cfg.get("allow_origins") != ["*"]
+
+
+def test_resolve_cors_env_opt_in_honors_specific_origins_with_credentials():
+    cfg = _resolve_cors("https://a.example, https://b.example")
+    assert cfg["allow_origins"] == ["https://a.example", "https://b.example"]
+    assert cfg["allow_credentials"] is True
+    assert "allow_origin_regex" not in cfg
+
+
+def test_resolve_cors_wildcard_opt_in_forces_credentials_off():
+    # If a user opts into "*", it can only ship with credentials OFF (browser rule +
+    # the reflect-any-origin anti-pattern this fix exists to prevent).
+    cfg = _resolve_cors("*")
+    assert cfg["allow_origins"] == ["*"]
+    assert cfg["allow_credentials"] is False
 
 
 # --- Basic Auth tests ---

--- a/tests/test_chat_complete.py
+++ b/tests/test_chat_complete.py
@@ -216,6 +216,53 @@ graph = builder.compile()
 '''
 
 
+# ── chat survives a non-cp1252 reply on a cp1252 console (gh #115) ────────────
+
+
+@pytest.mark.parametrize(
+    "prompt,escape",
+    [("\U0001f389", "1f389"), ("A→B", "2192"), ("日本語", "65e5")],
+    ids=["emoji", "arrow", "cjk"],
+)
+def test_chat_does_not_crash_on_cp1252_stdout(prompt, escape):
+    """gh #115: `langstage chat` printed the reply via a bare click.echo, which on a
+    non-UTF-8 console (the default Windows cp1252) raised UnicodeEncodeError as soon as
+    the reply held an emoji/CJK/arrow — losing the answer AND flipping the exit code to
+    a false 1, breaking the documented readiness-gate contract (the agent succeeded).
+
+    CliRunner(charset="cp1252") wraps stdout in a strict cp1252 encoder, faithfully
+    reproducing that console. The reply must now be shown (lossily, backslash-escaped)
+    and the exit code must reflect the agent's real, successful outcome (0)."""
+    from click.testing import CliRunner
+
+    from langstage import cli as cli_mod
+
+    result = CliRunner(charset="cp1252").invoke(
+        cli_mod.main, ["chat", "--demo", "--no-context", prompt]
+    )
+    assert result.exception is None, result.output  # no unhandled UnicodeEncodeError
+    assert result.exit_code == 0  # agent succeeded => exit 0, not a false failure
+    assert result.output.strip()  # the answer reached stdout, not just a traceback
+    assert result.output.isascii()  # degraded to ASCII escapes, printable on cp1252
+    assert escape in result.output.lower()  # the char is shown escaped, not dropped
+
+
+def test_chat_json_path_still_survives_cp1252(monkeypatch):
+    """Control: the --json path was already safe (json.dumps escapes to ASCII); keep it
+    green so the plain-path fix didn't regress it."""
+    import json
+
+    from click.testing import CliRunner
+
+    from langstage import cli as cli_mod
+
+    result = CliRunner(charset="cp1252").invoke(
+        cli_mod.main, ["chat", "--demo", "--no-context", "--json", "\U0001f389"]
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["content"]  # parseable, content present
+
+
 @pytest.mark.parametrize("extra", [[], ["--no-context"]], ids=["default", "no-context"])
 def test_chat_enters_workspace_so_relative_writes_land_there(tmp_path, monkeypatch, extra):
     """gh #110: `langstage chat` must `chdir` into the resolved workspace before the turn,

--- a/tests/test_file_manager.py
+++ b/tests/test_file_manager.py
@@ -58,6 +58,48 @@ def test_csv_language(workspace):
     assert content["language"] == "csv"
 
 
+# ── preview agrees with the read path on what counts as text (gh #114) ────────
+# The file browser renders via GET /api/files/preview, which classified plain-text
+# .log/.ini/.cfg/.conf as "binary" (download-only) because preview's LANGUAGE_MAP
+# and the read path's is_text_file / TEXT_EXTENSIONS disagreed. They now share
+# TEXT_EXTENSIONS as one source of truth, so both detectors agree.
+
+
+@pytest.mark.parametrize(
+    "name,body",
+    [
+        ("server.log", "INFO server started\nWARN low disk\n"),
+        ("settings.ini", "[server]\nhost = localhost\n"),
+        ("app.cfg", "key = value\n"),
+        ("nginx.conf", "server { listen 80; }\n"),
+    ],
+)
+def test_plain_text_configs_and_logs_preview_as_text_not_binary(tmp_path, name, body):
+    (tmp_path / name).write_text(body)
+    preview = FileManager(tmp_path).preview_file(name)
+    assert preview["preview_type"] == "text", preview
+    assert preview["data"] == body  # content is inlined, not a download-only stub
+    assert "download_url" not in preview
+
+
+def test_preview_and_is_text_file_agree_for_the_regressed_extensions(tmp_path):
+    # The core invariant of gh #114: is_text_file(f) True ⇒ preview shows text.
+    from langstage.file_utils import is_text_file
+
+    for name in ("a.log", "b.ini", "c.cfg", "d.conf"):
+        (tmp_path / name).write_text("plain text\n")
+        assert is_text_file(name) is True
+        assert FileManager(tmp_path).preview_file(name)["preview_type"] == "text"
+
+
+def test_genuinely_binary_file_still_previews_as_binary(tmp_path):
+    # The text-detector union must not loosen the guard for real binaries.
+    (tmp_path / "blob.bin").write_bytes(b"\x00\x01\x02\xff\xfe")
+    preview = FileManager(tmp_path).preview_file("blob.bin")
+    assert preview["preview_type"] == "binary"
+    assert "download_url" in preview
+
+
 def test_sibling_prefix_dir_cannot_escape_workspace(tmp_path):
     """A sibling dir sharing the workspace's name prefix must NOT be reachable.
 

--- a/tests/test_tab_visibility.py
+++ b/tests/test_tab_visibility.py
@@ -4,7 +4,7 @@ import os
 
 import pytest
 
-from langstage.config import AppConfig, _parse_optional_bool
+from langstage.config import AppConfig, _parse_bool_strict, _parse_optional_bool
 from langstage.middleware import CanvasMiddleware, agent_uses_canvas_middleware
 
 
@@ -29,6 +29,67 @@ from langstage.middleware import CanvasMiddleware, agent_uses_canvas_middleware
 )
 def test_parse_optional_bool(value, expected):
     assert _parse_optional_bool(value) is expected
+
+
+# --- _parse_bool_strict: the resolver caster that closes gh #112 --------------
+# The two boolean UI fields go through this strict caster in the _ENV map: a
+# recognized token resolves; a NON-EMPTY unrecognized value RAISES so the shared
+# resolver's malformed-value guard degrades it to the default (None) with a note and
+# does NOT credit the env var -- matching the theme/#104 treatment.
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [(None, None), ("", None), ("on", True), ("OFF", False), ("1", True), ("0", False)],
+)
+def test_parse_bool_strict_recognized_values(value, expected):
+    assert _parse_bool_strict(value) is expected
+
+
+@pytest.mark.parametrize("value", ["flase", "yep", "garbage", "2", "tru"])
+def test_parse_bool_strict_raises_on_unrecognized_nonempty(value):
+    with pytest.raises(ValueError):
+        _parse_bool_strict(value)
+
+
+def _clear_malformed_env_dedupe():
+    # The shared resolver dedupes its malformed-env note per (var, value) across a
+    # process; clear it so each test can observe its own note regardless of order.
+    from langstage_core.host import config as core_config
+
+    core_config._warned_malformed_env_value.clear()
+
+
+@pytest.mark.parametrize("field", ["SHOW_FILES", "SHOW_CANVAS"])
+def test_invalid_show_flag_degrades_to_none_with_note_not_credited(
+    field, monkeypatch, capsys
+):
+    # gh #112: a typo (LANGSTAGE_SHOW_FILES=flase, meant to HIDE the tab) must NOT be
+    # silently swallowed to auto and credited to the env var in --show-config. It now
+    # degrades to the default (None) with a one-line stderr note, source repointed to
+    # "default" -- exactly the #104 / theme behavior, for these two bool fields.
+    _clear_malformed_env_dedupe()
+    monkeypatch.setenv(f"LANGSTAGE_{field}", "flase")
+    cfg = AppConfig.from_env()  # must NOT raise
+
+    attr = field.lower()
+    assert getattr(cfg, attr) is None  # degraded to auto, not silently mis-set
+    assert cfg.sources[attr] == "default"  # not credited to the rejected env var
+    err = capsys.readouterr().err
+    assert f"LANGSTAGE_{field}='flase'" in err  # names the ignored var + value
+    assert "using default" in err
+
+
+@pytest.mark.parametrize(
+    "raw,expected", [("off", False), ("false", False), ("on", True), ("1", True)]
+)
+def test_valid_show_flag_still_resolves_with_env_source(raw, expected, monkeypatch):
+    # A VALID value must resolve normally with correct source attribution (only the
+    # invalid path degrades).
+    monkeypatch.setenv("LANGSTAGE_SHOW_FILES", raw)
+    cfg = AppConfig.from_env()
+    assert cfg.show_files is expected
+    assert cfg.sources["show_files"] == "env:LANGSTAGE_SHOW_FILES"
 
 
 # --- AppConfig: env + client_dict ---------------------------------------------


### PR DESCRIPTION
One release (0.13.32) bundling one **security** fix and three nightly-dogfood fixes. Each has a regression test; the full suite passes (`361 passed, 1 skipped` — the skip is the pre-existing optional-`deepagents` case).

## Fixes

### #113 — Unsafe CORS (security) 🔒
The server attached `CORSMiddleware` with `allow_origins=["*"]` **and** `allow_credentials=True`. Starlette turns that into "reflect the caller's `Origin` back + `Access-Control-Allow-Credentials: true`", so on the default `langstage run` (localhost, no password) **any website the user visited could make credentialed cross-origin requests to their local server and read the responses** — read/write the workspace, read chat/config, delegate agent runs, create cron jobs.

**Fix:** CORS is **loopback-only by default** — credentialed access is granted only to `http(s)://localhost` / `127.0.0.1` / `[::1]` (any port) via `allow_origin_regex`, which is everything the same-origin SPA and a local Vite dev server need. A drive-by origin (`https://evil.example`, the `null` origin) is never reflected. New `LANGSTAGE_CORS_ORIGINS` env var opts specific sites in; a literal `*` there is honored only with `allow_credentials=False`.

### #112 — Invalid `LANGSTAGE_SHOW_FILES` / `LANGSTAGE_SHOW_CANVAS` silently swallowed to auto
`theme` got the #104 degrade-with-note treatment; these two bool fields did not — a typo (`LANGSTAGE_SHOW_FILES=flase`, meant to hide the tab) silently showed it and `--show-config` still credited the env var. **Fix:** a strict bool caster so the shared resolver's malformed-value guard emits the `note:` and repoints the source to `[default]`. Valid values unchanged.

### #114 — Preview classifies `.log`/`.ini`/`.cfg`/`.conf` as `binary`
Preview's `LANGUAGE_MAP` and the read path's `is_text_file`/`TEXT_EXTENSIONS` disagreed on what's text. **Fix:** preview's text set is now the **union** of both (one shared source of truth), so `.log`/`.ini`/`.cfg`/`.conf` preview as text; the binary guard is unchanged for real binaries.

### #115 — `langstage chat` crashes with `UnicodeEncodeError` on a cp1252 console
A bare `click.echo(reply)` crashed on the default Windows console as soon as the reply held an emoji/CJK/arrow — losing the answer and falsely exiting `1` (the agent had succeeded), breaking the readiness-gate contract. **Fix:** write with `errors="backslashreplace"` so an un-encodable char degrades to an ASCII `\uXXXX` escape and the turn completes with the real exit code.

## Tests
- `tests/test_app.py` — CORS: random/`null` origin not reflected, loopback SPA still credentialed, preflight DELETE from a hostile origin not granted, `_resolve_cors` unit cases (default / env opt-in / wildcard-forces-credentials-off).
- `tests/test_tab_visibility.py` — `_parse_bool_strict`, invalid `SHOW_*` degrades to `None` + note + source `[default]`, valid values still credited.
- `tests/test_file_manager.py` — `.log`/`.ini`/`.cfg`/`.conf` preview as text, preview agrees with `is_text_file`, real binary still binary.
- `tests/test_chat_complete.py` — `chat` on `CliRunner(charset="cp1252")` with emoji/arrow/CJK: no crash, exit 0, answer shown escaped; `--json` control still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B