### PR TITLE
Range-check port, fix download-on-dir 404, add `config --strict` (gh #123, #124, #125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 0.13.34 — 2026-08-06
+
+Requires **langstage-core >= 1.0.33** (bumped from >=1.0.32): #123 is fixed at the
+shared core layer and this release wires it through, adds the `--port` CLI guard, and
+ships two langstage-local fixes (#124, #125).
+
+### Fixed
+- **An out-of-range port (e.g. `70000`, `99999`) is no longer accepted and silently
+  mis-bound (gh #123).** A type-valid but out-of-range integer port sailed through the
+  resolver, was advertised by `--show-config` and the startup banner, and then uvicorn
+  masked it to 16 bits at bind time (`70000 & 0xFFFF == 4464`) — the server listened on a
+  *different* port than everything advertised, with no error. Now: the ambient paths
+  (`LANGSTAGE_PORT` env, `server.port` in `langstage.toml`, a Python `port=` override)
+  **degrade** an out-of-range value to the default `8050` + a one-line stderr `note:` and
+  attribute it to `[default]` (via langstage-core 1.0.33's `resolve()` port-range
+  validator — the same treatment a non-int value already got), and the interactive
+  `--port` flag **hard-errors** cleanly at parse time (`Invalid value for '--port': 70000
+  is not in the range 1<=x<=65535`) via `click.IntRange`, mirroring how `--theme`
+  hard-rejects. Either way the silent misbind is gone.
+- **`GET /api/files/download?path=<a dir>` now returns a clean `400 "Path is a directory"`
+  instead of a misleading `404 "File not found"` (gh #124).** Downloading a directory
+  path collapsed "exists but is a directory" into the same 404 as "doesn't exist",
+  telling a client an existing path was gone. The route now distinguishes the two —
+  `400` for a directory (matching `read`/`preview`, and the #117 `tree`-on-a-file fix),
+  `404` only when the path truly doesn't exist. `download` was the last `/api/files/*`
+  route to misreport a node type.
+
+### Added
+- **`langstage config --strict` — a CI gate on a typo'd/unknown `langstage.toml` key (gh
+  #125).** `config` surfaces unknown keys (via core's `unknown_toml_keys()`) but always
+  exited `0`, so a deploy/CI step couldn't fail the build on a config typo without
+  hand-parsing the JSON. `--strict` exits **1** when the config isn't clean (any unknown
+  key), and **0** when clean, so `langstage config --strict` is a one-line CI gate. The
+  default (no `--strict`) still exits `0`, keeping the "degrade, don't crash on ambient
+  config" contract. Composes with `--json` (same output on stdout, the strict error
+  summary on stderr, same exit-code contract).
+
 ## 0.13.33 — 2026-08-03
 
 Requires **langstage-core >= 1.0.32** (bumped from >=1.0.9): #119 and #120 are

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -53,7 +53,13 @@ def main(ctx, show_config):
 @click.option("--agent", "-a", "agent_spec", default=None, help="Agent spec (e.g., my_agent.py:agent)")
 @click.option("--demo", is_flag=True, default=False, help="Run with the built-in keyless demo agent - no API key needed")
 @click.option("--workspace", default=None, type=click.Path(), help="Workspace directory")
-@click.option("--port", default=None, type=int, help="Server port (default: 8050)")
+# click.IntRange gives an explicit --port the clean hard error the interactive flag
+# deserves ("Invalid value for '--port': 70000 is not in the range 1<=x<=65535"), at
+# parse time before the server starts — mirroring how --theme hard-rejects. The ambient
+# paths (env / langstage.toml / Python override) instead DEGRADE to the default + a note
+# via langstage-core's resolver validator (>=1.0.33). Either way the out-of-range value
+# is never silently masked to 16 bits by uvicorn and mis-bound (gh #123).
+@click.option("--port", default=None, type=click.IntRange(1, 65535), help="Server port (default: 8050)")
 @click.option("--host", default=None, help="Server host (default: localhost)")
 @click.option("--debug", is_flag=True, default=None, help="Enable debug mode")
 @click.option("--title", default=None, help="App title in header bar")
@@ -123,37 +129,63 @@ def run(agent_spec, demo, workspace, port, host, debug, title, subtitle, welcome
 @click.option("--json", "as_json", is_flag=True, default=False,
               help="Emit the resolved config as JSON (each field's value + source, plus the "
                    "TOML files read) so a deploy step can assert what a container resolved.")
-def config(workspace, as_json):
+@click.option("--strict", is_flag=True, default=False,
+              help="Exit non-zero (1) when the config isn't clean — any unknown/typo'd "
+                   "langstage.toml key (surfaced as `unknown_toml_keys`) — so a CI/deploy "
+                   "step can gate on a config typo with an exit code alone, instead of "
+                   "hand-parsing the JSON. Default (no --strict) always exits 0. Composes "
+                   "with --json (same output, same exit-code contract).")
+@click.pass_context
+def config(ctx, workspace, as_json, strict):
     """Show the resolved configuration: each value, its source, and the
-    env var / langstage.toml key that sets it."""
+    env var / langstage.toml key that sets it.
+
+    Add ``--strict`` to make it a CI gate: exit non-zero if langstage.toml has any
+    unknown/typo'd key, so ``langstage config --strict`` fails the build on a config
+    typo (which otherwise ships a running-but-wrong server silently). (gh #125)"""
     from dataclasses import fields as _fields
 
     overrides = {"workspace_root": workspace} if workspace else None
     cfg = AppConfig.resolve(overrides=overrides)
+    # The unknown/typo'd keys the layered config silently dropped — the gate --strict
+    # fails on. The output below already surfaces them (human via describe(), JSON via
+    # the payload); --strict only adds the exit-code half (gh #125).
+    unknown = cfg.unknown_toml_keys()
+
     if not as_json:
         click.echo(cfg.describe())
-        return
+    else:
+        import json as _json
 
-    import json as _json
+        def _jsonable(v):
+            # Config values are scalars or Paths; keep JSON-native types, stringify the rest.
+            return v if isinstance(v, (str, int, float, bool, type(None))) else str(v)
 
-    def _jsonable(v):
-        # Config values are scalars or Paths; keep JSON-native types, stringify the rest.
-        return v if isinstance(v, (str, int, float, bool, type(None))) else str(v)
+        src = cfg.sources
+        payload = {
+            "config": {
+                f.name: {"value": _jsonable(getattr(cfg, f.name)), "source": src.get(f.name, "default")}
+                for f in _fields(cfg)
+            },
+            "toml_read_from": [str(p) for p in getattr(cfg, "_toml_paths", [])],
+            # Keys present in langstage.toml that map to no known field (typo'd / misplaced /
+            # unknown). The human `config` / `--show-config` surface these via describe(); a
+            # deploy step asserting on JSON gets them here too, so a silent-dropped edit can be
+            # caught machine-side, not just by eye (gh #120).
+            "unknown_toml_keys": unknown,
+        }
+        click.echo(_json.dumps(payload, indent=2))
 
-    src = cfg.sources
-    payload = {
-        "config": {
-            f.name: {"value": _jsonable(getattr(cfg, f.name)), "source": src.get(f.name, "default")}
-            for f in _fields(cfg)
-        },
-        "toml_read_from": [str(p) for p in getattr(cfg, "_toml_paths", [])],
-        # Keys present in langstage.toml that map to no known field (typo'd / misplaced /
-        # unknown). The human `config` / `--show-config` surface these via describe(); a
-        # deploy step asserting on JSON gets them here too, so a silent-dropped edit can be
-        # caught machine-side, not just by eye (gh #120).
-        "unknown_toml_keys": cfg.unknown_toml_keys(),
-    }
-    click.echo(_json.dumps(payload, indent=2))
+    if strict and unknown:
+        n = len(unknown)
+        # A one-line stderr summary (so it survives a `... --json | jq` pipe on stdout),
+        # then a non-zero exit so CI fails the build. ASCII-only (cp1252-safe).
+        click.echo(
+            f"error: config is not clean: {n} unknown TOML key"
+            f"{'s' if n != 1 else ''} ({', '.join(unknown)}). (--strict)",
+            err=True,
+        )
+        ctx.exit(1)
 
 
 @main.command()

--- a/langstage/server/routes_files.py
+++ b/langstage/server/routes_files.py
@@ -84,6 +84,13 @@ def create_files_router(file_manager: FileManager) -> APIRouter:
         """Serve a file for download."""
         try:
             abs_path = file_manager.get_absolute_path(path)
+            # Distinguish "exists but is a directory" (400) from "doesn't exist" (404),
+            # instead of collapsing both into a misleading 404 "File not found" for a
+            # directory that plainly exists. Mirrors read/preview's IsADirectoryError -> 400
+            # and the #117 tree-on-a-file fix — download was the last files route to
+            # misreport a node type (gh #124).
+            if abs_path.is_dir():
+                raise HTTPException(status_code=400, detail=f"Path is a directory: {path}")
             if not abs_path.is_file():
                 raise HTTPException(status_code=404, detail=f"File not found: {path}")
             return FileResponse(str(abs_path), filename=abs_path.name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.33"
+version = "0.13.34"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"
@@ -22,7 +22,10 @@ dependencies = [
     # >=1.0.32 for per-file TOML source provenance in resolve() (a global-config value is
     # no longer mislabeled as coming from the project langstage.toml, gh #119) and for
     # HostConfig.unknown_toml_keys() + describe() surfacing typo'd/unknown keys (gh #120).
-    "langstage-core[agui]>=1.0.32",
+    # >=1.0.33 for the resolver's port-range validator: an out-of-range port (70000) from
+    # env / TOML / a Python override now degrades to the default + a note instead of being
+    # silently masked to 16 bits by uvicorn at bind time (gh #123).
+    "langstage-core[agui]>=1.0.33",
     # Any real use of langstage already has langgraph in the env (it is the
     # thing being hosted); declaring it makes `run --demo` work on a bare install.
     "langgraph>=1.0",
@@ -50,7 +53,7 @@ deepagents = [
 # Redundant since AG-UI moved into base deps (core 1.0); kept as a no-op alias so
 # existing `pip install langstage[agui]` scripts/READMEs still resolve.
 agui = [
-    "langstage-core[agui]>=1.0.32",
+    "langstage-core[agui]>=1.0.33",
 ]
 dev = [
     "pytest>=8",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,6 +120,34 @@ async def test_files_tree_on_a_nested_file_returns_400_not_500(client):
 
 
 @pytest.mark.asyncio
+async def test_files_download_on_a_directory_returns_400_not_false_404(client):
+    # gh #124: download of a DIRECTORY that exists (subdir/ in the fixture) used to
+    # return a misleading 404 "File not found", telling a client an existing path does
+    # not exist. It must now return a clean 400 "Path is a directory", matching
+    # read/preview for the same node-type case (and the #117 tree-on-a-file fix).
+    resp = await client.get("/api/files/download?path=subdir")
+    assert resp.status_code == 400, f"got {resp.status_code}: {resp.text}"
+    assert "directory" in resp.json()["detail"].lower()
+    assert "subdir" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_files_download_missing_path_still_404(client):
+    # A path that truly doesn't exist must STILL be a 404 — the fix distinguishes
+    # is-a-directory from doesn't-exist, it doesn't collapse them the other way.
+    resp = await client.get("/api/files/download?path=nope.txt")
+    assert resp.status_code == 404, f"got {resp.status_code}: {resp.text}"
+
+
+@pytest.mark.asyncio
+async def test_files_download_serves_a_real_file(client):
+    # The happy path is unaffected: an existing file downloads with 200.
+    resp = await client.get("/api/files/download?path=hello.py")
+    assert resp.status_code == 200, f"got {resp.status_code}: {resp.text}"
+    assert resp.text == "print('hello')"
+
+
+@pytest.mark.asyncio
 async def test_canvas_empty(client):
     resp = await client.get("/api/canvas/items")
     assert resp.status_code == 200

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -319,3 +319,139 @@ def test_config_clean_toml_reports_no_unknown_keys(tmp_path, monkeypatch):
     assert cfg.unknown_toml_keys() == []
     result = CliRunner().invoke(cli_mod.main, ["config"])
     assert "unknown TOML keys" not in result.output
+
+
+# ── out-of-range port degrades / hard-errors, never a silent misbind (gh #123) ──
+# An out-of-range integer port (70000) was type-valid so it sailed through the
+# resolver, was advertised by --show-config and the startup banner, and then uvicorn
+# silently masked it to 16 bits (70000 & 0xFFFF == 4464) — the server bound a
+# DIFFERENT port than everything advertised, with no error. Fixed at the core layer
+# (langstage-core >= 1.0.33: resolve()'s port-range validator degrades an out-of-range
+# env/TOML/override value to the default + a note); the interactive --port flag adds a
+# clean hard error via click.IntRange. These pin both halves reach langstage.
+
+
+def _clear_invalid_port_note_dedupe():
+    # The core "ignoring invalid port=..." note dedupes per (field, value) across a
+    # process; clear it so each test observes its own note regardless of test order.
+    from langstage_core.host import config as _core_cfg
+
+    _core_cfg._warned_invalid_value.clear()
+
+
+def test_out_of_range_env_port_degrades_to_default_with_note(monkeypatch, capsys):
+    _clear_invalid_port_note_dedupe()
+    monkeypatch.setenv("LANGSTAGE_PORT", "70000")
+    cfg = AppConfig.from_env()  # must NOT raise
+
+    assert cfg.port == 8050  # degraded to the default, not the masked 4464
+    assert cfg.sources["port"] == "default"  # not credited to the rejected env var
+    err = capsys.readouterr().err
+    assert "ignoring invalid port=70000" in err
+    assert "1-65535" in err  # names the valid range
+
+
+def test_out_of_range_override_port_degrades_to_default(capsys):
+    # The Python/CLI override path (CoworkApp(port=...) -> resolve(overrides=...)) also
+    # degrades — an out-of-range value can never reach uvicorn to be masked.
+    _clear_invalid_port_note_dedupe()
+    cfg = AppConfig.resolve(overrides={"port": 99999})
+
+    assert cfg.port == 8050
+    assert cfg.sources["port"] == "default"
+    assert "ignoring invalid port=99999" in capsys.readouterr().err
+
+
+def test_show_config_reports_degraded_port_as_default(monkeypatch):
+    # --show-config must never present the out-of-range port as a resolved value.
+    _clear_invalid_port_note_dedupe()
+    monkeypatch.setenv("LANGSTAGE_PORT", "70000")
+    result = CliRunner().invoke(cli_mod.main, ["--show-config"])
+
+    assert result.exit_code == 0, result.output
+    assert re.search(r"port\s*=\s*8050\s+\[default\]", result.output), result.output
+    # The rejected 70000 must never appear as a resolved value (a table line is
+    # `port = <value> [source]`). The stderr note names 70000 as the ignored value —
+    # `port=70000 (ValueError...)` — which is fine; only the resolved line must not
+    # show it, so match the value-then-`[source]` shape the note never has.
+    assert not re.search(r"port\s*=\s*70000\s+\[", result.output), result.output
+
+
+def test_valid_env_port_still_resolves_with_source(monkeypatch):
+    # An in-range value must resolve normally with correct source attribution.
+    monkeypatch.setenv("LANGSTAGE_PORT", "9000")
+    cfg = AppConfig.from_env()
+    assert cfg.port == 9000
+    assert cfg.sources["port"] == "env:LANGSTAGE_PORT"
+
+
+def test_cli_port_flag_hard_rejects_out_of_range():
+    # The interactive --port flag hard-errors at parse time (exit 2, before the command
+    # body runs, so no server starts) via click.IntRange — the clean CLI error an
+    # explicit flag deserves, mirroring --theme. Guards the silent-misbind is gone.
+    result = CliRunner().invoke(
+        cli_mod.main, ["run", "--port", "70000", "--demo", "--no-browser"]
+    )
+    assert result.exit_code == 2
+    assert "Invalid value for '--port'" in result.output
+
+
+# ── `langstage config --strict` is a CI gate on a typo'd/unknown TOML key (gh #125) ──
+# `config` surfaces unknown keys but always exits 0, so CI can't gate on a config typo
+# with an exit code. --strict exits 1 when there are unknown keys (0 when clean), so a
+# deploy step can fail the build on a mistyped key. Default (no --strict) stays exit 0.
+
+
+def test_config_strict_exits_nonzero_on_unknown_key(tmp_path, monkeypatch):
+    _isolate_global(tmp_path, monkeypatch)
+    # `prt` is a typo for `port` -> the server would silently bind :8050, not :9000.
+    (tmp_path / "langstage.toml").write_text('[server]\nprt = 9000\nhost = "0.0.0.0"\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config", "--strict"])
+
+    assert result.exit_code == 1, result.output
+    # Still prints the human table + the unknown-keys line...
+    assert "server.prt" in result.output
+    # ...plus the strict error summary on stderr.
+    assert "not clean" in result.stderr
+    assert "server.prt" in result.stderr
+
+
+def test_config_strict_exits_zero_on_clean_config(tmp_path, monkeypatch):
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text('[server]\nport = 9000\nhost = "0.0.0.0"\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config", "--strict"])
+
+    assert result.exit_code == 0, result.output
+    assert "not clean" not in result.output
+
+
+def test_config_without_strict_exits_zero_even_with_unknown_key(tmp_path, monkeypatch):
+    # The default (no --strict) keeps the "degrade, don't crash" contract: exit 0 even
+    # with a typo, only surfacing it in the output.
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text('[server]\nprt = 9000\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config"])
+
+    assert result.exit_code == 0, result.output
+    assert "server.prt" in result.output
+
+
+def test_config_strict_composes_with_json(tmp_path, monkeypatch):
+    # --strict composes with --json: same exit-code contract, JSON still on stdout so a
+    # pipeline can gate coarsely on the exit code or finely on the JSON.
+    import json
+
+    _isolate_global(tmp_path, monkeypatch)
+    (tmp_path / "langstage.toml").write_text('[ui]\ntitel = "My App"\n')
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(cli_mod.main, ["config", "--json", "--strict"])
+
+    assert result.exit_code == 1, result.output
+    # The JSON payload is still emitted (with the unknown key) on stdout; the strict
+    # error summary goes to stderr, so the two don't collide.
+    payload = json.loads(result.stdout[: result.stdout.index("error:")] if "error:" in result.stdout else result.stdout)
+    assert payload["unknown_toml_keys"] == ["ui.titel"]
+    assert "not clean" in result.stderr


### PR DESCRIPTION
Ships three routine fixes as **0.13.34**. Bumps the `langstage-core` floor to **>=1.0.33**.

## #123 — out-of-range port accepted + silently truncated to 16 bits
A type-valid but out-of-range integer port (`70000`, `99999`) sailed through the resolver, was advertised by `--show-config` and the startup banner, then uvicorn masked it to 16 bits at bind time (`70000 & 0xFFFF == 4464`) — the server bound a *different* port than everything advertised, with no error.

- **Ambient paths** (`LANGSTAGE_PORT`, `server.port` TOML, Python `port=` override) now **degrade** to the default `8050` + a one-line stderr `note:` and are attributed to `[default]`, via langstage-core 1.0.33's `resolve()` port-range validator (same treatment a non-int value already got).
- **Interactive `--port` flag** now **hard-errors** cleanly at parse time (`Invalid value for '--port': 70000 is not in the range 1<=x<=65535`) via `click.IntRange`, mirroring `--theme`.

Either way the silent misbind is gone.

## #124 — `GET /api/files/download?path=<a dir>` returned a false 404
Downloading a directory that exists returned a misleading `404 "File not found"`. The route now distinguishes "exists but is a directory" (`400 "Path is a directory"`, matching `read`/`preview` and the #117 `tree`-on-a-file fix) from "doesn't exist" (`404`). `download` was the last `/api/files/*` route to misreport a node type.

## #125 — `langstage config --strict` (new CI gate)
`config` surfaced unknown TOML keys but always exited `0`. `--strict` now exits **1** when there's any unknown/typo'd key (**0** when clean), so `langstage config --strict` is a one-line CI gate on a config typo. Default (no `--strict`) still exits `0`. Composes with `--json` (JSON on stdout, strict error summary on stderr).

## Tests
A regression test per issue; full suite green locally (381 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B