### PR TITLE
docs: document the full config-precedence chain incl. the global layer (gh #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.13.35 — 2026-08-08
+
+Docs-only. No code or dependency change.
+
+### Fixed
+- **README Configuration section now documents the *full* config-precedence chain,
+  including the global config layer and `LANGSTAGE_CONFIG_HOME` (gh #128).** The section
+  described a single, cwd-local `langstage.toml`, but `langstage-core`'s resolver
+  (`HostConfig.resolve()`) actually reads **two** deep-merged TOML layers: the global
+  `~/.langstage/config.toml` (directory overridable via `LANGSTAGE_CONFIG_HOME`; legacy
+  `~/.deepagents/config.toml` / `DEEPAGENTS_CONFIG_HOME` still honored) and the project
+  `langstage.toml` — the latter discovered by walking **up** the directory tree from the
+  working directory (not from `--workspace`), and winning key-by-key over the global file.
+  The corrected chain is now stated as **Python args > CLI args > environment variables >
+  project `langstage.toml` (nearest at or above the working directory) > global
+  `~/.langstage/config.toml` > defaults**, with a note that a parent-directory or global
+  file can silently set values like `auth.password` / `server.host`, so `langstage
+  --show-config` is the way to see the resolved source file. This closes the "Related doc
+  gap" flagged when #119 shipped. `tests/test_readme_config_priority.py` is updated to pin
+  the new chain and the global-layer docs.
+
 ## 0.13.34 — 2026-08-06
 
 Requires **langstage-core >= 1.0.33** (bumped from >=1.0.32): #123 is fixed at the

--- a/README.md
+++ b/README.md
@@ -223,9 +223,14 @@ Schedules (cron) REST API: `GET /api/cron`, `POST /api/cron` (create), `DELETE /
 
 ## Configuration
 
-Configuration priority (highest wins): **Python args > CLI args > environment variables > `langstage.toml` > defaults**.
+Configuration priority (highest wins): **Python args > CLI args > environment variables > project `langstage.toml` (nearest at or above the working directory) > global `~/.langstage/config.toml` > defaults**.
 
-Never remember a variable name — print the resolved configuration (each value, its source, and the env var / `langstage.toml` key that sets it):
+There are **two** TOML layers, not one — both are read and deep-merged, with the project file winning key-by-key over the global file:
+
+- **Project `langstage.toml`** — the nearest `langstage.toml` found by walking **up** the directory tree from your current working directory (the way `git` finds `.git`). A file in a *parent* directory therefore configures every `langstage` run beneath it. Discovery is anchored to the working directory, **not** to `--workspace`: a `langstage.toml` sitting inside the workspace directory is *not* read unless that directory is also at or above your cwd.
+- **Global `~/.langstage/config.toml`** — a per-user file applied to every invocation. Set `LANGSTAGE_CONFIG_HOME` to relocate the directory it lives in (the file is always named `config.toml` inside that directory). Legacy `~/.deepagents/config.toml` and `DEEPAGENTS_CONFIG_HOME` are still honored as deprecated fallbacks, as are a project-level `deepagents.toml` and the `DEEPAGENT_*` env vars (the canonical `LANGSTAGE_*` names win when both are set).
+
+Because a parent-directory or global file can silently set things like `auth.password` or `server.host` for *every* invocation under that tree, never assume config comes only from `./langstage.toml`. When a value isn't what you expect, print the resolved configuration (each value, the source **file** it won from, and the env var / `langstage.toml` key that sets it):
 
 ```bash
 langstage --show-config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langstage"
-version = "0.13.34"
+version = "0.13.35"
 description = "The web stage for your LangGraph agent — AI-powered workspace with streaming, file browser, and canvas"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_readme_config_priority.py
+++ b/tests/test_readme_config_priority.py
@@ -1,10 +1,12 @@
-"""The README's config-priority chain must include ``langstage.toml`` (gh #100).
+"""The README's config-priority chain must name every TOML layer core reads (gh #128).
 
-The Configuration section — the one section entirely about ``langstage.toml`` — used
-to state the priority as *"Python args > CLI args > environment variables > defaults"*,
-dropping the exact TOML layer it teaches the reader to create with ``langstage init``.
-That contradicted both the ``init``-generated file header and the ``--show-config``
-help, which both name the file. This pins the README to the real four-layer chain.
+The Configuration section — the one section entirely about ``langstage.toml`` — first
+stated the priority as *"Python args > CLI args > environment variables > defaults"*,
+dropping TOML entirely (gh #100); it was then fixed to a single ``langstage.toml`` layer.
+But ``langstage-core``'s resolver actually reads **two** TOML layers: the global
+``~/.langstage/config.toml`` (dir overridable via ``LANGSTAGE_CONFIG_HOME``) and the
+project ``langstage.toml`` discovered by walking *up* from cwd, with the project file
+winning. This pins the README to that real chain and to the global-layer docs (gh #128).
 """
 from pathlib import Path
 
@@ -16,12 +18,26 @@ from click.testing import CliRunner
 _README = Path(__file__).resolve().parent.parent / "README.md"
 
 
-def test_priority_line_names_langstage_toml_between_env_and_defaults():
+def test_priority_line_names_both_toml_layers_between_env_and_defaults():
     text = _README.read_text(encoding="utf-8")
-    # The corrected four-layer chain, TOML between env and defaults.
-    assert "environment variables > `langstage.toml` > defaults" in text
-    # And the old three-layer statement that silently dropped TOML is gone.
+    # The corrected chain: project langstage.toml, then global config.toml, then defaults.
+    assert (
+        "environment variables > project `langstage.toml` (nearest at or above the "
+        "working directory) > global `~/.langstage/config.toml` > defaults"
+    ) in text
+    # The earlier three-layer statement that silently dropped TOML is gone (gh #100)...
     assert "environment variables > defaults" not in text
+    # ...and so is the single-layer chain that omitted the global file (gh #128).
+    assert "environment variables > `langstage.toml` > defaults" not in text
+
+
+def test_readme_documents_the_global_layer_and_config_home():
+    """The global config file and its env override must be documented (gh #128)."""
+    text = _README.read_text(encoding="utf-8")
+    assert "~/.langstage/config.toml" in text
+    assert "LANGSTAGE_CONFIG_HOME" in text
+    # The upward-walk discovery is what makes a parent-directory file surprising.
+    assert "walking **up**" in text
 
 
 def test_readme_agrees_with_init_header_and_show_config():


### PR DESCRIPTION
## What

Fixes the doc gap in **gh #128**: the README **Configuration** section documented a single, cwd-local `langstage.toml`, but `langstage-core`'s `HostConfig.resolve()` actually reads **two** deep-merged TOML layers.

## Why

Verified against the installed `langstage_core/host/config.py` (`_load_toml_files`, `_global_toml_path`, `_find_project_toml`, `_deep_merge`):

- **Global** `~/.langstage/config.toml` — directory overridable via `LANGSTAGE_CONFIG_HOME`; legacy `~/.deepagents/config.toml` / `DEEPAGENTS_CONFIG_HOME` honored as fallbacks.
- **Project** `langstage.toml` — found by walking **up** the directory tree from cwd (not from `--workspace`).
- Deep-merged with the **project file winning** key-by-key over the global one.

So the documented chain was incomplete. A docs-only reader couldn't tell that a parent-directory or global file was silently setting values like `auth.password` / `server.host`. This is the "Related doc gap" flagged when #119 shipped.

## Change

- **Before:** `Python args > CLI args > environment variables > `langstage.toml` > defaults`
- **After:** `Python args > CLI args > environment variables > project `langstage.toml` (nearest at or above the working directory) > global `~/.langstage/config.toml` > defaults`

Plus a prose paragraph documenting both TOML layers, `LANGSTAGE_CONFIG_HOME`, the upward-walk discovery (and that it is *not* anchored to `--workspace`), the legacy fallbacks, and a pointer to `langstage --show-config` to see the resolved source file.

## Scope

Docs-only; no code or dependency change. `tests/test_readme_config_priority.py` is updated to pin the corrected chain and add a guard that the global layer + `LANGSTAGE_CONFIG_HOME` stay documented. Version bump 0.13.34 -> 0.13.35 + dated CHANGELOG entry.

Full suite: **382 passed, 1 skipped** locally (`.venv/Scripts/python.exe -m pytest -q`).

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HWCfJii6gXd3XL3Gq3W8B
