### PR TITLE
fix: keep default agent todos available

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Point `--agent` at any compiled LangGraph graph — `langstage run --agent my_ag
 
 | Feature | How |
 | --- | --- |
-| **Plan** tab populates | agent calls `write_todos` (the deepagents convention) |
+| **Plan** tab populates | agent exposes `write_todos` (for example via DeepAgents `TodoListMiddleware`) |
 | **Rich inline content** (charts, images, DataFrames, HTML) | a tool returns the `display_inline` shape |
 | **Canvas** tab | attach `CanvasMiddleware` to your agent |
 | **Agent self-delegation + agent-created schedules** | add the host tools — `from langstage import LANGSTAGE_TOOLS` → `tools=[*my_tools, *LANGSTAGE_TOOLS]` |

--- a/langstage/cli.py
+++ b/langstage/cli.py
@@ -232,8 +232,22 @@ def _agent_tool_names(agent) -> set[str] | None:
     if the graph can't be introspected (capabilities may still work)."""
     try:
         names: set[str] = set()
+
+        def add_from_tools(tools) -> None:
+            for tool in tools or ():
+                name = getattr(tool, "name", getattr(tool, "__name__", ""))
+                if name:
+                    names.add(name)
+
+        for owner in (agent, getattr(agent, "builder", None)):
+            for attr in ("middleware", "_middleware"):
+                for middleware in getattr(owner, attr, None) or ():
+                    add_from_tools(getattr(middleware, "tools", None))
+
         nodes = getattr(agent, "nodes", None) or {}
-        for node in nodes.values():
+        for node_name, node in nodes.items():
+            if isinstance(node_name, str) and node_name.startswith("TodoListMiddleware."):
+                names.add("write_todos")
             target = getattr(node, "bound", node)
             tbn = getattr(target, "tools_by_name", None)
             if isinstance(tbn, dict):

--- a/langstage/default_agent.py
+++ b/langstage/default_agent.py
@@ -1,10 +1,15 @@
 """Default deepagent when no --agent is provided."""
 
+# ruff: noqa: E402 - load .env before importing modules that read configuration.
+
+import re
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from dotenv import load_dotenv
 
 load_dotenv()
 
+from langchain.agents.middleware import TodoListMiddleware
 from langstage_core.demo import create_default_agent as _build_default_agent
 from langstage_core.tasks import TASK_TOOLS
 
@@ -133,8 +138,22 @@ AGENT_TOOLS = [
     *TASK_TOOLS,  # start/check/list/update/cancel_async_task — agent self-delegation
 ]
 
-# Middleware list — canvas is opt-in via CanvasMiddleware.
+def _deepagents_has_builtin_todo_middleware(version_text: str | None = None) -> bool:
+    """DeepAgents < 0.7 injected write_todos by default; newer releases do not."""
+    try:
+        raw = version_text if version_text is not None else version("deepagents")
+    except PackageNotFoundError:
+        return False
+    match = re.match(r"^(\d+)\.(\d+)", raw)
+    if not match:
+        return False
+    return (int(match.group(1)), int(match.group(2))) < (0, 7)
+
+
+# Middleware list used by the bundled default agent.
 AGENT_MIDDLEWARE = [CanvasMiddleware()]
+if not _deepagents_has_builtin_todo_middleware():
+    AGENT_MIDDLEWARE.append(TodoListMiddleware())
 
 # Global agent for physical filesystem mode (writes to disk via the shared
 # demo factory's FilesystemBackend + InMemorySaver boilerplate). Cowork supplies

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,6 +242,20 @@ def test_check_json_emits_structured_report_for_demo():
     assert "[ ok ]" not in result.output and "[warn]" not in result.output
 
 
+def test_agent_tool_names_detects_todo_middleware_node():
+    """DeepAgents can expose middleware tools through graph nodes, not ToolNode only."""
+
+    class Agent:
+        nodes = {
+            "__start__": None,
+            "model": None,
+            "tools": None,
+            "TodoListMiddleware.after_model": None,
+        }
+
+    assert "write_todos" in (cli_mod._agent_tool_names(Agent()) or set())
+
+
 def test_check_json_load_failure_still_json_and_exit_1():
     """A load failure preserves exit 1 AND still emits JSON (loads:false, ok:false, error)."""
     import json

--- a/tests/test_default_agent.py
+++ b/tests/test_default_agent.py
@@ -36,6 +36,21 @@ def test_default_agent_imports_and_exposes_middleware():
     )
 
 
+def test_default_agent_adds_todo_middleware_when_deepagents_stops_defaulting_it():
+    from langstage.default_agent import _deepagents_has_builtin_todo_middleware
+
+    assert _deepagents_has_builtin_todo_middleware("0.3.3") is True
+    assert _deepagents_has_builtin_todo_middleware("0.7.11") is False
+
+
+def test_default_agent_exposes_write_todos_for_plan():
+    """The bundled default agent must keep the Plan tab's `write_todos` tool bound."""
+    from langstage.cli import _agent_tool_names
+    from langstage.default_agent import agent
+
+    assert "write_todos" in (_agent_tool_names(agent) or set())
+
+
 def test_agent_tools_exclude_canvas_tools():
     """Canvas tools should only be injected via CanvasMiddleware — never baked
     into the core tool list. Regression guard against accidental re-duplication.


### PR DESCRIPTION
## What
Fixes #149. The bundled default agent can lose `write_todos` with DeepAgents releases where todo tracking is no longer injected by default.

## Fix
Adds version-aware default-agent middleware selection so `TodoListMiddleware` is attached only when DeepAgents does not already provide todos, and teaches `check` to detect middleware-provided todo tools.

## Test
Adds regression tests for default-agent todo availability and middleware-node tool detection.