### PR TITLE
Clean 4xx for /tree on a file + correct config source/unknown-key surfacing (#117, #119, #120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.13.33 — 2026-08-03
+
+Requires **langstage-core >= 1.0.32** (bumped from >=1.0.9): #119 and #120 are
+fixed at the shared core layer and this release wires the fixes through langstage's
+config surface.
+
+### Fixed
+- **`GET /api/files/tree?path=<a file>` now returns a clean 400 instead of HTTP 500
+  (gh #117).** Passing a *file* path where a directory is expected raised an uncaught
+  `NotADirectoryError` out of the `/tree` route — the only `/api/files/*` route that
+  leaked a 500 for a wrong node type (the boundary always held; it was an
+  error-handling gap). The route now catches `NotADirectoryError` and returns
+  `400 {"detail": "Not a directory: …"}`, the mirror image of `read`/`preview`'s
+  existing `IsADirectoryError` → 400 guard for the inverse case.
+- **`langstage config` / `--show-config` now attributes each TOML value to the file it
+  actually came from (gh #119).** When both a global `~/.langstage/config.toml` and a
+  project `langstage.toml` were present, every TOML-sourced field was labeled
+  `[toml (langstage.toml)]` — even a value that existed *only* in the global file —
+  because the deep-merged config dict had lost per-key provenance. Values always
+  resolved correctly (global < project); only the source column was wrong, silently
+  defeating the deploy-time "where did this value come from?" assertion the column
+  exists for. Fixed in langstage-core 1.0.32's `resolve()` (each key is attributed to
+  the highest-precedence file that actually defines it); langstage inherits it —
+  `subtitle` set only in the global file now reads `[toml (config.toml)]`.
+
+### Added
+- **`langstage config` / `--show-config` now flags unknown / typo'd / misplaced keys in
+  `langstage.toml` (gh #120).** A key that maps to no known field — a typo (`titel`),
+  a key in the wrong section (`prot` under `[server]`), or an entirely unknown
+  table — was silently dropped, so the "edit it, then `langstage config` to verify"
+  workflow couldn't catch the single most common hand-edit mistake (`config` just
+  reported the field as `[default]`). `config` and `--show-config` now print
+  `unknown TOML keys (ignored - a typo or wrong table?): …` (via langstage-core
+  1.0.32's `HostConfig.unknown_toml_keys()`, surfaced by `describe()`), and
+  `config --json` reports them under a new `unknown_toml_keys` field so a deploy step
+  can assert on them machine-side. Keys under the `[configurable]` passthrough table
+  are never flagged. Advisory only (exit 0), matching the legacy-env-var notice.
+
 ## 0.13.32 — 2026-07-31
 
 ### Security

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -147,6 +147,11 @@ def config(workspace, as_json):
             for f in _fields(cfg)
         },
         "toml_read_from": [str(p) for p in getattr(cfg, "_toml_paths", [])],
+        # Keys present in langstage.toml that map to no known field (typo'd / misplaced /
+        # unknown). The human `config` / `--show-config` surface these via describe(); a
+        # deploy step asserting on JSON gets them here too, so a silent-dropped edit can be
+        # caught machine-side, not just by eye (gh #120).
+        "unknown_toml_keys": cfg.unknown_toml_keys(),
     }
     click.echo(_json.dumps(payload, indent=2))
 

--- a/langstage/server/routes_files.py
+++ b/langstage/server/routes_files.py
@@ -31,6 +31,11 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
             return tree
         except FileNotFoundError:
             raise HTTPException(status_code=404, detail=f"Path not found: {path}")
+        except NotADirectoryError as e:
+            # A FILE was passed where a directory is expected — the mirror-image of
+            # read/preview's IsADirectoryError guard. Return a clean 400 instead of
+            # letting it fall through to a 500 (gh #117).
+            raise HTTPException(status_code=400, detail=str(e))
         except ValueError as e:
             # Path escapes the workspace — the boundary holds (no traversal), but
             # return a clean 400 instead of letting it fall through to a 500.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.32"
+version = "0.13.33"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -19,7 +19,10 @@ dependencies = [
     # >=1.0.6 for the shared preflight primitive core.verify() used by `check --live`.
     # >=1.0.9 for the relative-workspace idempotency fix (#66): _enter_workspace()
     # chdirs into the workspace, and pre-1.0.9 workspace_root() doubled a relative root.
-    "langstage-core[agui]>=1.0.9",
+    # >=1.0.32 for per-file TOML source provenance in resolve() (a global-config value is
+    # no longer mislabeled as coming from the project langstage.toml, gh #119) and for
+    # HostConfig.unknown_toml_keys() + describe() surfacing typo'd/unknown keys (gh #120).
+    "langstage-core[agui]>=1.0.32",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -47,7 +50,7 @@ deepagents = [
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage[agui]` scripts/READMEs still resolve.
 agui = [
-    "langstage-core[agui]>=1.0.9",
+    "langstage-core[agui]>=1.0.32",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -102,6 +102,24 @@ async def test_files_tree_path_escape_returns_400_not_500(client):
 
 
 @pytest.mark.asyncio
+async def test_files_tree_on_a_file_returns_400_not_500(client):
+    # gh #117: /tree on a FILE (not a directory) used to raise an uncaught
+    # NotADirectoryError -> 500, the only files route that leaked a 500 for a
+    # wrong node type. It must now return a clean 4xx, mirroring read/preview's
+    # IsADirectoryError -> 400 for the inverse case.
+    resp = await client.get("/api/files/tree?path=/hello.py")
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert "hello.py" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_files_tree_on_a_nested_file_returns_400_not_500(client):
+    # Same defect for a nested file path (subdir/nested.txt exists in the fixture).
+    resp = await client.get("/api/files/tree?path=subdir/nested.txt")
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+
+
+@pytest.mark.asyncio
 async def test_canvas_empty(client):
     resp = await client.get("/api/canvas/items")
     assert resp.status_code == 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,3 +183,139 @@ def test_cli_theme_flag_still_hard_rejects():
     )
     assert result.exit_code == 2
     assert "Invalid value for '--theme'" in result.output
+
+
+# ── per-file TOML source provenance (gh #119) ─────────────────────────────────
+# When both a global (~/.langstage/config.toml) and a project langstage.toml
+# contribute, each TOML-sourced field must be attributed to the file that actually
+# supplied its value. A value set ONLY in the global file used to be mislabeled as
+# coming from the project langstage.toml (the deep-merged dict lost per-key
+# provenance), silently defeating the deploy-time "where did this value come from?"
+# guardrail the source column exists for. Fixed at the core layer (langstage-core
+# >= 1.0.32); these pin that the corrected source reaches langstage's config surface.
+
+
+def _global_and_project(tmp_path, monkeypatch, global_toml: str, project_toml: str):
+    """Write a global config.toml + a project langstage.toml, point the resolver at
+    the global via LANGSTAGE_CONFIG_HOME (isolating any real ~/.langstage/config.toml),
+    and chdir into the project. Returns the project dir."""
+    gdir = tmp_path / "global"
+    gdir.mkdir()
+    (gdir / "config.toml").write_text(global_toml)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "langstage.toml").write_text(project_toml)
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(gdir))
+    monkeypatch.chdir(proj)
+    return proj
+
+
+def test_global_only_value_attributed_to_global_file_not_project(tmp_path, monkeypatch):
+    _global_and_project(
+        tmp_path,
+        monkeypatch,
+        global_toml='[ui]\nsubtitle = "i-am-from-GLOBAL"\n',   # global sets ONLY subtitle
+        project_toml='[ui]\ntitle = "i-am-from-PROJECT"\n',    # project sets ONLY title
+    )
+    cfg = AppConfig.resolve()
+
+    # Value resolution was always correct (global < project); the SOURCE column is
+    # what #119 is about.
+    assert cfg.subtitle == "i-am-from-GLOBAL"
+    assert cfg.title == "i-am-from-PROJECT"
+    # subtitle came only from the global config.toml -> it must name THAT file, not
+    # the project langstage.toml.
+    assert cfg.sources["subtitle"] == "toml (config.toml)"
+    assert cfg.sources["title"] == "toml (langstage.toml)"
+
+
+def test_show_config_attributes_global_value_to_global_file(tmp_path, monkeypatch):
+    # The fix must reach the actual user surface (`--show-config`), not just resolve().
+    _global_and_project(
+        tmp_path,
+        monkeypatch,
+        global_toml='[ui]\nsubtitle = "i-am-from-GLOBAL"\n',
+        project_toml='[ui]\ntitle = "i-am-from-PROJECT"\n',
+    )
+    result = CliRunner().invoke(cli_mod.main, ["--show-config"])
+
+    assert result.exit_code == 0, result.output
+    # subtitle labeled with the global file it came from...
+    assert re.search(
+        r"subtitle\s*=\s*i-am-from-GLOBAL\s+\[toml \(config\.toml\)\]", result.output
+    ), result.output
+    # ...and the project-only title with the project file.
+    assert re.search(
+        r"title\s*=\s*i-am-from-PROJECT\s+\[toml \(langstage\.toml\)\]", result.output
+    ), result.output
+
+
+# ── unknown / typo'd / misplaced TOML keys are surfaced (gh #120) ─────────────
+# A typo'd key, a key in the wrong section, or an entirely unknown key in
+# langstage.toml is silently dropped by the layered config -- the #1 hand-edit
+# mistake, which `config` / `--show-config` (the "edit it, then verify" step)
+# couldn't catch. Wired at the core layer (langstage-core >= 1.0.32) via
+# HostConfig.unknown_toml_keys(), rendered by describe(); these pin that langstage's
+# config surfaces it.
+
+
+def _isolate_global(tmp_path, monkeypatch):
+    """Point the resolver's global-config lookup at an EMPTY dir so a real
+    ~/.langstage/config.toml can't perturb an exact unknown-keys assertion."""
+    empty = tmp_path / "no-global"
+    empty.mkdir()
+    monkeypatch.setenv("LANGSTAGE_CONFIG_HOME", str(empty))
+
+
+def test_unknown_toml_keys_reported_at_resolve(tmp_path, monkeypatch):
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text(
+        '[ui]\ntitel = "My App"\n[server]\nprot = 9000\n'  # typos: title / port
+    )
+    monkeypatch.chdir(tmp_path)
+    cfg = AppConfig.resolve()
+
+    assert cfg.unknown_toml_keys() == ["server.prot", "ui.titel"]
+    # The fields the typos were meant for stay at their defaults (the edit was dropped).
+    assert cfg.title == "LangStage" and cfg.sources["title"] == "default"
+    assert cfg.port == 8050 and cfg.sources["port"] == "default"
+
+
+def test_config_command_reports_unknown_toml_keys(tmp_path, monkeypatch):
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text(
+        '[ui]\ntitel = "My App"\n[server]\nprot = 9000\n'
+    )
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config"])
+
+    assert result.exit_code == 0, result.output
+    assert "unknown TOML keys" in result.output
+    assert "ui.titel" in result.output
+    assert "server.prot" in result.output
+
+
+def test_config_json_reports_unknown_toml_keys(tmp_path, monkeypatch):
+    # The machine-readable surface a deploy step asserts on gets them too (gh #120).
+    import json
+
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text('[ui]\ntitel = "My App"\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["unknown_toml_keys"] == ["ui.titel"]
+
+
+def test_config_clean_toml_reports_no_unknown_keys(tmp_path, monkeypatch):
+    # A correct file must NOT be flagged -- guards against false positives.
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text('[ui]\ntitle = "My App"\n[server]\nport = 9000\n')
+    monkeypatch.chdir(tmp_path)
+    cfg = AppConfig.resolve()
+
+    assert cfg.unknown_toml_keys() == []
+    result = CliRunner().invoke(cli_mod.main, ["config"])
+    assert "unknown TOML keys" not in result.output


### PR DESCRIPTION
Ships three fixes as one release (**0.13.33**), bumping the `langstage-core` floor to **>=1.0.32** (two of the three are fixed at the shared core layer and wired through here).

## #117 — `GET /api/files/tree?path=<a file>` returned HTTP 500
Passing a *file* path where a directory is expected raised an uncaught `NotADirectoryError` out of the `/tree` route — the only `/api/files/*` route that leaked a 500 for a wrong node type (the workspace boundary always held; it was an error-handling gap). Added the symmetric `except NotADirectoryError -> 400` guard, mirroring `read`/`preview`'s existing `IsADirectoryError -> 400` for the inverse case.

**Before:** `tree?path=afile.txt` → `500 Internal Server Error` + traceback.
**After:** `400 {"detail": "Not a directory: afile.txt"}`.

## #119 — config misattributed global-config values to the project `langstage.toml`
Fixed at the core layer (**langstage-core 1.0.32**): `resolve()` now attributes each TOML key to the highest-precedence file that actually defines it, instead of blindly to the last file read. langstage inherits it via `describe()`/`sources` — **floor bump only, no local wiring needed**. A `subtitle` set only in `~/.langstage/config.toml` now reads `[toml (config.toml)]`, not `[toml (langstage.toml)]`.

## #120 — `langstage config` silently ignored unknown / typo'd keys
Core 1.0.32 added `HostConfig.unknown_toml_keys()`, surfaced by `describe()`. langstage's `config` / `--show-config` now print `unknown TOML keys (ignored - a typo or wrong table?): …`. Also added an `unknown_toml_keys` field to the `config --json` payload so a deploy step can assert on them machine-side. `[configurable]` passthrough keys are never flagged. Advisory only (exit 0).

## Tests
Regression test per issue in `tests/test_app.py` (#117) and `tests/test_config.py` (#119, #120). Full suite: **369 passed, 1 skipped**. CI runs pytest only (no ruff gate); added code is lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B